### PR TITLE
Re-prompt for the directory handle when the handle can't be found

### DIFF
--- a/noodles-editor/src/noodles/storage.ts
+++ b/noodles-editor/src/noodles/storage.ts
@@ -367,7 +367,8 @@ export async function readAsset(
   }
 
   // For filesystem-based storage types (fileSystemAccess or opfs)
-  const projectDirectory = await getProjectDirectoryHandle(type, projectName, false)
+  // Try to get directory handle, prompting user if not found in cache
+  const projectDirectory = await getProjectDirectoryHandle(type, projectName, true)
   if (!projectDirectory.success) {
     return projectDirectory
   }


### PR DESCRIPTION
Fixes hard-lock when the handle is out of date (lets fix that eventually but for now fix this). Also add some tests. Lots of mocks for now because it's hard to mock the filesystem apis
