### PR TITLE
Cache yarn and playwright deps in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
+        working-directory: noodles-editor
         run: |
-          cd noodles-editor
-          version=$(yarn info @playwright/test version --json | jq -r .data)
+          version=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers


### PR DESCRIPTION
Github actions run brutally slow (~6 mins for playwright installation each time). This caches dependencies so that they won't update unless the version changes, or the yarn.lock hash updates. This should make developing much faster.
