### PR TITLE
Fix path test and throw on invalid handles

### DIFF
--- a/docs/developers/paths-containers.md
+++ b/docs/developers/paths-containers.md
@@ -112,13 +112,13 @@ Examples:
 ### Connection Examples
 
 ```javascript
-// Connect using fully qualified handle IDs in the edges array
+// Connect using fully qualified node IDs and handle names in the edges array
 edges: [{
   id: '/data-loader.out.data->/processing/filter.par.input',
   source: '/data-loader',
   target: '/processing/filter',
-  sourceHandle: '/data-loader.out.data',
-  targetHandle: '/processing/filter.par.input',
+  sourceHandle: 'out.data',
+  targetHandle: 'par.input',
 }]
 ```
 

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -67,11 +67,11 @@ import { pick } from './utils/pick'
 import { EMPTY_PROJECT, type NoodlesProjectJSON } from './utils/serialization'
 
 export type Edge<N1 extends Operator<IOperator>, N2 extends Operator<IOperator>> = {
-  id: `${N1['id']}/${keyof N1['outputs']}->${N2['id']}/${keyof N2['inputs']}`
+  id: `${N1['id']}.${'par'|'out'}.${keyof N1['outputs']}->${N2['id']}.${'par'|'out'}.${keyof N2['inputs']}`
   source: N1['id']
   target: N2['id']
-  sourceHandle: `${N1['id']}/${keyof N1['outputs']}`
-  targetHandle: `${N2['id']}/${keyof N2['inputs']}`
+  sourceHandle: `${'par'|'out'}.${keyof N1['outputs']}`
+  targetHandle: `${'par'|'out'}.${keyof N2['inputs']}`
 }
 
 const fitViewOptions: FitViewOptions = {

--- a/noodles-editor/src/noodles/qualified-paths-integration.test.ts
+++ b/noodles-editor/src/noodles/qualified-paths-integration.test.ts
@@ -681,16 +681,9 @@ describe('Qualified Paths Integration Tests', () => {
         },
       ]
 
-      // Transform the graph - should not throw errors
-      const operators = transformGraph({ nodes, edges })
-
-      // Verify operators were still created
-      expect(operators).toHaveLength(2)
-
-      // Verify only the valid connection was established
-      const target = opMap.get('/valid-target') as MathOp
-      expect(target.inputs.a.subscriptions.size).toBe(1) // Valid connection
-      expect(target.inputs.b.subscriptions.size).toBe(0) // Invalid connections ignored
+      expect(() => transformGraph({ nodes, edges })).toThrow(
+        'Invalid handle ID format - migration should have converted all handles to qualified format',
+      )
     })
 
     it('supports complex ReactFlow scenarios with containers and qualified paths', async () => {

--- a/noodles-editor/src/noodles/transform-graph.test.ts
+++ b/noodles-editor/src/noodles/transform-graph.test.ts
@@ -41,7 +41,7 @@ describe('transform-graph', () => {
     expect(add.id).toBe('/add')
   })
 
-  it('skips connections with invalid handle ID format', () => {
+  it('throws on connections with invalid handle ID format', () => {
     const graph: {
       nodes: ReactFlowNode<Record<string, unknown>>[]
       edges: Record<string, unknown>[] // Using Record type to test invalid handle IDs
@@ -66,17 +66,9 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
-    expect(instances).toHaveLength(2)
-
-    const [num, add] = instances
-    expect(num).toBeInstanceOf(NumberOp)
-    expect(add).toBeInstanceOf(MathOp)
-    expect(num.id).toBe('/num')
-    expect(add.id).toBe('/add')
-
-    // Verify that the invalid connection was not established
-    expect(add.inputs.a.subscriptions.size).toBe(0)
+    expect(() => transformGraph(graph)).toThrow(
+      'Invalid handle ID format - migration should have converted all handles to qualified format'
+    )
   })
 
   it('generates correct edge IDs with qualified paths', () => {

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -122,10 +122,7 @@ export function transformGraph<
       const targetHandleInfo = parseHandleId(targetHandleStr)
 
       if (!sourceHandleInfo || !targetHandleInfo) {
-        console.warn(
-          'Invalid handle ID format - migration should have converted all handles to qualified format'
-        )
-        continue
+        throw new Error('Invalid handle ID format - migration should have converted all handles to qualified format')
       }
 
       const sourceFieldName = sourceHandleInfo.fieldName


### PR DESCRIPTION
Previously we just warned if handles were invalid but I think it was getting lost in the shuffle. I'd rather this fail loudly given how much depends on this being right and how often this has tripped us up.

This may require more integration-style tests on anything that creates a handle id to make sure it's making it in the right format, but at the very least I want to fix this issue.