### PR TITLE
Add a MapLibreBaseMapOp to new project

### DIFF
--- a/noodles-editor/public/noodles/new/noodles.json
+++ b/noodles-editor/public/noodles/new/noodles.json
@@ -23,6 +23,18 @@
         "x": 390,
         "y": 0
       }
+    },
+    {
+      "type": "MaplibreBasemapOp",
+      "id": "/maplibre-basemap",
+      "position": {
+        "x": -27.097062041233293,
+        "y": 282.8294486649364
+      },
+      "data": {
+        "inputs": {},
+        "locked": false
+      }
     }
   ],
   "edges": [
@@ -32,10 +44,20 @@
       "target": "/out",
       "sourceHandle": "out.vis",
       "targetHandle": "par.vis"
+    },
+    {
+      "source": "/maplibre-basemap",
+      "sourceHandle": "out.maplibre",
+      "target": "/deck",
+      "targetHandle": "par.basemap",
+      "id": "/maplibre-basemap.out.maplibre->/deck.par.basemap"
     }
   ],
-  "viewport": {},
-  "version": 6,
+  "viewport": {
+    "x": 487.61570812099455,
+    "y": 199.8206070154179,
+    "zoom": 0.7608097176595698
+  },
   "timeline": {
     "sheetsById": {
       "Noodles": {
@@ -48,5 +70,6 @@
     "revisionHistory": [
       "JFf3TQ8BG-ho9JXk"
     ]
-  }
+  },
+  "version": 7
 }


### PR DESCRIPTION
I find this is something I do for most projects, so it would make sense to include it in the "base" project.

I still find it confusing that there is a ViewState and a Basemap op that do similar things but are slightly different. Remind me why these are here and different @chrisgervang? 

My preference would be to reach a future where these inputs are parameters in a side window for the DeckRendererOp instead of draggable inputs as a separate Op, mostly for streamlining sake. For now this'll do.

Before:
<img width="2184" height="1414" alt="Screenshot 2025-10-27 at 9 52 18 PM" src="https://github.com/user-attachments/assets/602e4f86-1c17-4791-9cfe-16d76f0b7bec" />

After:
<img width="2086" height="1458" alt="Screenshot 2025-10-27 at 9 51 53 PM" src="https://github.com/user-attachments/assets/30b01430-0726-4e75-bb10-adea88d65cc9" />
