### PR TITLE
fix: Block library scroll position and keyboard navigation

### DIFF
--- a/noodles-editor/src/noodles/components/block-library.module.css
+++ b/noodles-editor/src/noodles/components/block-library.module.css
@@ -162,6 +162,14 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
+/* Disable hover effects in keyboard mode */
+.blockLibraryContent[data-input-mode='keyboard'] .blockLibraryCard:hover {
+  background-color: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.08);
+  transform: none;
+  box-shadow: none;
+}
+
 .blockLibraryCard:focus {
   outline: 2px solid var(--color-selected);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary

Fixes multiple scroll-related issues in the block library:
- Block library no longer remembers scroll position from previous open
- Keyboard navigation works smoothly without jumping back
- Hover effects are properly disabled during keyboard navigation
- Correct index calculation for duplicate operators in multiple categories

## Changes

1. **Reset scroll position on open**: Added `contentRef` to reset `scrollTop` to 0 when modal opens
2. **Input mode tracking**: Distinguish between keyboard and mouse input to prevent interference
3. **Smart mouse detection**: Only switch to mouse mode when cursor actually moves (not when content scrolls)
4. **Keyboard-only scrollIntoView**: Only trigger automatic scrolling during arrow key navigation
5. **CSS hover suppression**: Disable hover effects when in keyboard mode via `data-input-mode` attribute
6. **Fixed duplicate operator indices**: Use cumulative index tracking instead of `indexOf` to prevent conflicts with operators appearing in both Popular and their actual category

## Test plan

### Scroll Reset
1. Open block library (press 'A')
2. Scroll down in the list
3. Close (Escape) and reopen
4. **Expected**: Opens at top showing Popular category

### Keyboard Navigation
1. Open block library
2. Use arrow keys to navigate down beyond visible area
3. **Expected**: Selection scrolls smoothly, stays on selected card, no jumping back
4. Navigate from Popular section into next category
5. **Expected**: Smooth navigation without unexpected scroll jumps

### Mouse/Keyboard Mode Switching
1. Open block library and use arrow keys to navigate
2. **Expected**: No hover effects visible on cards under stationary cursor
3. Move mouse around
4. **Expected**: Hover effects now appear
5. Use arrow keys again
6. **Expected**: Hover effects disappear, keyboard navigation works smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)