### PR TITLE
Add SelectOp operator for array element selection

### DIFF
--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -157,6 +157,7 @@ export const categories = {
     'ObjectMergeOp',
     'OutOp',
     'ScatterOp',
+    'SelectOp',
     'SliceOp',
     'SortOp',
     'SwitchOp',

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -20,6 +20,7 @@ import {
   ProjectOp,
   RectangleOp,
   ScatterplotLayerOp,
+  SelectOp,
   SwitchOp,
 } from './operators'
 import { opMap } from './store'
@@ -1162,5 +1163,48 @@ describe('Viral Accessor Tests', () => {
       expect(isAccessor(result.object)).toBe(true)
       expect((result.object as Function)({ x: 1, y: 2 })).toEqual({ x: 1, z: 3, y: 2 })
     })
+  })
+})
+
+describe('SelectOp', () => {
+  it('returns undefined for empty array', () => {
+    const operator = new SelectOp('/select-0')
+    const result = operator.execute({
+      data: [],
+      index: 0,
+    })
+    expect(result.value).toEqual(undefined)
+  })
+
+  it('selects element', () => {
+    const operator = new SelectOp('/select-1')
+    const result = operator.execute({
+      data: ['a', 'b', 'c'],
+      index: 1,
+    })
+    expect(result.value).toEqual('b')
+  })
+
+  it('clamps index', () => {
+    const operator = new SelectOp('/select-2')
+    const result = operator.execute({
+      data: [10, 20, 30],
+      index: -5,
+    })
+    expect(result.value).toEqual(10)
+    const result2 = operator.execute({
+      data: [10, 20, 30],
+      index: 5,
+    })
+    expect(result2.value).toEqual(30)
+  })
+
+  it('floors decimal index values', () => {
+    const operator = new SelectOp('/select-4')
+    const result = operator.execute({
+      data: ['a', 'b', 'c', 'd'],
+      index: 2.7,
+    })
+    expect(result.value).toEqual('c')
   })
 })

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -450,6 +450,34 @@ export class ExtentOp extends Operator<ExtentOp> {
   }
 }
 
+export class SelectOp extends Operator<SelectOp> {
+  static displayName = 'Select'
+  static description = 'Select an element from an array using an index (clamped to array bounds)'
+  createInputs() {
+    return {
+      data: new DataField(),
+      index: new NumberField(0, { step: 1 }),
+    }
+  }
+  createOutputs() {
+    return {
+      value: new UnknownField(undefined),
+    }
+  }
+  execute({ data, index }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    if (!Array.isArray(data) || data.length === 0) {
+      return { value: undefined }
+    }
+
+    // Clamp index to array bounds
+    const clampedIndex = Math.max(0, Math.min(Math.floor(index), data.length - 1))
+
+    return {
+      value: data[clampedIndex],
+    }
+  }
+}
+
 // Allow adding a "virtual" operator from the Add Node menu that wraps the Math operator with a specific operation
 export const mathOps = {
   DivideOp: 'divide',
@@ -4824,6 +4852,7 @@ export const opTypes = {
   ScenegraphLayerOp,
   ScreenGridLayerOp,
   SimpleMeshLayerOp,
+  SelectOp,
   SliceOp,
   SolidPolygonLayerOp,
   SortOp,


### PR DESCRIPTION
Introduces the SelectOp operator, which selects an element from an array using a clamped index. Includes tests for empty arrays, index clamping, and decimal index handling. Also registers SelectOp in the operator categories and opTypes.
