### PR TITLE
chore: Move render settings to OutOp with migration

### DIFF
--- a/noodles-editor/src/noodles/__migrations__/010-render-settings-to-outop.test.ts
+++ b/noodles-editor/src/noodles/__migrations__/010-render-settings-to-outop.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from 'vitest'
+import type { NoodlesProjectJSON } from '../utils/serialization'
+import { down, up } from './010-render-settings-to-outop'
+
+describe('010-render-settings-to-outop', () => {
+  it('should migrate render settings from Theatre.js to OutOp', async () => {
+    const project: NoodlesProjectJSON = {
+      version: 9,
+      nodes: [
+        {
+          id: '/out',
+          type: 'OutOp',
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: {
+              vis: null,
+            },
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {
+        sheetsById: {
+          Noodles: {
+            staticOverrides: {
+              byObject: {
+                render: {
+                  display: 'responsive',
+                  resolution: { width: 3840, height: 2160 },
+                  lod: 1.5,
+                },
+                editor: {
+                  someOtherSetting: 'value',
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const migrated = await up(project)
+
+    // Should have render settings in OutOp inputs
+    const outOp = migrated.nodes.find(n => n.type === 'OutOp')
+    expect(outOp?.data.inputs.display).toBe('responsive')
+    expect(outOp?.data.inputs.resolution).toEqual({ width: 3840, height: 2160 })
+    expect(outOp?.data.inputs.lod).toBe(1.5)
+
+    // Should remove render from Theatre.js staticOverrides
+    const byObject = (migrated.timeline as any).sheetsById.Noodles.staticOverrides.byObject
+    expect(byObject.render).toBeUndefined()
+
+    // Should preserve other staticOverrides
+    expect(byObject.editor).toEqual({
+      someOtherSetting: 'value',
+    })
+  })
+
+  it('should handle missing render settings gracefully', async () => {
+    const project: NoodlesProjectJSON = {
+      version: 9,
+      nodes: [
+        {
+          id: '/out',
+          type: 'OutOp',
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: {
+              vis: null,
+            },
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {
+        sheetsById: {
+          Noodles: {
+            staticOverrides: {
+              byObject: {},
+            },
+          },
+        },
+      },
+    }
+
+    const migrated = await up(project)
+
+    // Should not modify nodes if no render settings exist
+    expect(migrated).toEqual(project)
+  })
+
+  it('should handle partial render settings', async () => {
+    const project: NoodlesProjectJSON = {
+      version: 9,
+      nodes: [
+        {
+          id: '/out',
+          type: 'OutOp',
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: {
+              vis: null,
+            },
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {
+        sheetsById: {
+          Noodles: {
+            staticOverrides: {
+              byObject: {
+                render: {
+                  resolution: { width: 2560, height: 1440 },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const migrated = await up(project)
+
+    // Should only migrate settings that exist
+    const outOp = migrated.nodes.find(n => n.type === 'OutOp')
+    expect(outOp?.data.inputs.resolution).toEqual({ width: 2560, height: 1440 })
+    expect(outOp?.data.inputs.display).toBeUndefined()
+    expect(outOp?.data.inputs.lod).toBeUndefined()
+  })
+
+  it('should handle projects without OutOp', async () => {
+    const project: NoodlesProjectJSON = {
+      version: 9,
+      nodes: [
+        {
+          id: '/viewer',
+          type: 'ViewerOp',
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: {},
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {
+        sheetsById: {
+          Noodles: {
+            staticOverrides: {
+              byObject: {
+                render: {
+                  display: 'fixed',
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const migrated = await up(project)
+
+    // Should still remove render from Theatre.js even without OutOp
+    const byObject = (migrated.timeline as any).sheetsById.Noodles.staticOverrides.byObject
+    expect(byObject.render).toBeUndefined()
+  })
+
+  it('should migrate back down correctly', async () => {
+    const projectWithSettings: NoodlesProjectJSON = {
+      version: 10,
+      nodes: [
+        {
+          id: '/out',
+          type: 'OutOp',
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: {
+              vis: null,
+              display: 'responsive',
+              resolution: { width: 3840, height: 2160 },
+              lod: 1.5,
+            },
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {
+        sheetsById: {
+          Noodles: {
+            staticOverrides: {
+              byObject: {
+                editor: {
+                  someOtherSetting: 'value',
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const migrated = await down(projectWithSettings)
+
+    // Should remove render settings from OutOp
+    const outOp = migrated.nodes.find(n => n.type === 'OutOp')
+    expect(outOp?.data.inputs.display).toBeUndefined()
+    expect(outOp?.data.inputs.resolution).toBeUndefined()
+    expect(outOp?.data.inputs.lod).toBeUndefined()
+    expect(outOp?.data.inputs.vis).toBe(null) // Should preserve other inputs
+
+    // Should have render back in Theatre.js staticOverrides
+    const byObject = (migrated.timeline as any).sheetsById.Noodles.staticOverrides.byObject
+    expect(byObject.render).toEqual({
+      display: 'responsive',
+      resolution: { width: 3840, height: 2160 },
+      lod: 1.5,
+    })
+
+    // Should preserve other staticOverrides
+    expect(byObject.editor).toEqual({
+      someOtherSetting: 'value',
+    })
+  })
+
+  it('should handle down migration without render settings', async () => {
+    const project: NoodlesProjectJSON = {
+      version: 10,
+      nodes: [
+        {
+          id: '/out',
+          type: 'OutOp',
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: {
+              vis: null,
+            },
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {
+        sheetsById: {
+          Noodles: {
+            staticOverrides: {
+              byObject: {},
+            },
+          },
+        },
+      },
+    }
+
+    const migrated = await down(project)
+
+    // Should not modify project if no render settings exist
+    expect(migrated).toEqual(project)
+  })
+
+  it('should round-trip correctly', async () => {
+    const original: NoodlesProjectJSON = {
+      version: 9,
+      nodes: [
+        {
+          id: '/out',
+          type: 'OutOp',
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: {
+              vis: null,
+            },
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {
+        sheetsById: {
+          Noodles: {
+            staticOverrides: {
+              byObject: {
+                render: {
+                  display: 'fixed',
+                  resolution: { width: 1920, height: 1080 },
+                  lod: 2,
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const migrated = await up(original)
+    const reverted = await down(migrated)
+
+    // Timeline should be equivalent
+    const originalRender = (original.timeline as any).sheetsById.Noodles.staticOverrides.byObject.render
+    const revertedRender = (reverted.timeline as any).sheetsById.Noodles.staticOverrides.byObject.render
+    expect(revertedRender).toEqual(originalRender)
+
+    // OutOp should be back to original state
+    const originalOutOp = original.nodes.find(n => n.type === 'OutOp')
+    const revertedOutOp = reverted.nodes.find(n => n.type === 'OutOp')
+    expect(revertedOutOp?.data.inputs).toEqual(originalOutOp?.data.inputs)
+  })
+})

--- a/noodles-editor/src/noodles/__migrations__/010-render-settings-to-outop.ts
+++ b/noodles-editor/src/noodles/__migrations__/010-render-settings-to-outop.ts
@@ -1,0 +1,142 @@
+import type { NoodlesProjectJSON } from '../utils/serialization'
+
+// Migration to move render settings from Theatre.js staticOverrides to OutOp inputs
+//
+// This migration:
+// 1. Extracts render settings (display, resolution, lod) from Theatre.js staticOverrides
+// 2. Adds them as inputs to the OutOp operator (only if they exist)
+// 3. Removes the render object from Theatre.js staticOverrides to clean up
+
+export async function up(project: NoodlesProjectJSON): Promise<NoodlesProjectJSON> {
+  const { timeline, nodes, ...rest } = project
+
+  // Extract render settings from Theatre.js staticOverrides
+  const sheetsById = (timeline as any)?.sheetsById || {}
+  const noodlesSheet = sheetsById.Noodles || {}
+  const staticOverrides = noodlesSheet.staticOverrides || {}
+  const byObject = staticOverrides.byObject || {}
+  const renderOverrides = byObject.render || {}
+
+  // Only migrate if render settings exist
+  if (!Object.keys(renderOverrides).length) {
+    return project
+  }
+
+  // Find OutOp node(s) and update with render settings
+  const newNodes = nodes.map(node => {
+    if (node.type === 'OutOp') {
+      const inputs = { ...node.data.inputs }
+
+      // Only add settings that exist in Theatre.js
+      if (renderOverrides.display !== undefined) {
+        inputs.display = renderOverrides.display
+      }
+      if (renderOverrides.resolution !== undefined) {
+        inputs.resolution = renderOverrides.resolution
+      }
+      if (renderOverrides.lod !== undefined) {
+        inputs.lod = renderOverrides.lod
+      }
+
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          inputs,
+        },
+      }
+    }
+    return node
+  })
+
+  // Remove render from staticOverrides
+  const { render: _, ...restOfObjects } = byObject
+  const newStaticOverrides = {
+    ...staticOverrides,
+    byObject: restOfObjects,
+  }
+
+  // Update timeline without render staticOverrides
+  const newTimeline = {
+    ...timeline,
+    sheetsById: {
+      ...sheetsById,
+      Noodles: {
+        ...noodlesSheet,
+        staticOverrides: newStaticOverrides,
+      },
+    },
+  }
+
+  return {
+    ...rest,
+    nodes: newNodes,
+    timeline: newTimeline,
+  }
+}
+
+export async function down(project: NoodlesProjectJSON): Promise<NoodlesProjectJSON> {
+  const { timeline, nodes, ...rest } = project
+
+  // Extract render settings from OutOp
+  const outOpNode = nodes.find(node => node.type === 'OutOp')
+  const inputs = outOpNode?.data.inputs || {}
+
+  // Only migrate back if OutOp has render settings
+  const hasRenderSettings = inputs.display !== undefined ||
+                            inputs.resolution !== undefined ||
+                            inputs.lod !== undefined
+
+  if (!hasRenderSettings) {
+    return project
+  }
+
+  // Put render settings back into Theatre.js staticOverrides
+  const sheetsById = (timeline as any)?.sheetsById || {}
+  const noodlesSheet = sheetsById.Noodles || {}
+  const staticOverrides = noodlesSheet.staticOverrides || {}
+  const byObject = staticOverrides.byObject || {}
+
+  const renderSettings: any = {}
+  if (inputs.display !== undefined) renderSettings.display = inputs.display
+  if (inputs.resolution !== undefined) renderSettings.resolution = inputs.resolution
+  if (inputs.lod !== undefined) renderSettings.lod = inputs.lod
+
+  const newTimeline = {
+    ...timeline,
+    sheetsById: {
+      ...sheetsById,
+      Noodles: {
+        ...noodlesSheet,
+        staticOverrides: {
+          ...staticOverrides,
+          byObject: {
+            ...byObject,
+            render: renderSettings,
+          },
+        },
+      },
+    },
+  }
+
+  // Remove render settings from OutOp nodes
+  const newNodes = nodes.map(node => {
+    if (node.type === 'OutOp') {
+      const { display, resolution, lod, ...restOfInputs } = node.data.inputs
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          inputs: restOfInputs,
+        },
+      }
+    }
+    return node
+  })
+
+  return {
+    ...rest,
+    nodes: newNodes,
+    timeline: newTimeline,
+  }
+}

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -2985,6 +2985,17 @@ export class OutOp extends Operator<OutOp> {
   createInputs() {
     return {
       vis: new VisualizationField(),
+      display: new StringLiteralField('fixed', {
+        options: {
+          fixed: 'fixed',
+          responsive: 'responsive',
+        },
+      }),
+      resolution: new CompoundPropsField({
+        width: new NumberField(1920),
+        height: new NumberField(1080),
+      }),
+      lod: new NumberField(2, { min: 1, max: 2 }),
     }
   }
   createOutputs() {

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -10,7 +10,8 @@ import ReactMapGL, { type MapProps, useControl } from 'react-map-gl/maplibre'
 import { Layout } from './layout'
 import { getNoodles } from './noodles/noodles'
 import { TopMenuBar } from './noodles/components/top-menu-bar'
-import { setSheetObject, deleteSheetObject } from './noodles/store'
+import { type Operator } from './noodles/operators'
+import { setSheetObject, deleteSheetObject, useOperatorStore } from './noodles/store'
 import { useDeckDrawLoop } from './render/draw-loop'
 import { captureScreenshot, rafDriver, useRenderer } from './render/renderer'
 import { TransformScale } from './render/transform-scale'
@@ -69,15 +70,6 @@ observer.observe(document.body, { childList: true, subtree: true })
 injectTheatreStyles()
 
 const INITIAL_RENDER_STATE = {
-  display: types.stringLiteral('fixed', {
-    fixed: 'fixed',
-    responsive: 'responsive',
-  }),
-  resolution: types.compound({
-    width: types.number(1920),
-    height: types.number(1080),
-  }),
-  lod: types.number(2, { range: [1, 2] }),
   waitForData: types.boolean(true),
   codec: types.stringLiteral('avc', {
     hevc: 'hevc', // h265
@@ -99,10 +91,10 @@ const INITIAL_RENDER_STATE = {
 const DeckGLOverlay = forwardRef<
   Deck,
   MapboxOverlayProps & {
-    renderer: PropsValue<typeof INITIAL_RENDER_STATE>
+    rendererConfig: { waitForData: boolean; captureDelay: number }
     isRendering: boolean
   }
->(({ renderer, isRendering, ...props }, ref) => {
+>(({ rendererConfig, isRendering, ...props }, ref) => {
   // MapboxOverlay handles a variety of props differently than the Deck class.
   // https://deck.gl/docs/api-reference/mapbox/mapbox-overlay#constructor
   const deck = useControl<MapboxOverlay>(() => new MapboxOverlay({ ...props, interleaved: true }))
@@ -122,7 +114,7 @@ const DeckGLOverlay = forwardRef<
   useDeckDrawLoop({
     deck: deckgl,
     isRendering,
-    rendererConfig: renderer,
+    rendererConfig,
     props,
   })
 
@@ -184,9 +176,20 @@ export default function TimelineEditor() {
   }, [rendererSheet])
 
   const renderer = useSheetValue(rendererSheet)
+  const { framerate, bitrateMbps, bitrateMode, codec, waitForData, captureDelay } = renderer
 
-  const { framerate, bitrateMbps, bitrateMode, codec, resolution, lod, waitForData, captureDelay } =
-    renderer
+  // Get render settings from OutOp operator
+  const outOp = useOperatorStore(state => {
+    const ops = Array.from(state.operators.values())
+    return ops.find(op => (op.constructor as typeof Operator).displayName === 'Out')
+  })
+
+  // Extract render settings from OutOp inputs with inline defaults
+  const {
+    display: { value: display = 'fixed' } = {},
+    resolution: { value: resolution = { width: 1920, height: 1080 } } = {},
+    lod: { value: lod = 2 } = {},
+  } = outOp?.inputs ?? {}
 
   const { startCapture, captureFrame, currentFrame, isRendering } = useRenderer({
     project,
@@ -361,7 +364,7 @@ export default function TimelineEditor() {
   }
 
   // Use fixed resolution for 'fixed' display mode, undefined for 'responsive' mode to use natural dimensions
-  const isFixedMode = renderer.display === 'fixed'
+  const isFixedMode = display === 'fixed'
   const displayResolution = isFixedMode ? lodResolution : undefined
 
   if (!ready) {
@@ -375,7 +378,7 @@ export default function TimelineEditor() {
         <ReactMapGL style={displayResolution} {...mapProps}>
           <DeckGLOverlay
             ref={deckRef}
-            renderer={renderer}
+            rendererConfig={{ waitForData, captureDelay }}
             isRendering={isRendering}
             {...deckProps}
           />


### PR DESCRIPTION
## Summary

Moves render settings (resolution, display, and lod) from Theatre.js to OutOp inputs with migration.

## Changes

- Added display, resolution, and lod inputs to OutOp
- Removed these settings from Theatre.js INITIAL_RENDER_STATE
- Created migration 010 to move values from old projects
- Updated timeline-editor.tsx to read from OutOp via Zustand store
- Comprehensive test coverage for migration (7 tests, all passing)

## Benefits

- Settings are now more discoverable in the OutOp node UI
- Consistent with other operator-based settings
- Proper migration ensures backward compatibility