### PR TITLE
chore: Fix packageManager version to yarn@4.5.3

### DIFF
--- a/noodles-editor/package.json
+++ b/noodles-editor/package.json
@@ -122,5 +122,5 @@
     "node": "24.11.0",
     "yarn": "4.5.3"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@4.5.3"
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
     "serve:website": "(cd website && yarn serve)",
     "serve:app": "(cd noodles-editor && yarn serve)"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@4.5.3"
 }


### PR DESCRIPTION
## Summary
Updates the packageManager field in both root and noodles-editor package.json files to properly specify yarn@4.5.3.

## Changes
- Updated `package.json` packageManager field to `yarn@4.5.3`
- Updated `noodles-editor/package.json` packageManager field to `yarn@4.5.3`

## Context
The project has been using yarn 4 for a while, but the packageManager field in package.json still had an old value. This PR updates it to correctly reflect the actual yarn version being used.

## Test Plan
1. Verify `yarn --version` shows 4.5.3
2. Verify yarn commands work correctly
3. Confirm no warnings about packageManager mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)