### PR TITLE
fix: GlobeView text rendering with cullMode parameter

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3305,7 +3305,7 @@ export class TextLayerOp extends Operator<TextLayerOp> {
       }),
       extensions: new ListField(new ExtensionField()),
       parameters: new CompoundPropsField({
-        cullMode: new StringLiteralField('back', {
+        cullMode: new StringLiteralField('none', {
           values: ['none', 'back', 'front'],
         }),
       }),
@@ -3612,7 +3612,7 @@ export class GeoJsonLayerOp extends Operator<GeoJsonLayerOp> {
       _full3d: new BooleanField(false),
       extensions: new ListField(new ExtensionField()),
       parameters: new CompoundPropsField({
-        cullMode: new StringLiteralField('back', {
+        cullMode: new StringLiteralField('none', {
           values: ['none', 'back', 'front'],
         }),
       }),


### PR DESCRIPTION
## Problem

Text rendering in `GlobeView` is not visible from any angle due to triangle culling (https://github.com/visgl/deck.gl/issues/9777). The default culling mode for GlobeView (`'back'`) causes text to be culled and invisible.

## Solution

Add `parameters.cullMode` to TextLayerOp and GeoJsonLayerOp with options:
- `'back'`: Back-face culling
- `'front'`: Front-face culling
- `'none'`: Disable culling - fixes GlobeView text rendering, and is the default for none-GlobeView.
  - See https://luma.gl/docs/api-reference/core/parameters#assembly-culling

Long term, we'll need to solve these issues in deck but the root cause needs to be found, and solution approaches discussed.

## Changes

- Added `parameters` CompoundPropsField to TextLayerOp
- Added `parameters` CompoundPropsField to GeoJsonLayerOp
- Each contains `cullMode` StringLiteralField with three options

## Testing

1. Create a TextLayer or GeoJsonLayer with text in GlobeView
2. Observe that text is not visible with default settings
3. Set `parameters.cullMode` to `'none'` to make text visible
4. Verify default (`'none'`) behavior is preserved for non-GlobeView use cases

## References

- https://github.com/visgl/deck.gl/issues/9777
