### PR TITLE
Lazy-load examples and add a new /projects route

### DIFF
--- a/noodles-editor/src/app.tsx
+++ b/noodles-editor/src/app.tsx
@@ -1,8 +1,10 @@
-import { Component, type ReactNode } from 'react'
+import { Component, lazy, Suspense, type ReactNode } from 'react'
 import { Redirect, Route, Router, Switch, useRoute, useSearchParams } from 'wouter'
 import { AnalyticsConsentBanner } from './components/analytics-consent-banner'
-import ExamplesPage from './examples-page'
 import TimelineEditor from './timeline-editor'
+
+// Lazy-load ExamplesPage to reduce main bundle size
+const ExamplesPage = lazy(() => import('./examples-page'))
 
 // Error boundary to catch analytics failures
 class AnalyticsErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
@@ -35,14 +37,19 @@ function App() {
   return (
     <Router base={baseUrl}>
       <Switch>
-        {/* Project route - /examples/:projectId (most specific first) */}
+        {/* Project routes - /examples/:projectId and /projects/:projectId (most specific first) */}
         <Route path="/examples/:projectId">
+          <TimelineEditor />
+        </Route>
+        <Route path="/projects/:projectId">
           <TimelineEditor />
         </Route>
 
         {/* Examples list page */}
         <Route path="/examples">
-          <ExamplesPage />
+          <Suspense fallback={<div>Loading...</div>}>
+            <ExamplesPage />
+          </Suspense>
         </Route>
 
         {/* Catch-all for root path, 404s, and redirects */}

--- a/noodles-editor/src/examples-page.tsx
+++ b/noodles-editor/src/examples-page.tsx
@@ -3,8 +3,12 @@ import { useEffect, useState } from 'react'
 import { Link } from 'wouter'
 import s from './examples-page.module.css'
 
-const projects = import.meta.glob('./examples/**/noodles.json')
+const projects = import.meta.glob('./examples/**/noodles.json', {
+  eager: true,
+  import: 'default',
+})
 const readmes = import.meta.glob('./examples/**/README.md', {
+  eager: true,
   query: '?raw',
   import: 'default',
 })
@@ -66,45 +70,41 @@ export default function ExamplesPage() {
   const [examples, setExamples] = useState<ExampleProject[]>([])
 
   useEffect(() => {
-    const loadExamples = async () => {
-      const examplesList: ExampleProject[] = []
+    const examplesList: ExampleProject[] = []
 
-      for (const path of Object.keys(projects)) {
-        const projectId = basename(dirname(path))
-        const readmePath = path.replace('noodles.json', 'README.md')
+    for (const path of Object.keys(projects)) {
+      const projectId = basename(dirname(path))
+      const readmePath = path.replace('noodles.json', 'README.md')
 
-        let projectName = projectId
+      let projectName = projectId
 
-        let readme: string | undefined
-        if (readmes[readmePath]) {
-          try {
-            readme = (await readmes[readmePath]()) as string
-            if (readme) {
-              // parse first line for project name as "# Project Name"
-              const firstLine = readme.split('\n')[0]
-              const match = firstLine.match(/^#\s+(.*)/)
-              if (match?.[1]) {
-                projectName = match[1].trim()
-              }
+      let readme: string | undefined
+      if (readmes[readmePath]) {
+        try {
+          readme = readmes[readmePath] as string
+          if (readme) {
+            // parse first line for project name as "# Project Name"
+            const firstLine = readme.split('\n')[0]
+            const match = firstLine.match(/^#\s+(.*)/)
+            if (match?.[1]) {
+              projectName = match[1].trim()
             }
-          } catch (e) {
-            console.warn(`Failed to load README for ${projectName}`, e)
           }
+        } catch (e) {
+          console.warn(`Failed to load README for ${projectName}`, e)
         }
-
-        examplesList.push({
-          name: projectName,
-          path: `/examples/${projectId}`,
-          readme,
-        })
       }
 
-      // Sort alphabetically
-      examplesList.sort((a, b) => a.name.localeCompare(b.name))
-      setExamples(examplesList)
+      examplesList.push({
+        name: projectName,
+        path: `/examples/${projectId}`,
+        readme,
+      })
     }
 
-    loadExamples()
+    // Sort alphabetically
+    examplesList.sort((a, b) => a.name.localeCompare(b.name))
+    setExamples(examplesList)
   }, [])
 
   return (


### PR DESCRIPTION
Keeps the shipped file size down, makes vite start faster and has fewer vite complaints

Also adds a `/projects/:projectId` route to make it more obvious when instructing people how to load a project. For now they're the same but this will hopefully change when #145 lands