### PR TITLE
Add Joby color palette to categorical color ramp

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -1205,6 +1205,19 @@ export class HSLOp extends Operator<HSLOp> {
   }
 }
 
+const JOBY_COLORS = [
+  '#FFB300', // Joby Yellow
+  '#EB6110', // Joby Orange
+  '#E64839', // Joby Red
+  '#00994C', // Joby Green
+  '#883DF2', // Joby Purple
+  '#7CC3FF', // Joby Light Blue
+  '#3EC26A', // Joby Light Green
+  '#FF9058', // Joby Light Orange
+  '#FFCC54', // Joby Light Yellow
+  '#B580FF', // Joby Light Purple
+]
+
 export class ColorRampOp extends Operator<ColorRampOp> {
   static displayName = 'ColorRamp'
   static description = 'Interpolate a color from a color ramp, value range 0-1'
@@ -1234,18 +1247,7 @@ export class ColorRampOp extends Operator<ColorRampOp> {
       oranges: interpolateOranges,
       purples: interpolatePurples,
 
-      joby: d3.interpolateRgbBasis([
-        '#FFB300', // Joby Yellow
-        '#EB6110', // Joby Orange
-        '#E64839', // Joby Red
-        '#00994C', // Joby Green
-        '#883DF2', // Joby Purple
-        '#7CC3FF', // Joby Light Blue
-        '#3EC26A', // Joby Light Green
-        '#FF9058', // Joby Light Orange
-        '#FFCC54', // Joby Light Yellow
-        '#B580FF', // Joby Light Purple
-      ]),
+      joby: d3.interpolateRgbBasis(JOBY_COLORS),
 
       PinkYellowGreen: interpolatePiYG,
       PurpleOrange: interpolatePuOr,
@@ -1313,18 +1315,7 @@ export class CategoricalColorRampOp extends Operator<CategoricalColorRampOp> {
       set2: schemeSet2,
       set3: schemeSet3,
       tableau10: schemeTableau10,
-      joby: [
-        '#FFB300', // Joby Yellow
-        '#EB6110', // Joby Orange
-        '#E64839', // Joby Red
-        '#00994C', // Joby Green
-        '#883DF2', // Joby Purple
-        '#7CC3FF', // Joby Light Blue
-        '#3EC26A', // Joby Light Green
-        '#FF9058', // Joby Light Orange
-        '#FFCC54', // Joby Light Yellow
-        '#B580FF', // Joby Light Purple
-      ],
+      joby: JOBY_COLORS,
 
       // These schemes are arrays of arrays, ordered by number of stops. In the future we should
       // allow the user to select the number of stops


### PR DESCRIPTION
## Summary

Adds Joby brand colors as a new palette option in both color ramp operators.

## Changes

- Added 'joby' palette to **CategoricalColorRampOp** (discrete colors) with 10 Joby brand colors
- Added 'joby' palette to **ColorRampOp** (continuous gradient) using `d3.interpolateRgbBasis()` for smooth interpolation

### Joby Colors
- Primary colors: Yellow, Orange, Red, Green, Purple
- Light variations: Light Blue, Light Green, Light Orange, Light Yellow, Light Purple

## Usage

- **Continuous gradient**: Select "joby" from the colorScheme dropdown in ColorRampOp
- **Categorical/discrete**: Select "joby" from the colorScheme dropdown in CategoricalColorRampOp

## Screenshot

<img width="754" height="348" alt="Screenshot 2026-01-04 at 9 15 58 PM" src="https://github.com/user-attachments/assets/0c0a97f6-6dc5-42c8-aff7-794c11df5d11" />
<img width="612" height="335" alt="Screenshot 2026-01-21 at 10 34 23 AM" src="https://github.com/user-attachments/assets/ab4604bf-7c04-4441-ac31-737414ff68f8" />
