### PR TITLE
Handle Github Pages 404 fallback

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -25,12 +25,7 @@ const config: Config = {
   projectName: 'noodles.gl',
 
   onBrokenLinks: 'throw',
-
-  markdown: {
-    hooks: {
-      onBrokenMarkdownLinks: 'warn',
-    },
-  },
+  onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/website/src/theme/NotFound/index.tsx
+++ b/website/src/theme/NotFound/index.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from 'react';
+import NotFound from '@theme-original/NotFound';
+import { useLocation } from '@docusaurus/router';
+import type { Props } from '@theme/NotFound';
+
+export default function NotFoundWrapper(props: Props): JSX.Element {
+  const location = useLocation();
+
+  useEffect(() => {
+    // Check if the 404 path belongs to the app
+    if (location.pathname.startsWith('/app/')) {
+      // Redirect to the SPA root with the path as a query param
+      // Match this query param key ('redirect') to what your SPA expects
+      const redirectPath = location.pathname + location.search + location.hash;
+      window.location.replace(
+        `/app/?redirect=${encodeURIComponent(redirectPath)}`
+      );
+    }
+  }, [location]);
+
+  // Render the standard Docusaurus 404 for all other paths
+  return <NotFound {...props} />;
+}


### PR DESCRIPTION
#68 worked on Cloudflare but it doesn't work with Github pages. They aren't true one-to-one environments. For most app development this doesn't matter but this sort of thing it does. Annying.

It also see that we can put a 404.html in the root directory but I'd sorta rather not. Giving this a try based on [this](https://github.com/facebook/docusaurus/discussions/6030) and [this](https://docsaid.org/en/blog/customized-docusaurus-404-page/). 