### PR TITLE
Add Flight Tracks example for querying ADSB data

### DIFF
--- a/noodles-editor/public/examples/flight-tracks/README.md
+++ b/noodles-editor/public/examples/flight-tracks/README.md
@@ -1,0 +1,60 @@
+# Flight Tracks Near SFO
+
+_Adapted from [Root Geospatial Flight Tracks dataset](https://source.coop/root-geospatial/flight-tracks)_
+
+## Overview
+
+This example visualizes flight tracks near San Francisco International Airport (SFO) on June 15, 2024. It queries pre-processed flight trajectory data from the Root Geospatial Flight Tracks dataset on Source Cooperative's S3 bucket and displays flight paths as colored lines with start (green) and end (red) points. The data covers 4 quadkey tiles around the San Francisco Bay Area.
+
+## Key Techniques
+
+- **DuckDB query**: `DuckDbOp` loads pre-processed flight segments from S3 Parquet files using spatial extensions
+- **S3 data access**: Queries 4 specific quadkey-partitioned files without splat arguments (duckdb-wasm limitation)
+- **Pre-aggregated geometries**: Uses existing LINESTRING geometries from the source data
+- **Deduplication**: Uses `DISTINCT ON` to remove duplicate flight segments appearing in multiple tiles
+- **Path layer**: `PathLayerOp` renders flight trajectories in cyan
+- **Position accessors**: Extract start/end positions from LINESTRING geometry text
+- **Scatterplot layers**: Green markers for flight starts, red markers for flight ends
+- **Basemap**: `MaplibreBasemapOp` with dark matter style
+
+## Data Structure
+
+The flight-tracks dataset contains pre-processed flight segments with:
+
+- `icao`: Aircraft unique identifier (ICAO 24-bit address)
+- `r` (aliased as `registration`): Aircraft registration number
+- `aircraft_type`: Type of aircraft
+- `start_t`, `end_t`: Flight segment start and end times (Unix timestamp)
+- `start_height_agl_ft`, `end_height_agl_ft`: Altitude above ground level in feet
+- `geometry`: Array of coordinate structs with x (longitude) and y (latitude)
+- Partitioned by `quadkey_z8` (zoom level 8 quadkey), `year`, `month`, and `day`
+
+## DuckDB Query Highlights
+
+The query demonstrates several techniques:
+
+1. Loading DuckDB spatial and httpfs extensions for S3 access
+2. Explicitly listing 4 quadkey tile paths (required for duckdb-wasm, no wildcard support)
+3. Converting the geometry array to LINESTRING WKT text using `ST_AsText(ST_MakeLine(...))`
+4. Using `DISTINCT ON (icao, end_t)` to deduplicate flights that span multiple tiles
+5. Filtering out NULL geometries to ensure clean visualization data
+
+## Node Graph Flow
+
+```
+DuckDB (S3 query) → Path Layer → Deck
+                  → Start Position Accessor → Scatterplot (green) → Deck
+                  → End Position Accessor → Scatterplot (red) → Deck
+Basemap → Deck → Out
+```
+
+## Use Cases
+
+This pattern is useful for:
+
+- Aviation traffic analysis
+- Flight path visualization
+- ADS-B data exploration
+- Geospatial data processing from S3
+- Working with partitioned datasets
+- Real-world trajectory visualization

--- a/noodles-editor/public/examples/flight-tracks/noodles.json
+++ b/noodles-editor/public/examples/flight-tracks/noodles.json
@@ -1,0 +1,299 @@
+{
+  "nodes": [
+    {
+      "id": "/duckdb-flight-data",
+      "type": "DuckDbOp",
+      "position": {
+        "x": -1183.0445205479452,
+        "y": -279.4189497716895
+      },
+      "data": {
+        "inputs": {
+          "query": [
+            "WITH raw_flights AS (",
+            "  SELECT",
+            "    icao,",
+            "    r AS registration,",
+            "    aircraft_type,",
+            "    start_t,",
+            "    end_t,",
+            "    start_height_agl_ft,",
+            "    end_height_agl_ft,",
+            "    ST_AsText(",
+            "      ST_MakeLine(",
+            "        list_transform(geometry, g -> ST_Point(g.x, g.y))",
+            "      )",
+            "    ) AS geom_text",
+            "  FROM read_parquet([",
+            "    'https://data.source.coop/root-geospatial/flight-tracks/quadkey_z8=02301200/year=2024/month=6/day=15/flights-2024-06-15.parquet',",
+            "    'https://data.source.coop/root-geospatial/flight-tracks/quadkey_z8=02301201/year=2024/month=6/day=15/flights-2024-06-15.parquet',",
+            "    'https://data.source.coop/root-geospatial/flight-tracks/quadkey_z8=02301210/year=2024/month=6/day=15/flights-2024-06-15.parquet',",
+            "    'https://data.source.coop/root-geospatial/flight-tracks/quadkey_z8=02301211/year=2024/month=6/day=15/flights-2024-06-15.parquet'",
+            "  ])",
+            "),",
+            "unique_flights AS (",
+            "  SELECT DISTINCT ON (icao, end_t)",
+            "    icao,",
+            "    registration,",
+            "    aircraft_type,",
+            "    start_t,",
+            "    end_t,",
+            "    start_height_agl_ft,",
+            "    end_height_agl_ft,",
+            "    geom_text",
+            "  FROM raw_flights",
+            "  WHERE geom_text IS NOT NULL",
+            ")",
+            "SELECT * FROM unique_flights",
+            "LIMIT 500;"
+          ]
+        },
+        "locked": false
+      },
+      "width": 600,
+      "height": 500,
+      "measured": {
+        "width": 600,
+        "height": 500
+      }
+    },
+    {
+      "id": "/path-layer",
+      "type": "PathLayerOp",
+      "position": {
+        "x": 12.242330508321743,
+        "y": 247.56712805717322
+      },
+      "data": {
+        "inputs": {
+          "opacity": 0.6,
+          "getColor": "#00bfffff",
+          "getWidth": 2,
+          "widthUnits": "pixels"
+        },
+        "locked": false
+      }
+    },
+    {
+      "id": "/path-accessor",
+      "type": "AccessorOp",
+      "position": {
+        "x": -455.0379350854169,
+        "y": 385.13555905252576
+      },
+      "data": {
+        "inputs": {
+          "expression": "d.geom_text.replace('LINESTRING (', '').replace(')', '').split(',').map(coord => coord.trim().split(' ').map(Number).reverse())"
+        },
+        "locked": false
+      }
+    },
+    {
+      "id": "/scatterplot-start",
+      "type": "ScatterplotLayerOp",
+      "position": {
+        "x": 0,
+        "y": -200
+      },
+      "data": {
+        "inputs": {
+          "opacity": 0.8,
+          "getFillColor": "#00ff00ff",
+          "getLineColor": "#ffffffff",
+          "getRadius": 500,
+          "radiusUnits": "meters"
+        },
+        "locked": false
+      }
+    },
+    {
+      "id": "/start-position-accessor",
+      "type": "AccessorOp",
+      "position": {
+        "x": -433.70069415474563,
+        "y": -72.47768858170832
+      },
+      "data": {
+        "inputs": {
+          "expression": "(() => { const coords = d.geom_text.replace('LINESTRING (', '').replace(')', '').split(',')[0].trim().split(' ').map(Number); return [coords[0], coords[1]]; })()"
+        },
+        "locked": false
+      }
+    },
+    {
+      "id": "/scatterplot-end",
+      "type": "ScatterplotLayerOp",
+      "position": {
+        "x": 1.850456621004568,
+        "y": -607.7137557077626
+      },
+      "data": {
+        "inputs": {
+          "opacity": 0.8,
+          "getFillColor": "#ff0000ff",
+          "getLineColor": "#ffffffff",
+          "getRadius": 500,
+          "radiusUnits": "meters"
+        },
+        "locked": false
+      }
+    },
+    {
+      "id": "/end-position-accessor",
+      "type": "AccessorOp",
+      "position": {
+        "x": -420.35502283105023,
+        "y": -477.7191780821918
+      },
+      "data": {
+        "inputs": {
+          "expression": "(() => { const coords = d.geom_text.replace('LINESTRING (', '').replace(')', '').split(','); const last = coords[coords.length - 1].trim().split(' ').map(Number); return [last[0], last[1]]; })()"
+        },
+        "locked": false
+      }
+    },
+    {
+      "id": "/basemap",
+      "type": "MaplibreBasemapOp",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "data": {
+        "inputs": {
+          "mapStyle": "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+          "viewState": {
+            "latitude": 36.3593,
+            "longitude": -121.646,
+            "zoom": 10,
+            "pitch": 0,
+            "bearing": 0
+          }
+        },
+        "locked": false
+      }
+    },
+    {
+      "id": "/deck",
+      "type": "DeckRendererOp",
+      "position": {
+        "x": 400,
+        "y": 0
+      },
+      "data": {
+        "inputs": {},
+        "locked": false
+      }
+    },
+    {
+      "id": "/out",
+      "type": "OutOp",
+      "position": {
+        "x": 700,
+        "y": 0
+      },
+      "data": {
+        "inputs": {},
+        "locked": false
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "/duckdb-flight-data.out.data->/path-layer.par.data",
+      "source": "/duckdb-flight-data",
+      "sourceHandle": "out.data",
+      "target": "/path-layer",
+      "targetHandle": "par.data"
+    },
+    {
+      "id": "/path-accessor.out.accessor->/path-layer.par.getPath",
+      "source": "/path-accessor",
+      "sourceHandle": "out.accessor",
+      "target": "/path-layer",
+      "targetHandle": "par.getPath"
+    },
+    {
+      "id": "/duckdb-flight-data.out.data->/scatterplot-start.par.data",
+      "source": "/duckdb-flight-data",
+      "sourceHandle": "out.data",
+      "target": "/scatterplot-start",
+      "targetHandle": "par.data"
+    },
+    {
+      "id": "/start-position-accessor.out.accessor->/scatterplot-start.par.getPosition",
+      "source": "/start-position-accessor",
+      "sourceHandle": "out.accessor",
+      "target": "/scatterplot-start",
+      "targetHandle": "par.getPosition"
+    },
+    {
+      "id": "/duckdb-flight-data.out.data->/scatterplot-end.par.data",
+      "source": "/duckdb-flight-data",
+      "sourceHandle": "out.data",
+      "target": "/scatterplot-end",
+      "targetHandle": "par.data"
+    },
+    {
+      "id": "/end-position-accessor.out.accessor->/scatterplot-end.par.getPosition",
+      "source": "/end-position-accessor",
+      "sourceHandle": "out.accessor",
+      "target": "/scatterplot-end",
+      "targetHandle": "par.getPosition"
+    },
+    {
+      "id": "/path-layer.out.layer->/deck.par.layers",
+      "source": "/path-layer",
+      "sourceHandle": "out.layer",
+      "target": "/deck",
+      "targetHandle": "par.layers"
+    },
+    {
+      "id": "/scatterplot-start.out.layer->/deck.par.layers",
+      "source": "/scatterplot-start",
+      "sourceHandle": "out.layer",
+      "target": "/deck",
+      "targetHandle": "par.layers"
+    },
+    {
+      "id": "/scatterplot-end.out.layer->/deck.par.layers",
+      "source": "/scatterplot-end",
+      "sourceHandle": "out.layer",
+      "target": "/deck",
+      "targetHandle": "par.layers"
+    },
+    {
+      "id": "/basemap.out.maplibre->/deck.par.basemap",
+      "source": "/basemap",
+      "sourceHandle": "out.maplibre",
+      "target": "/deck",
+      "targetHandle": "par.basemap"
+    },
+    {
+      "id": "/deck.out.vis->/out.par.vis",
+      "source": "/deck",
+      "sourceHandle": "out.vis",
+      "target": "/out",
+      "targetHandle": "par.vis"
+    }
+  ],
+  "viewport": {
+    "x": 534.0033593826707,
+    "y": 343.55942368830074,
+    "zoom": 0.3391789834557667
+  },
+  "timeline": {
+    "sheetsById": {
+      "Noodles": {
+        "staticOverrides": {
+          "byObject": {}
+        }
+      }
+    },
+    "definitionVersion": "0.4.0",
+    "revisionHistory": [
+      "vrjd4WA23V7f--Q9"
+    ]
+  },
+  "version": 7
+}


### PR DESCRIPTION
Inspired by @carstonhernke, adding an example based on [Flight Tracks](https://source.coop/root-geospatial/flight-tracks) data. It also shows off the power of pulling in data from parquet.