### PR TITLE
Migrate useOp -> getOp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -817,11 +817,8 @@ When implementing features or fixes:
 8. **Testing is expected** - Add tests for new features and changes to critical components
 9. **Document edge cases** - Users may not expect implementation-specific behavior
 10. **Keep PRs focused** - Split large changes into reviewable chunks when possible
-11. **Use store helpers** - Always use `getOp()`, `getAllOps()`, etc. instead of direct `opMap` access
-12. **Batch store updates** - Use `getOpStore().batch()` when making multiple related changes
-13. **Non-reactive store access** - Store helpers don't trigger React re-renders; use hooks for reactive access
 
 ---
 
-**Last Updated**: 2025-01-12
-**Version**: Based on project version 6 schema with Zustand state management
+**Last Updated**: 2025-11-12
+**Version**: Based on project version 6 schema

--- a/noodles-editor/src/noodles/__tests__/hooks.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/hooks.test.tsx
@@ -1,9 +1,9 @@
-// Tests for custom React hooks
-// Tests useSlice, useOp, and integration with the Noodles context
+// Tests for custom React hooks and store utilities
+// Tests getOp, useNestingStore, and integration with the Noodles context
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { NumberOp } from '../operators'
-import { clearOps, getOp, getSheetObject, setOp, useOp, useNestingStore } from '../store'
+import { clearOps, getOp, getSheetObject, setOp, useNestingStore } from '../store'
 
 describe('Noodles Hooks', () => {
   afterEach(() => {
@@ -39,33 +39,21 @@ describe('Noodles Hooks', () => {
     })
   })
 
-  describe('useOp', () => {
+  describe('getOp', () => {
     it('returns an operator when it exists', () => {
       const op = new NumberOp('/test-num', {})
       setOp('/test-num', op)
 
-      const { result } = renderHook(() => useOp('/test-num'))
+      const result = getOp('/test-num')
 
-      expect(result.current).toBe(op)
-      expect(result.current).toBeInstanceOf(NumberOp)
+      expect(result).toBe(op)
+      expect(result).toBeInstanceOf(NumberOp)
     })
 
-    it('throws an error when operator does not exist', () => {
-      // Use a try-catch in the hook to capture the error
-      const TestHook = () => {
-        try {
-          return useOp('/nonexistent')
-        } catch (error) {
-          return { error }
-        }
-      }
+    it('returns undefined when operator does not exist', () => {
+      const result = getOp('/nonexistent')
 
-      const { result } = renderHook(() => TestHook())
-
-      expect(result.current).toHaveProperty('error')
-      expect((result.current as { error: Error }).error.message).toBe(
-        'Operator with id /nonexistent not found'
-      )
+      expect(result).toBeUndefined()
     })
 
     it('returns the correct operator when multiple exist', () => {
@@ -74,39 +62,40 @@ describe('Noodles Hooks', () => {
       setOp('/num1', op1)
       setOp('/num2', op2)
 
-      const { result: result1 } = renderHook(() => useOp('/num1'))
-      const { result: result2 } = renderHook(() => useOp('/num2'))
+      const result1 = getOp('/num1')
+      const result2 = getOp('/num2')
 
-      expect(result1.current).toBe(op1)
-      expect(result2.current).toBe(op2)
-      expect(result1.current).not.toBe(result2.current)
+      expect(result1).toBe(op1)
+      expect(result2).toBe(op2)
+      expect(result1).not.toBe(result2)
     })
   })
 
-  describe('Hook integration with operators', () => {
-    it('can access operator properties through hooks', () => {
+  describe('Store integration with operators', () => {
+    it('can access operator properties through getOp', () => {
       const op = new NumberOp('/test-num', { val: 42 })
       setOp('/test-num', op)
 
-      const { result } = renderHook(() => useOp('/test-num'))
+      const result = getOp('/test-num')
 
-      expect(result.current.inputs.val.value).toBe(42)
+      expect(result?.inputs.val.value).toBe(42)
     })
 
     it('reflects operator updates', () => {
       const op = new NumberOp('/test-num', { val: 10 })
       setOp('/test-num', op)
 
-      const { result } = renderHook(() => useOp('/test-num'))
-
-      expect(result.current.inputs.val.value).toBe(10)
+      const result = getOp('/test-num')
+      expect(result?.inputs.val.value).toBe(10)
 
       // Update the operator
       act(() => {
         op.inputs.val.setValue(20)
       })
 
-      expect(result.current.inputs.val.value).toBe(20)
+      // getOp returns the same operator reference, so updates are reflected
+      expect(result?.inputs.val.value).toBe(20)
+      expect(getOp('/test-num')?.inputs.val.value).toBe(20)
     })
   })
 })

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -49,7 +49,7 @@ import {
   type TimeOp,
   type ViewerOp,
 } from '../operators'
-import { useOp, useNestingStore, setHoveredOutputHandle, hasOp, setOp, getAllOps, deleteOp } from '../store'
+import { getOp, useNestingStore, setHoveredOutputHandle, hasOp, setOp, getAllOps, deleteOp } from '../store'
 import type { NodeDataJSON } from '../transform-graph'
 import { edgeId } from '../utils/id-utils'
 import { generateQualifiedPath, getBaseName, getParentPath } from '../utils/path-utils'
@@ -386,7 +386,10 @@ function NodeComponent({
   type,
   selected,
 }: ReactFlowNodeProps<NodeDataJSON<Operator<IOperator>>> & { type: OpType }) {
-  const op = useOp(id)
+  const op = getOp(id as string)
+  if (!op) {
+    throw new Error(`Operator with id ${id} not found`)
+  }
   const locked = useLocked(op)
   const executionState = useExecutionState(op)
 
@@ -711,7 +714,10 @@ function GeocoderOpComponent({
   id,
   type,
 }: ReactFlowNodeProps<NodeDataJSON<GeocoderOp>> & { type: 'GeocoderOp' }) {
-  const op = useOp(id)
+  const op = getOp(id as string)
+  if (!op) {
+    throw new Error(`Operator with id ${id} not found`)
+  }
 
   const containerRef = useRef<HTMLDivElement>(null)
   const geocoderRef = useRef<MapboxGeocoder>()
@@ -792,7 +798,10 @@ function MouseOpComponent({
   id,
   type,
 }: ReactFlowNodeProps<NodeDataJSON<MouseOp>> & { type: 'MouseOp' }) {
-  const op = useOp(id)
+  const op = getOp(id as string)
+  if (!op) {
+    throw new Error(`Operator with id ${id} not found`)
+  }
 
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
 
@@ -839,7 +848,10 @@ function TableEditorOpComponent({
   type,
   selected,
 }: ReactFlowNodeProps<NodeDataJSON<TableEditorOp>> & { type: 'TableEditorOp' }) {
-  const op = useOp(id)
+  const op = getOp(id as string)
+  if (!op) {
+    throw new Error(`Operator with id ${id} not found`)
+  }
 
   const [dataArray, setDataArray] = useState(op.inputs.data.value as unknown[])
   useEffect(() => {
@@ -1014,7 +1026,10 @@ function ViewerOpComponent({
   type,
   selected,
 }: ReactFlowNodeProps<NodeDataJSON<ViewerOp>> & { type: 'ViewerOp' }) {
-  const op = useOp(id)
+  const op = getOp(id as string)
+  if (!op) {
+    throw new Error(`Operator with id ${id} not found`)
+  }
 
   // TODO: use react-flow helpers
   const [viewerData, setViewerData] = useState(viewerFormatter(op.inputs.data.value))
@@ -1099,7 +1114,10 @@ function ContainerOpComponent({
   type,
   selected,
 }: ReactFlowNodeProps<NodeDataJSON<ContainerOp>>) {
-  const op = useOp(id)
+  const op = getOp(id as string)
+  if (!op) {
+    throw new Error(`Operator with id ${id} not found`)
+  }
 
   const setCurrentContainerId = useNestingStore(state => state.setCurrentContainerId)
   const nodes = useNodes()
@@ -1143,7 +1161,10 @@ function TimeOpComponent({
   id,
   type,
 }: ReactFlowNodeProps<NodeDataJSON<TimeOp>> & { type: 'TimeOp' }) {
-  const op = useOp(id)
+  const op = getOp(id as string)
+  if (!op) {
+    throw new Error(`Operator with id ${id} not found`)
+  }
   const sheet = useContext(SheetContext) as ISheet
 
   const [now, setNow] = useState(0)

--- a/noodles-editor/src/noodles/store.tsx
+++ b/noodles-editor/src/noodles/store.tsx
@@ -115,15 +115,6 @@ export const getOpStore = () => useOperatorStore.getState()
 // Get the UI store instance for use outside React components
 export const getUIStore = () => useUIStore.getState()
 
-// Helpful hook to get an op, just be careful not to break rule of hooks with it.
-export const useOp = (id: OpId) => {
-  const op = useOperatorStore.getState().getOp(id)
-  if (!op) {
-    throw new Error(`Operator with id ${id} not found`)
-  }
-  return op
-}
-
 // `path` can be absolute or relative to `contextOperatorId`
 export const getOp = (
   path: string,


### PR DESCRIPTION
`useOp` implies a React hook, while in most cases these are not reactive. Clarify the code here