### PR TITLE
Add font settings to TextLayer to fix text blurriness

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3291,7 +3291,7 @@ export class TextLayerOp extends Operator<TextLayerOp> {
       fontFamily: new StringField('Inter'),
       fontWeight: new NumberField(400, { min: 100, max: 900, step: 100 }),
       sizeUnits: new StringLiteralField('pixels', ['pixels', 'meters']),
-      getSize: new NumberField(48, { min: 0, max: 100, accessor: true }),
+      getSize: new NumberField(48, { min: 0, accessor: true }),
       getColor: new ColorField('#f0f0f0', { accessor: true, transform: hexToColor }),
       getAngle: new NumberField(0, { min: 0, max: 360, accessor: true }),
       getTextAnchor: new StringLiteralField('middle', {
@@ -3302,6 +3302,14 @@ export class TextLayerOp extends Operator<TextLayerOp> {
       getAlignmentBaseline: new StringLiteralField('center', {
         values: ['top', 'center', 'bottom'],
         accessor: true,
+      }),
+      fontSettings: new CompoundPropsField({
+        sdf: new BooleanField(false),
+        fontSize: new NumberField(64, { min: 8, max: 256 }),
+        buffer: new NumberField(4, { min: 0, max: 20 }),
+        radius: new NumberField(12, { min: 0, max: 50 }),
+        cutoff: new NumberField(0.25, { min: 0, max: 1, step: 0.01 }),
+        smoothing: new NumberField(0.1, { min: 0, max: 1, step: 0.01 }),
       }),
       extensions: new ListField(new ExtensionField()),
     }


### PR DESCRIPTION
## Summary

Adds font settings to TextLayerOp to fix text blurriness at large sizes, and removes the max limit on text size.

## Problem

Text can appear blurry at large sizes due to the default font atlas resolution.

<img width="898" height="352" alt="Screenshot 2026-01-04 at 9 11 38 PM" src="https://github.com/user-attachments/assets/776eb4c6-9052-4dc8-b15f-bb4bd8a00ccd" />

## Solution

Add `fontSettings` CompoundPropsField to expose deck.gl's SDF font configuration options:
  - `sdf`: Enable/disable SDF rendering (default: false)
  - `fontSize`: Font atlas resolution (8-256, default: 64) - **increasing this value fixes text blurriness**
<img width="955" height="332" alt="Screenshot 2026-01-04 at 9 11 45 PM" src="https://github.com/user-attachments/assets/c2f17c1b-5a87-4039-bfd9-79e6539bf251" />

  - `buffer`: SDF buffer size around glyphs (0-20, default: 4)
  - `radius`: SDF search radius (0-50, default: 12)
  - `cutoff`: SDF cutoff threshold (0-1, default: 0.25)
  - `smoothing`: SDF edge smoothing (0-1, default: 0.1)

Also removed `max: 100` limit from `getSize` field to allow larger text rendering.

## Benefits

- Fixes text blurriness at large sizes by increasing `fontSettings.fontSize`
- Exposes deck.gl's SDF font configuration for users who want to enable it
- No size limit on text allows for large-scale visualizations

## Testing

1. Create a TextLayer with large text (>100 pixels)
2. If text appears blurry, increase `fontSettings.fontSize` (e.g., to 128 or 256) to fix it
3. Optionally enable `fontSettings.sdf` and adjust other parameters for SDF rendering
