### PR TITLE
refactor: Use :not() selector for block-library hover handling

### DIFF
--- a/noodles-editor/src/noodles/components/block-library.module.css
+++ b/noodles-editor/src/noodles/components/block-library.module.css
@@ -97,7 +97,8 @@
   text-overflow: ellipsis;
 }
 
-.blockLibraryCategoryItem:hover {
+/* Only apply hover in mouse mode */
+.blockLibrarySidebar:not([data-input-mode='keyboard']) .blockLibraryCategoryItem:hover {
   background-color: rgba(255, 255, 255, 0.05);
 }
 
@@ -155,19 +156,12 @@
   gap: 10px;
 }
 
-.blockLibraryCard:hover {
+/* Only apply hover in mouse mode */
+.blockLibraryContent:not([data-input-mode='keyboard']) .blockLibraryCard:hover {
   background-color: rgba(255, 255, 255, 0.06);
   border-color: rgba(255, 255, 255, 0.15);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-}
-
-/* Disable hover effects in keyboard mode */
-.blockLibraryContent[data-input-mode='keyboard'] .blockLibraryCard:hover {
-  background-color: rgba(255, 255, 255, 0.03);
-  border-color: rgba(255, 255, 255, 0.08);
-  transform: none;
-  box-shadow: none;
 }
 
 .blockLibraryCard:focus {

--- a/noodles-editor/src/noodles/components/block-library.tsx
+++ b/noodles-editor/src/noodles/components/block-library.tsx
@@ -306,7 +306,7 @@ export const BlockLibrary = forwardRef<BlockLibraryRef, BlockLibraryProps>(
       <div className={s.blockLibraryOverlay} onClick={onCloseModal}>
         {/* biome-ignore lint/a11y/noStaticElementInteractions: modal content container */}
         <div className={s.blockLibraryModal} onClick={e => e.stopPropagation()}>
-          <div className={s.blockLibrarySidebar}>
+          <div className={s.blockLibrarySidebar} data-input-mode={inputMode}>
             <div className={s.blockLibraryHeader}>Operator Library</div>
             <input
               ref={inputRef}


### PR DESCRIPTION
## Summary

Closes #173

Refactors block-library CSS to use `:not()` selectors instead of explicit override rules for disabling hover effects in keyboard mode.

## Changes Made

**Before:**
- Hover styles applied unconditionally
- Separate CSS rules to override each hover property in keyboard mode
- Required maintaining two sets of rules

**After:**
- Hover styles only apply when NOT in keyboard mode using `:not([data-input-mode='keyboard'])`
- Single selector handles both mouse and keyboard modes
- Removed 8 lines of redundant CSS overrides

**Files Modified:**
- `noodles-editor/src/noodles/components/block-library.module.css` - Updated hover selectors
- `noodles-editor/src/noodles/components/block-library.tsx` - Added `data-input-mode` to sidebar

## Technical Details

### New Selectors:
```css
/* Category items - only hover in mouse mode */
.blockLibrarySidebar:not([data-input-mode='keyboard']) .blockLibraryCategoryItem:hover {
  background-color: rgba(255, 255, 255, 0.05);
}

/* Operator cards - only hover in mouse mode */
.blockLibraryContent:not([data-input-mode='keyboard']) .blockLibraryCard:hover {
  background-color: rgba(255, 255, 255, 0.06);
  border-color: rgba(255, 255, 255, 0.15);
  transform: translateY(-2px);
  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
}
```

### Benefits:
1. **More maintainable**: Adding new hover properties doesn't require corresponding reset rules
2. **Cleaner code**: Reduced CSS by 8 lines (~50% reduction in hover-related code)
3. **More readable**: Intent is immediately clear from the selector
4. **Consistent pattern**: Both sidebar and content use the same approach

## Testing

**Manual Testing:**
1. Open block library (press 'A')
2. **Mouse mode**: Hover over category items and operator cards → should see hover effects
3. **Keyboard mode**: Use Tab to navigate → hover effects should NOT apply
4. Switch between mouse and keyboard → behavior should be correct in both modes

The `:not()` selector approach is cleaner and more maintainable than the previous override-based approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)