### PR TITLE
fix: Prevent 'Locate Project' dialog after creating new project

### DIFF
--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -381,6 +381,9 @@ export function getNoodles(): Visualization {
 
   const currentProjectRef = useRef<NoodlesProjectJSON>(newProjectJSON)
 
+  // Track when we're programmatically loading a project to prevent useEffect from trying to reload
+  const isProgrammaticLoadRef = useRef(false)
+
   // Ref to access undo/redo and copy/paste functionality from inside ReactFlow context
   const undoRedoRef = useRef<UndoRedoHandlerRef>(null)
   const copyControlsRef = useRef<CopyControlsRef>(null)
@@ -595,6 +598,10 @@ export function getNoodles(): Visualization {
 
       // Clear unsaved changes flag when loading a project
       setHasUnsavedChanges(false)
+
+      // Mark that we've programmatically loaded this project
+      // This prevents the useEffect from trying to reload it from storage
+      isProgrammaticLoadRef.current = true
     },
     [setNodes, setEdges, setProjectName, setTheatreProject, navigate, routePrefix]
   )
@@ -607,6 +614,13 @@ export function getNoodles(): Visualization {
   // biome-ignore lint/correctness/useExhaustiveDependencies: loadProjectFile would cause infinite loop
   useEffect(() => {
     ;(async () => {
+      // If this is a programmatic load (from onNewProject, onImport, etc.),
+      // skip loading from storage to avoid showing the "Project Not Found" dialog
+      if (isProgrammaticLoadRef.current) {
+        isProgrammaticLoadRef.current = false
+        return
+      }
+
       // If no projectName, load the default new project
       if (!projectName || projectName === 'new') {
         try {


### PR DESCRIPTION
## Summary

Fixes the bug where the "Locate Project" dialog appears immediately after creating a new project, even though the project was just successfully created.

## Problem

When creating or importing a project, the flow was:
1. Project created and cached
2. URL updated to `/projects/{projectName}`
3. URL change triggered a `useEffect` that depends on `projectName`
4. Effect tried to load project from storage
5. Load operation triggered "Project Not Found" dialog

## Solution

Introduced a `isProgrammaticLoadRef` to track programmatic loads:
- Set to `true` after programmatic loads (New/Import/Open)
- The URL change effect checks this flag and returns early if set
- This prevents redundant storage loads while preserving URL-based navigation

## Testing

- [x] Create a new project → no dialog appears
- [x] Import a project → no dialog appears
- [x] Open an existing project → no dialog appears
- [x] Navigate to non-existent project URL → dialog still appears (expected)

## Files Modified

- `noodles-editor/src/noodles/noodles.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>