### PR TITLE
chore: Refactor deck.gl View operators to POJOs

### DIFF
--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -1,3 +1,4 @@
+import { MapView } from '@deck.gl/core'
 import { Temporal } from 'temporal-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import z from 'zod/v4'
@@ -26,6 +27,7 @@ import {
   UnknownField,
   Vec2Field,
   Vec3Field,
+  ViewField,
 } from './fields'
 import { NumberOp } from './operators'
 import { clearOps, setOp } from './store'
@@ -1137,6 +1139,30 @@ describe('LayerField', () => {
     const field = new LayerField()
     field.setValue({ type: 'TestLayer', id: 'layer-1' })
     expect(field.value).toEqual({ type: 'TestLayer', id: 'layer-1' })
+  })
+})
+
+describe('ViewField', () => {
+  it('accepts supported view descriptors', () => {
+    const field = new ViewField()
+    field.setValue({ type: 'MapView', id: 'map-view', width: '50%' })
+
+    expect(field.value).toEqual({ type: 'MapView', id: 'map-view', width: '50%' })
+  })
+
+  it('rejects unknown view types', () => {
+    const field = new ViewField()
+    field.setValue({ type: 'UnknownView' } as never)
+
+    expect(field.value).toBeUndefined()
+  })
+
+  it('accepts existing View instances from custom operators', () => {
+    const field = new ViewField()
+    const view = new MapView({ id: 'custom-map-view' })
+    field.setValue(view)
+
+    expect(field.value).toBe(view)
   })
 })
 

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -9,6 +9,7 @@ import { debugSetValue } from '../utils/debug'
 import type { BetterDeckProps, BetterMapProps } from '../visualizations'
 import type { inputComponents } from './components/field-components'
 import type { IOperator, Operator } from './operators'
+import type { DeckViewDescriptor, DeckViewValue } from './types'
 import { deepEqual } from './utils/deep-equal'
 import type { ExtractProps } from './utils/extract-props'
 import { resolvePath } from './utils/path-utils'
@@ -1549,14 +1550,26 @@ export class ExtensionField extends Field<z.ZodTypeAny> {
   }
 }
 
-export class ViewField extends Field<
-  z.ZodType<InstanceType<View>, z.ZodTypeDef, InstanceType<View>>
-> {
+const deckViewDescriptorSchema = z.looseObject({
+  type: z.enum(['MapView', 'GlobeView', 'FirstPersonView', 'OrbitView', 'OrthographicView']),
+}) as z.ZodType<DeckViewDescriptor>
+
+const deckViewSchema = z.union([
+  deckViewDescriptorSchema,
+  z.instanceof(View),
+]) as z.ZodType<DeckViewValue>
+
+export class ViewField extends Field<z.ZodType<DeckViewValue>> {
   static type = 'view'
   static defaultValue = undefined
   createSchema() {
-    return z.instanceof(View)
+    return deckViewSchema
   }
+}
+
+export type VisualizationDeckProps = Omit<BetterDeckProps, 'layers' | 'views'> & {
+  layers?: (LayerProps & { type: string })[]
+  views?: DeckViewValue[]
 }
 
 export class MapLibreLayerField extends Field<
@@ -1586,7 +1599,7 @@ export class MapLibreLayerField extends Field<
 
 export class VisualizationField extends Field<
   z.ZodType<{
-    deckProps: { layers: (LayerProps & { type: string })[] } & BetterDeckProps
+    deckProps: VisualizationDeckProps
     mapProps?: BetterMapProps
     maplibreLayers?: Array<{
       id: string
@@ -1610,6 +1623,7 @@ export class VisualizationField extends Field<
             })
           )
           .optional(),
