### PR TITLE
Add a watcher plugin to vite for context changes

### DIFF
--- a/noodles-editor/scripts/generate-context.ts
+++ b/noodles-editor/scripts/generate-context.ts
@@ -132,7 +132,6 @@ function generateOperatorRegistry(): OperatorRegistry {
     const category = opToCategory[opName] || 'utility'
 
     operators[opName] = {
-      name: opName,
       type: opName,
       category,
       description: meta.description,


### PR DESCRIPTION
We currently only automatically generate context changes on push to github. This allows localhost to be kept up to date on any changes, for developing with the agent locally