### PR TITLE
feat: Use asterisk as indicator of unsaved changes

### DIFF
--- a/noodles-editor/src/noodles/components/breadcrumbs.module.css
+++ b/noodles-editor/src/noodles/components/breadcrumbs.module.css
@@ -34,21 +34,9 @@
 }
 
 .unsavedIndicator {
-  display: inline-flex;
-  align-items: center;
   margin-left: 2px;
-  margin-right: -8px;
-  vertical-align: super;
-  font-size: 0.7em;
   line-height: 0;
   cursor: help;
-}
-
-.unsavedDot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: var(--color-text-accent);
 }
 
 .menu {

--- a/noodles-editor/src/noodles/components/breadcrumbs.tsx
+++ b/noodles-editor/src/noodles/components/breadcrumbs.tsx
@@ -128,7 +128,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({ projectName, hasUnsavedChang
             {segment.name}
             {index === 0 && hasUnsavedChanges && (
               <span className={s.unsavedIndicator} title="Unsaved changes">
-                <span className={s.unsavedDot} />
+                *
               </span>
             )}
           </button>

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -282,6 +282,8 @@ export function getNoodles(): Visualization {
       }
     }
 
+    document.title = projectName ? `Noodles.gl - ${projectName}${hasUnsavedChanges ? ' *' : ''}` : 'Noodles.gl'
+
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
   }, [hasUnsavedChanges])


### PR DESCRIPTION
## Summary
- Replace the dot indicator with an asterisk (*) for unsaved changes in the breadcrumbs
- Add asterisk to document title when there are unsaved changes
- Clean up unused CSS styles for the old dot indicator

## Changes
- **Breadcrumbs UI**: Changed from a styled dot to a simple asterisk character
- **Document Title**: Added asterisk suffix to title when project has unsaved changes
- **CSS Cleanup**: Removed unused .unsavedDot styles and simplified .unsavedIndicator

## Benefits
- More conventional unsaved changes indicator (matches common editor patterns)
- Simpler implementation with less CSS
- Visible in browser tab title for better awareness

## Test plan
- Verify asterisk appears in breadcrumbs when project is modified
- Verify asterisk appears in document title when project is modified
- Verify indicators disappear after saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="856" height="468" alt="Screenshot 2025-12-15 at 10 43 05 PM" src="https://github.com/user-attachments/assets/5238d5c0-d3b9-4798-8481-779c8058996a" />
