### PR TITLE
Add MergeOpsOp operator

### DIFF
--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -31,6 +31,7 @@ export const categories = {
     'Filter',
     'Geocoder',
     'Merge',
+    'MergeOps',
     'Network',
     'Out',
     'RandomizeAttribute',

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -179,12 +179,12 @@ import {
   WidgetField,
 } from './fields'
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE, safeMode } from './globals'
-import { getAllOps, getOp, hasOp } from './store'
+import { getAllOps, getEdgeStore, getOp, hasOp } from './store'
 import { composeAccessor, isAccessor } from './utils/accessor-helpers'
 import type { ExtractProps } from './utils/extract-props'
 import { projectScheme } from './utils/filesystem'
 import type { OpId } from './utils/id-utils'
-import { isDirectChild } from './utils/path-utils'
+import { getBaseName, isDirectChild } from './utils/path-utils'
 import { pick } from './utils/pick'
 import { validateViewState } from './utils/viewstate-helpers'
 
@@ -2347,6 +2347,63 @@ export class MergeOp extends Operator<MergeOp> {
 
     // Static evaluation
     const object = Object.assign({}, ...objects)
+    return { object }
+  }
+}
+
+export class MergeOpsOp extends Operator<MergeOpsOp> {
+  static displayName = 'MergeOps'
+  static description =
+    'Collect values from connected operators into an object {[opId]: value}. Connect multiple operators to the values list.'
+  createInputs() {
+    return {
+      values: new ListField(new DataField()),
+    }
+  }
+  createOutputs() {
+    return {
+      object: new DataField(),
+    }
+  }
+  execute({ values }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    const edges = getEdgeStore().edges
+
+    // Find all edges targeting this operator's values list
+    // ListField edges all have the same targetHandle (e.g., "par.values"), not indexed
+    const targetEdges = edges.filter(
+      edge =>
+        edge.target === this.id &&
+        (edge.targetHandle === 'par.values' || edge.targetHandle?.startsWith('par.values.'))
+    )
+
+    // Check if any values are accessor functions
+    const hasAccessors = values.some(isAccessor)
+
+    if (hasAccessors) {
+      // Return an accessor function
+      const result = (...args: unknown[]) => {
+        const obj: Record<string, unknown> = {}
+        for (let i = 0; i < values.length; i++) {
+          const value = isAccessor(values[i]) ? values[i](...args) : values[i]
+          // Match edge to value by index in the filtered edges array
+          const edge = targetEdges[i]
+          const key = edge?.source ? getBaseName(edge.source) : `value_${i}`
+          obj[key] = value
+        }
+        return obj
+      }
+      return { object: result }
+    }
+
+    // Static evaluation
+    const object: Record<string, unknown> = {}
+    for (let i = 0; i < values.length; i++) {
+      // Match edge to value by index in the filtered edges array
+      const edge = targetEdges[i]
+      const key = edge?.source ? getBaseName(edge.source) : `value_${i}`
+      object[key] = values[i]
+    }
+
     return { object }
   }
 }
@@ -5414,6 +5471,7 @@ export const opTypes = {
   MaskExtensionOp,
   MathOp,
   MergeOp,
+  MergeOpsOp,
   MouseOp,
   MVTLayerOp,
   NetworkOp,


### PR DESCRIPTION
## Summary

Adds MergeOpsOp operator that collects values from connected operators into an object with operator names as keys.

<img width="2193" height="1069" alt="Screenshot 2026-01-04 at 4 58 01 PM" src="https://github.com/user-attachments/assets/f5c0795e-2779-4c6a-8b38-561b5dc3e085" />

[merge-ops.zip](https://github.com/user-attachments/files/24426976/merge-ops.zip)

## Motivation

When working with multiple related operators (e.g., different data sources, multiple computed values), it's useful to collect them into a single object structure. This operator automatically uses operator names as keys, making the resulting object more semantic than array indices.

## Changes

- Added `MergeOpsOp` operator class with ListField input
- Uses edge store to auto-detect connected operator IDs
- Extracts base names from operator paths (e.g., `/data/loader` → `loader`)
- Supports both static values and accessor functions
- Added to data category in operator menu
- Added necessary imports (`getEdgeStore`, `getBaseName`)

## Usage Example

Connect multiple operators to the `values` list input. MergeOpsOp will output an object like:

```javascript
{
  "temperature": 72,
  "humidity": 65,
  "pressure": 1013
}
```

Where keys come from the connected operator names.

## Dependencies

This PR is based on #198 (Theatre.js fix) which adds the edge store functionality.

## Testing

1. Create several operators (e.g., NumberOp instances named "temperature", "humidity", "pressure")
2. Create a MergeOpsOp
3. Connect the operators to MergeOpsOp's values list
4. Verify output object uses operator names as keys
5. Test with accessor functions to ensure accessor mode works correctly
