### PR TITLE
Allow custom LayerExtensions

### DIFF
--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -1014,13 +1014,13 @@ export class ExtensionField extends Field<z.ZodTypeAny> {
   static type = 'extension'
   static defaultValue = undefined
   createSchema() {
-    return z.union([
-      z.strictObject({
-        extension: z.looseObject({ type: z.string() }),
-        props: z.looseObject({}),
-      }),
-      z.instanceof(LayerExtension)
-    ])
+    return z.strictObject({
+      extension: z.union([
+        z.looseObject({ type: z.string() }),
+        z.instanceof(LayerExtension),
+      ]),
+      props: z.looseObject({}),
+    })
   }
 }
 

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -724,14 +724,15 @@ export function getNoodles(): Visualization {
               if (extensions && Array.isArray(extensions)) {
                 instantiatedExtensions = extensions
                   .map((ext: { type: string; [key: string]: unknown } | LayerExtension) => {
+
                     // If it's already a LayerExtension instance, return as is
                     if (ext instanceof LayerExtension) {
                       return ext
                     }
 
                     // Otherwise, instantiate from POJO
-
                     const { type: extType, ...constructorArgs } = ext
+
                     const extensionDef = extensionMap[extType]
                     if (!extensionDef) {
                       console.warn(`Unknown extension type: ${extType}`)

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3014,8 +3014,8 @@ function gatherTriggers(
   return triggers
 }
 
-type LayerExtensionFieldReturnValue = null | {
-  extension: LayerExtension
+type LayerExtensionFieldValue = null | {
+  extension: LayerExtension | { type: string, [key: string]: unknown }
   props: Record<string, unknown>
 }
 
@@ -3049,23 +3049,34 @@ function parseLayerProps<P extends LayerProps>({
   extensions = [],
   ...props
 }: {
-  extensions: LayerExtensionFieldReturnValue[]
+  extensions: LayerExtensionFieldValue[]
 } & P) {
   const validExtensions = extensions.filter(
-    (e): e is Exclude<LayerExtensionFieldReturnValue, null> => e !== null
+    (e): e is Exclude<LayerExtensionFieldValue, null> => e !== null
   )
+
+  const layerProps = {
+    ...props,
+    ...validExtensions.reduce((acc, ext) => {
+      if (ext.extension) {
+        return { ...acc, ...ext.props }
+      }
+      return acc
+    }, {} as Record<string, unknown>),
+  }
 
   // Keep extensions as POJOs for now - they'll be instantiated later
   // in noodles.tsx unless they are already instantiated (i.e. custom extensions)
   return {
     ...props,
-    extensions: [
+    extensions: validExtensions.length > 0 ? [
       ...validExtensions.filter(e => e instanceof LayerExtension),
 
       // Merge extension props into the layer props
-      ...validExtensions.filter(e => e.extension)
-        .map(e => ({ ...e.extension, ...e.props })),
-    ]
+      ...validExtensions
+        .filter(e => e.extension)
+        .map(e => e.extension),
+    ] : undefined,
   }
 
 }


### PR DESCRIPTION
You should be able to define your own layer extensions in code. I don't know that this is the best ultimate solution (it might be a special case like `type: 'custom'` but this does seem to work for now