### PR TITLE
fix: Fix import-save dialog bug

### DIFF
--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -558,6 +558,10 @@ export function getNoodles(): Visualization {
     (project: NoodlesProjectJSON, name?: string) => {
       const { nodes, edges, viewport, timeline, editorSettings } = project
 
+      // Mark that we've programmatically loading this project BEFORE any state changes
+      // This prevents the useEffect from trying to reload it from storage when the URL changes
+      isProgrammaticLoadRef.current = true
+
       // Update current project ref for undo/redo
       currentProjectRef.current = project
 
@@ -590,10 +594,6 @@ export function getNoodles(): Visualization {
 
       // Clear unsaved changes flag when loading a project
       setHasUnsavedChanges(false)
-
-      // Mark that we've programmatically loaded this project
-      // This prevents the useEffect from trying to reload it from storage
-      isProgrammaticLoadRef.current = true
     },
     [setNodes, setEdges, setProjectName, setTheatreProject, navigate, routePrefix]
   )


### PR DESCRIPTION
## Summary

Fixes the bug where File > Import then File > Save pops up with "project not found" dialog.

## Root Cause

Race condition in `loadProjectFile` where `isProgrammaticLoadRef.current = true` was set after navigation, causing the useEffect monitoring projectName changes to trigger before the flag was set.

## The Fix

Moved the `isProgrammaticLoadRef.current = true` assignment to the beginning of `loadProjectFile` before any state changes that could trigger the useEffect.

## Testing

- File > Import then File > Save now works correctly
- File > Open then File > Save continues to work
- No regression in other load paths