### PR TITLE
[fix] shouldn't undo graph changes when timeline is active

### DIFF
--- a/noodles-editor/src/noodles/components/UndoRedoHandler.tsx
+++ b/noodles-editor/src/noodles/components/UndoRedoHandler.tsx
@@ -36,6 +36,39 @@ export const UndoRedoHandler = forwardRef<UndoRedoHandlerRef>((_, ref) => {
   // Add keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Check if Theatre.js timeline is focused
+      // Theatre.js uses a shadow DOM with id 'theatrejs-studio-root'
+      // If the event target or active element is within Theatre's shadow DOM,
+      // don't handle the event - let Theatre.js handle its own undo/redo
+      const theatreRoot = document.querySelector('#theatrejs-studio-root')
+      const isTheatreFocused = (() => {
+        // Check if event target is within Theatre.js shadow DOM
+        if (theatreRoot?.shadowRoot && e.target instanceof Node) {
+          const composedPath = e.composedPath()
+          if (composedPath.includes(theatreRoot.shadowRoot as EventTarget)) {
+            return true
+          }
+        }
+
+        // Check if active element is within Theatre.js shadow DOM
+        if (theatreRoot?.shadowRoot?.activeElement) {
+          return true
+        }
+
+        // Check if the event target is the Theatre.js root itself
+        if (e.target === theatreRoot) {
+          return true
+        }
+
+        return false
+      })()
+
+      // Only handle undo/redo for the graph if Theatre.js is not focused
+      if (isTheatreFocused) {
+        console.info('Theatre.js is focused, skipping graph undo/redo')
+        return
+      }
+
       if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {
         e.preventDefault()
         console.info('Undo triggered via keyboard')


### PR DESCRIPTION
Runbook:
- open a project
- add a node
- open timeline and add a keyframe
- move the keyframe
- ctrl+z

It should only undo the keyframe move. The added node shouldn't be undone.

---

Modified noodles-editor/src/noodles/components/UndoRedoHandler.tsx:38-88 to add context-aware undo/redo handling:

The Fix:
  - Added detection for when Theatre.js timeline is focused by checking if the event target is within Theatre.js shadow DOM (#theatrejs-studio-root)
  - When Theatre.js is focused, the keyboard handler now skips graph undo/redo operations and lets Theatre.js handle its own undo/redo
  - The check uses composedPath() to detect events originating from within the shadow DOM

How it works:
  1. When Cmd+Z or Cmd+Shift+Z is pressed, the handler first checks if Theatre.js has focus
  2. If Theatre.js is focused (user is working in the timeline), the graph undo/redo is skipped
  3. If Theatre.js is NOT focused (user is working in the graph), the graph undo/redo proceeds normally

This ensures that when you're working on keyframes in the Theatre.js timeline, only the timeline changes are undone/redone, and the flow graph remains unchanged. When working on the graph itself, only graph changes are affected.

