### PR TITLE
Fix for Mask3dextension

### DIFF
--- a/noodles-editor/src/noodles/extensions/mask-3d-extension.ts
+++ b/noodles-editor/src/noodles/extensions/mask-3d-extension.ts
@@ -39,6 +39,7 @@ const mask3DUniforms: ShaderModule<Props> = {
 
 // Forked from https://github.com/grahambates-code/3d_tiles_mask
 export class Mask3DExtension extends LayerExtension {
+  static extensionName = 'Mask3DExtension'
   getShaders() {
     return {
       modules: [project32, mask3DUniforms],


### PR DESCRIPTION
I looked over [Graham's code](https://github.com/grahambates-code/3d_tiles_mask/blob/main/src/mask_extention.tsx) and I saw something about this `toGeocentric` helper (which for some reason negates the `longitude` value passed in). I thought we had this working before but maybe it broke somewhere along the line? I also see his example app uses deck v9, so maybe that has to do with it? I'm not seeing anything passed for `this.getModels()` so no uniforms are getting set. Also Deck was complaining about `componentname` not being set (it just looks for `extensionName`). Who knows if that helps

I also wanted to fix the default values on the operator and try to make it easier to set up by default.

Here's an example file as a test
[Mask3DExtension test.json](https://github.com/user-attachments/files/21522892/Mask3DExtension.test.json)