### PR TITLE
Strip large data fields in Github actions to keep deploy size small

### DIFF
--- a/.github/workflows/generate-context.yml
+++ b/.github/workflows/generate-context.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install dependencies
         run: yarn install:all
 
+      - name: Clean old context files
+        run: |
+          cd noodles-editor
+          rm -rf public/app/context/*
+          mkdir -p public/app/context
+
       - name: Generate context bundles
         run: |
           cd noodles-editor


### PR DESCRIPTION
Seeing some failures on Github Actions for trying to deploy the context PR in a single file. This cuts down the filesize significantly.