### PR TITLE
Fix breadcrumb bar and container state changes

### DIFF
--- a/noodles-editor/src/noodles/__tests__/hooks.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/hooks.test.tsx
@@ -3,7 +3,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { NumberOp } from '../operators'
-import { NoodlesProvider, opMap, useOp, useSlice } from '../store'
+import { NoodlesProvider, opMap, useOp, useSlice, useNestingStore } from '../store'
 
 describe('Noodles Hooks', () => {
   afterEach(() => {
@@ -24,17 +24,13 @@ describe('Noodles Hooks', () => {
     })
 
     it('can read nesting context', () => {
-      const { result } = renderHook(() => useSlice(state => state.nesting), {
-        wrapper: NoodlesProvider,
-      })
+      const { result } = renderHook(() => useNestingStore(state => state.currentContainerId))
 
-      expect(result.current.currentContainerId).toBe('/')
+      expect(result.current).toBe('/')
     })
 
     it('can update nesting context', () => {
-      const { result } = renderHook(() => useSlice(state => state.nesting), {
-        wrapper: NoodlesProvider,
-      })
+      const { result } = renderHook(() => useNestingStore())
 
       act(() => {
         result.current.setCurrentContainerId('/container1')

--- a/noodles-editor/src/noodles/components/block-library.tsx
+++ b/noodles-editor/src/noodles/components/block-library.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import s from './block-library.module.css'
-import { useSlice } from '../store'
+import { useNestingStore } from '../store'
 import { createNodesForType, getNodeTypeOptions, type NodeType } from '../utils/node-creation-utils'
 import { getNodeDescription, headerClass, typeCategory, typeDisplayName } from './op-components'
 import { getPopularOperators, rankNodeTypes } from './block-library-ranking'
@@ -28,7 +28,7 @@ type BlockLibraryProps = {
 export const BlockLibrary = forwardRef<BlockLibraryRef, BlockLibraryProps>(({ reactFlowRef }, ref) => {
   const { addNodes, addEdges, screenToFlowPosition } = useReactFlow()
   const [isOpen, setIsOpen] = useState(false)
-  const { currentContainerId } = useSlice(state => state.nesting)
+  const currentContainerId = useNestingStore(state => state.currentContainerId)
   const [searchText, setSearchText] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
   // Store the screen coordinates where the modal was opened

--- a/noodles-editor/src/noodles/components/breadcrumbs.tsx
+++ b/noodles-editor/src/noodles/components/breadcrumbs.tsx
@@ -3,12 +3,13 @@ import { useKeyPress, useReactFlow } from '@xyflow/react'
 import cx from 'classnames'
 import { type FC, Fragment, useCallback, useEffect } from 'react'
 import { ContainerOp } from '../operators'
-import { opMap, useSlice } from '../store' // To access opMap for node names
+import { opMap, useNestingStore } from '../store' // To access opMap for node names
 import { getBaseName, getParentPath, joinPath, splitPath } from '../utils/path-utils'
 import s from './breadcrumbs.module.css'
 
 export const Breadcrumbs: FC = () => {
-  const { currentContainerId, setCurrentContainerId } = useSlice(state => state.nesting)
+  const currentContainerId = useNestingStore(state => state.currentContainerId)
+  const setCurrentContainerId = useNestingStore(state => state.setCurrentContainerId)
   const reactFlow = useReactFlow()
   const uPressed = useKeyPress('u', { target: document.body })
 

--- a/noodles-editor/src/noodles/components/copy-controls.tsx
+++ b/noodles-editor/src/noodles/components/copy-controls.tsx
@@ -2,7 +2,7 @@ import { useReactFlow } from '@xyflow/react'
 import { useCallback, useEffect, useRef } from 'react'
 
 import { useProjectModifications } from '../hooks/use-project-modifications'
-import { useSlice } from '../store'
+import { useSlice, useNestingStore } from '../store'
 import { edgeId, nodeId } from '../utils/id-utils'
 import { getBaseName } from '../utils/path-utils'
 import { type CopiedNodesJSON, safeStringify, serializeNodes } from '../utils/serialization'
@@ -19,7 +19,7 @@ function copy(text: string) {
 export function CopyControls() {
   const ops = useSlice(state => state.ops)
   const { toObject, getNodes, getEdges, setNodes, setEdges, screenToFlowPosition } = useReactFlow()
-  const { currentContainerId } = useSlice(state => state.nesting)
+  const currentContainerId = useNestingStore(state => state.currentContainerId)
   const mousePositionRef = useRef({ x: 0, y: 0 })
 
   // Use shared hook for project modifications to properly handle nodes + edges atomically

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -49,7 +49,7 @@ import {
   type TimeOp,
   type ViewerOp,
 } from '../operators'
-import { opMap, setHoveredOutputHandle, useOp, useSlice } from '../store'
+import { opMap, setHoveredOutputHandle, useOp, useSlice, useNestingStore } from '../store'
 import type { NodeDataJSON } from '../transform-graph'
 import { edgeId } from '../utils/id-utils'
 import { generateQualifiedPath, getBaseName, getParentPath } from '../utils/path-utils'
@@ -1101,7 +1101,7 @@ function ContainerOpComponent({
 }: ReactFlowNodeProps<NodeDataJSON<ContainerOp>>) {
   const op = useOp(id)
 
-  const { setCurrentContainerId } = useSlice(state => state.nesting)
+  const setCurrentContainerId = useNestingStore(state => state.setCurrentContainerId)
   const nodes = useNodes()
   const children = nodes.filter(node => getParentPath(node.id) === id)
 

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -58,7 +58,7 @@ import s from './noodles.module.css'
 import type { IOperator, Operator, OutOp } from './operators'
 import { extensionMap } from './operators'
 import { load } from './storage'
-import { opMap, sheetObjectMap, useSlice, hoveredOutputHandle } from './store'
+import { opMap, sheetObjectMap, useSlice, hoveredOutputHandle, useNestingStore } from './store'
 import { transformGraph } from './transform-graph'
 import { edgeId, nodeId } from './utils/id-utils'
 import { migrateProject } from './utils/migrate-schema'
@@ -266,7 +266,7 @@ export function getNoodles(): Visualization {
 
   const vPressHandledRef = useRef(false)
 
-  const { currentContainerId } = useSlice(state => state.nesting)
+  const currentContainerId = useNestingStore(state => state.currentContainerId)
 
   // Handle 'v' key press to create ViewerOp
   useEffect(() => {

--- a/noodles-editor/src/noodles/store.tsx
+++ b/noodles-editor/src/noodles/store.tsx
@@ -1,5 +1,6 @@
 import type { ISheetObject } from '@theatre/core'
-import { createContext, type PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react'
+import { createContext, type PropsWithChildren, useContext, useMemo } from 'react'
+import { create } from 'zustand'
 import type { IOperator, Operator } from './operators'
 // only import types from noodles to avoid circular dependencies
 import type { OpId } from './utils/id-utils'
@@ -8,10 +9,19 @@ import { isAbsolutePath, resolvePath } from './utils/path-utils'
 export const opMap = new Map<OpId, Operator<IOperator>>()
 export const sheetObjectMap = new Map<OpId, ISheetObject>()
 
-export type NestingContextValue = {
+// ============================================================================
+// Nesting State (Zustand)
+// ============================================================================
+
+interface NestingState {
   currentContainerId: string
   setCurrentContainerId: (id: string) => void
 }
+
+export const useNestingStore = create<NestingState>((set) => ({
+  currentContainerId: '/',
+  setCurrentContainerId: (id: string) => set({ currentContainerId: id }),
+}))
 
 export type OpsContextValue = {
   get: (id: OpId) => Operator<IOperator> | undefined
@@ -27,10 +37,7 @@ export type SheetObjectsContextValue = {
 export type NoodlesContextValue = {
   ops: OpsContextValue
   sheetObjects: SheetObjectsContextValue
-  nesting: NestingContextValue
 }
-
-let currentContainerIdValue = '/'
 
 const opsContext: OpsContextValue = {
   get: (id: OpId) => opMap.get(id),
@@ -58,37 +65,17 @@ export const setHoveredOutputHandle = (handle: { nodeId: string; handleId: strin
 const defaultContextValue: NoodlesContextValue = {
   ops: opsContext,
   sheetObjects: sheetObjectsContext,
-  nesting: {
-    currentContainerId: currentContainerIdValue,
-    setCurrentContainerId: (id: string) => {
-      currentContainerIdValue = id
-    },
-  },
 }
 
 export const NoodlesContext = createContext<NoodlesContextValue>(defaultContextValue)
 
 export const NoodlesProvider = ({ children }: PropsWithChildren) => {
-  const [currentContainerId, setCurrentContainerIdState] = useState(currentContainerIdValue)
-
-  const setCurrentContainerId = useCallback(
-    (id: string) => {
-      currentContainerIdValue = id
-      setCurrentContainerIdState(id)
-    },
-    [setCurrentContainerIdState]
-  )
-
   const contextValue = useMemo<NoodlesContextValue>(() => {
     return {
       ops: opsContext,
       sheetObjects: sheetObjectsContext,
-      nesting: {
-        currentContainerId,
-        setCurrentContainerId,
-      },
     }
-  }, [currentContainerId, setCurrentContainerId])
+  }, [])
 
   return <NoodlesContext.Provider value={contextValue}>{children}</NoodlesContext.Provider>
 }


### PR DESCRIPTION
Fix for #93. 

Runbook:
1. Create container op
2. Double click the container to dive in and edit some stuff
3. Press `u` on the keyboard or the `/` in the breadcrumbs bar to go back to the root.
4. You should see different things for the both levels