### PR TITLE
Don't serialize ReferenceEdges - they're derived on load

### DIFF
--- a/noodles-editor/src/noodles/utils/serialization.ts
+++ b/noodles-editor/src/noodles/utils/serialization.ts
@@ -124,6 +124,10 @@ export function serializeEdges(
         )
         return false
       }
+      // Skip ReferenceEdge types - they should not be persisted in save files
+      if (edge.type === 'ReferenceEdge') {
+        return false
+      }
       return true
     })
     .map(edge =>


### PR DESCRIPTION
I thought this was already the behavior, but we should formalize and test for this
