### PR TITLE
Fix yarn cache github action

### DIFF
--- a/.github/workflows/generate-context.yml
+++ b/.github/workflows/generate-context.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'yarn'
+          cache-dependency-path: |
+            noodles-editor/yarn.lock
+            website/yarn.lock
 
       - name: Install dependencies
         run: yarn install:all


### PR DESCRIPTION
Github push is failing on the `Post Setup Node.js` step, likely due to the fact that our yarn files aren't in the root directory but rather subdirectories. This should fix the issue with caching.