### PR TITLE
Gitignore AI Chat context

### DIFF
--- a/noodles-editor/.gitignore
+++ b/noodles-editor/.gitignore
@@ -10,6 +10,9 @@
 # vibe coding
 .claude
 
+# AI Chat context (generated)
+/public/app
+
 # testing
 /coverage
 


### PR DESCRIPTION
From #26 - we want to be able to run the LLM locally, but vite doesn't serve from `/dist` locally