+        views: z.array(deckViewSchema).optional(),
       }),
       mapProps: z
         .looseObject({

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -109,6 +109,7 @@ import {
 } from './store'
 import { transformGraph } from './transform-graph'
 import { canConnectCached } from './utils/can-connect'
+import { instantiateDeckView } from './utils/deck-view'
 import { directoryHandleCache } from './utils/directory-handle-cache'
 import {
   fileExists,
@@ -1773,7 +1774,7 @@ export function getNoodles(): Visualization {
         deckRendererOp ? 'DeckRendererOp.outputs.vis' : 'OutOp.inputs.vis'
       )
       const visSub = field.subscribe(
-        ({ deckProps: { layers, widgets, ...deckProps }, mapProps }) => {
+        ({ deckProps: { layers, widgets, views, ...deckProps }, mapProps }) => {
           // Map layers from POJOs to deck.gl instances
           const instantiatedLayers =
             layers?.map(({ type, extensions, ...layer }) => {
@@ -1834,6 +1835,8 @@ export function getNoodles(): Visualization {
             instantiatedLayers.push(overlayLayer)
           }
 
+          const instantiatedViews = views?.map(instantiateDeckView)
+
           debugVis(
             'vis subscription fired: %d layers types=%O hasMapProps=%s',
             instantiatedLayers.length,
@@ -1853,6 +1856,7 @@ export function getNoodles(): Visualization {
                 // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl widget types dynamically
                 return new deckWidgets[type](widget)
               }),
+              ...(instantiatedViews?.length ? { views: instantiatedViews } : {}),
             },
             mapProps,
           })

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -23,12 +23,14 @@ import {
   FillStyleExtensionOp,
   FileOp,
   FilterOp,
+  FirstPersonViewOp,
   FpsWidgetOp,
   FullscreenWidgetOp,
   GeohashLayerOp,
   GeocoderOp,
   GeoJsonLayerOp,
   GeoJsonTransformOp,
+  GlobeViewOp,
   GreatCircleLayerOp,
   H3ClusterLayerOp,
   JSONOp,
@@ -43,6 +45,8 @@ import {
   NetworkOp,
   NumberOp,
   Operator,
+  OrbitViewOp,
+  OrthographicViewOp,
   OverpassOp,
   PointOp,
   PointCloudLayerOp,
@@ -1088,7 +1092,7 @@ describe('deck.gl 9.4 properties', () => {
     const operator = new MapViewOp('/map-0')
     const { view } = operator.execute({ parameters: { depthTest: false } })
 
-    expect(view.props.parameters).toEqual({ depthTest: false })
+    expect(view.parameters).toEqual({ depthTest: false })
   })
 
   it('configures the zoom widget step', () => {
@@ -1102,6 +1106,10 @@ describe('deck.gl 9.4 properties', () => {
 describe('DeckRendererOp', () => {
   it('returns views if provided', () => {
     const operator = new DeckRendererOp('/deck-0')
+    const viewDescriptors = [
+      { type: 'MapView' as const, id: 'map-view' },
+      { type: 'OrbitView' as const, id: 'orbit-view' },
+    ]
     const {
       vis: {
         deckProps: { views },
@@ -1109,14 +1117,33 @@ describe('DeckRendererOp', () => {
     } = operator.execute({
       layers: [],
       effects: [],
-      views: ['view1', 'view2'],
+      views: viewDescriptors,
       layerFilter: () => true,
     })
-    expect(views).toEqual(['view1', 'view2'])
+    expect(views).toEqual(viewDescriptors)
     const {
       vis: { deckProps },
     } = operator.execute({})
     expect(deckProps.views).not.toBeDefined()
+  })
+
+  it('accepts connected view operator descriptors', async () => {
+    const viewOperator = new MapViewOp('/map-view')
+    const renderer = new DeckRendererOp('/deck-0')
+    renderer.inputs.views.addConnection('view-edge', viewOperator.outputs.view)
+
+    await viewOperator.pull()
+
+    expect(renderer.inputs.views.value).toEqual([
+      expect.objectContaining({ type: 'MapView', id: '/map-view' }),
+    ])
+    await expect(renderer.pull()).resolves.toMatchObject({
+      vis: {
+        deckProps: {
+          views: [expect.objectContaining({ type: 'MapView', id: '/map-view' })],
+        },
+      },
+    })
   })
 
   it('returns undefined mapProps when basemap is null', () => {
@@ -1344,7 +1371,21 @@ describe('MapViewOp', () => {
     const { view } = operator.execute({
       clearColor: [127.5, 0, 127.5, 255],
     })
-    expect(view.props.clearColor).toEqual([127.5, 0, 127.5, 255])
+    expect(view.clearColor).toEqual([127.5, 0, 127.5, 255])
+  })
+
+  it.each([
+    [MapViewOp, 'MapView'],
+    [GlobeViewOp, 'GlobeView'],
+    [FirstPersonViewOp, 'FirstPersonView'],
+    [OrbitViewOp, 'OrbitView'],
+    [OrthographicViewOp, 'OrthographicView'],
+  ] as const)('%s returns a serializable %s descriptor', (ViewOperator, type) => {
+    const operator = new ViewOperator('/view-0')
+    const { view } = operator.execute({})
+
+    expect(view).toMatchObject({ type, id: '/view-0' })
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view)
   })
 })
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -6,17 +6,7 @@ import type {
   HexagonLayerProps,
   ScreenGridLayerProps,
 } from '@deck.gl/aggregation-layers'
-import {
-  type DeckProps,
-  FirstPersonView,
-  _GlobeView as GlobeView,
-  type LayerExtension,
-  type LayerProps,
-  MapView,
-  OrbitView,
-  OrthographicView,
-  WebMercatorViewport,
-} from '@deck.gl/core'
+import { type LayerExtension, type LayerProps, WebMercatorViewport } from '@deck.gl/core'
 import {
   BrushingExtension,
   ClipExtension,
@@ -146,6 +136,7 @@ import {
   Vec2Field,
   Vec3Field,
   ViewField,
+  type VisualizationDeckProps,
   VisualizationField,
   WidgetField,
 } from './fields'
@@ -4124,7 +4115,7 @@ export class DeckRendererOp extends Operator<DeckRendererOp> {
       : {}
     if (basemap) validateViewState(basemapViewState)
 
-    const deckProps: DeckProps & { layers: (LayerProps & { type: string })[] } = {
+    const deckProps: VisualizationDeckProps = {
       layers,
       effects,
       ...(views?.length > 0 ? { views } : {}),
@@ -4235,7 +4226,7 @@ export class MapViewOp extends Operator<MapViewOp> {
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     validateViewState(viewState)
     return {
-      view: new MapView({ id: this.id, ...props, viewState: { ...viewState, maxPitch: 90 } }),
+      view: { type: 'MapView', id: this.id, ...props, viewState: { ...viewState, maxPitch: 90 } },
     }
   }
 }
@@ -4444,7 +4435,7 @@ export class GlobeViewOp extends Operator<GlobeViewOp> {
 
   execute(props: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     validateViewState(props.viewState)
-    return { view: new GlobeView({ id: this.id, ...props }) }
+    return { view: { type: 'GlobeView', id: this.id, ...props } }
   }
 }
 
@@ -4816,7 +4807,7 @@ export class FirstPersonViewOp extends Operator<FirstPersonViewOp> {
 
   execute(props: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     validateViewState(props.viewState)
-    return { view: new FirstPersonView({ id: this.id, ...props }) }
+    return { view: { type: 'FirstPersonView', id: this.id, ...props } }
   }
 }
 
@@ -4851,7 +4842,7 @@ export class OrbitViewOp extends Operator<OrbitViewOp> {
 
   execute(props: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     validateViewState(props.viewState)
-    return { view: new OrbitView({ id: this.id, ...props }) }
+    return { view: { type: 'OrbitView', id: this.id, ...props } }
   }
 }
 
@@ -4879,7 +4870,7 @@ export class OrthographicViewOp extends Operator<OrthographicViewOp> {
 
   execute(props: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     validateViewState(props.viewState)
-    return { view: new OrthographicView({ id: this.id, ...props }) }
+    return { view: { type: 'OrthographicView', id: this.id, ...props } }
   }
 }
 

--- a/noodles-editor/src/noodles/types.ts
+++ b/noodles-editor/src/noodles/types.ts
@@ -1,3 +1,4 @@
+import type { View } from '@deck.gl/core'
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import type { RefObject } from 'react'
 
@@ -12,6 +13,25 @@ export type GraphRef = RefObject<{ nodes: ReactFlowNode[]; edges: ReactFlowEdge[
 // Valid values for Deck.gl layer properties
 // Represents the common types that can be passed as layer props
 export type LayerPropsValue = string | number | boolean | unknown[] | Record<string, unknown> | null
+
+export type DeckViewType =
+  | 'MapView'
+  | 'GlobeView'
+  | 'FirstPersonView'
+  | 'OrbitView'
+  | 'OrthographicView'
+
+// Serializable description of a deck.gl View. View operators produce these values;
+// the renderer turns them into class instances at the deck.gl boundary.
+export type DeckViewDescriptor = {
+  type: DeckViewType
+  id?: string
+  [key: string]: unknown
+}
+
+// Keep accepting class instances produced by custom CodeOps while built-in view
+// operators migrate to descriptors.
+export type DeckViewValue = DeckViewDescriptor | View
 
 // Constructor arguments for Deck.gl layer extensions
 // Keep flexible as different extensions accept different arguments

--- a/noodles-editor/src/noodles/utils/deck-view.test.ts
+++ b/noodles-editor/src/noodles/utils/deck-view.test.ts
@@ -1,0 +1,33 @@
+import {
+  FirstPersonView,
+  _GlobeView as GlobeView,
+  MapView,
+  OrbitView,
+  OrthographicView,
+} from '@deck.gl/core'
+import { describe, expect, it } from 'vitest'
+import type { DeckViewDescriptor } from '../types'
+import { instantiateDeckView } from './deck-view'
+
+describe('instantiateDeckView', () => {
+  it.each([
+    ['MapView', MapView],
+    ['GlobeView', GlobeView],
+    ['FirstPersonView', FirstPersonView],
+    ['OrbitView', OrbitView],
+    ['OrthographicView', OrthographicView],
+  ] as const)('instantiates a %s descriptor', (type, ViewClass) => {
+    const descriptor: DeckViewDescriptor = { type, id: 'test-view', width: '50%' }
+    const view = instantiateDeckView(descriptor)
+
+    expect(view).toBeInstanceOf(ViewClass)
+    expect(view.props).toMatchObject({ id: 'test-view', width: '50%' })
+    expect(view.props).not.toHaveProperty('type')
+  })
+
+  it('preserves existing View instances from custom operators', () => {
+    const existingView = new MapView({ id: 'custom-map-view' })
+
+    expect(instantiateDeckView(existingView)).toBe(existingView)
+  })
+})

--- a/noodles-editor/src/noodles/utils/deck-view.ts
+++ b/noodles-editor/src/noodles/utils/deck-view.ts
@@ -1,0 +1,32 @@
+import {
+  FirstPersonView,
+  type FirstPersonViewProps,
+  _GlobeView as GlobeView,
+  type GlobeViewProps,
+  MapView,
+  type MapViewProps,
+  OrbitView,
+  type OrbitViewProps,
+  OrthographicView,
+  type OrthographicViewProps,
+  View,
+} from '@deck.gl/core'
+import type { DeckViewValue } from '../types'
+
+export function instantiateDeckView(view: DeckViewValue): View {
+  if (view instanceof View) return view
+
+  const { type, ...props } = view
+  switch (type) {
+    case 'MapView':
+      return new MapView(props as MapViewProps)
+    case 'GlobeView':
+      return new GlobeView(props as GlobeViewProps)
+    case 'FirstPersonView':
+      return new FirstPersonView(props as FirstPersonViewProps)
+    case 'OrbitView':
+      return new OrbitView(props as OrbitViewProps)
+    case 'OrthographicView':
+      return new OrthographicView(props as OrthographicViewProps)
+  }
+}


### PR DESCRIPTION
## Summary

Refactors the built-in deck.gl View operators to return serializable descriptors instead of constructing View class instances. View instances are now created at the rendering boundary, matching the existing Layer operator architecture.

## Changes

- MapViewOp, GlobeViewOp, FirstPersonViewOp, OrbitViewOp, and OrthographicViewOp return typed POJO descriptors
- ViewField validates supported descriptors
- DeckRendererOp carries descriptors until the visualization render boundary
- A centralized adapter constructs the corresponding deck.gl View class
- GlobeView descriptors correctly map to the experimental _GlobeView export
- Existing View instances from custom CodeOps remain supported for backwards compatibility
- Added field, connection, serialization, and constructor coverage for all five View types

## Why this replaces the original patch

The original implementation left ViewField restricted to View instances, which caused connected POJO descriptors to be rejected. It also attempted a dynamic GlobeView lookup even though deck.gl exports that class as _GlobeView. This revision fixes both issues and is rebased onto the latest main branch.

## Verification

- Focused suite: 485 tests passed
- Full suite: 3,088 tests passed, 10 skipped
- Lint and formatting passed
- Production build passed
- All example projects validated