### PR TITLE
Add multiline textarea support to StringField

### DIFF
--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -24,6 +24,7 @@ import {
   type NumberField,
   Point2DField,
   Point3DField,
+  StringField,
   StringLiteralField,
   Vec2Field,
   Vec3Field,
@@ -105,6 +106,18 @@ export function TextFieldComponent({
   disabled: boolean
 }) {
   const [value, setValue] = useState(formatText(field.value))
+  const { getNode } = useReactFlow()
+  const nodeId = useNodeId() as string
+  const node = getNode(nodeId)
+  const [nodeHeight, setNodeHeight] = useState(node?.height || 100)
+
+  // Track node height changes
+  useEffect(() => {
+    const currentNode = getNode(nodeId)
+    if (currentNode?.height !== nodeHeight) {
+      setNodeHeight(currentNode?.height || 100)
+    }
+  }, [node?.height, nodeId, getNode, nodeHeight])
 
   useEffect(() => {
     const sub = field.subscribe(newVal => {
@@ -139,6 +152,22 @@ export function TextFieldComponent({
           </option>
         ))}
       </select>
+    )
+  } else if (field instanceof StringField && (field.multiline || value.includes('\n'))) {
+    // Calculate height based on node height, accounting for header and padding
+    const textareaHeight = Math.max(60, nodeHeight - 40) // Reserve space for header
+
+    input = (
+      <textarea
+        id={id}
+        className={cx(s.fieldInput, s.fieldTextarea)}
+        title={value}
+        value={value}
+        onBlur={onChange}
+        onChange={onChange}
+        disabled={disabled}
+        style={{ height: `${textareaHeight}px` }}
+      />
     )
   } else {
     input = (

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -135,6 +135,7 @@ export const resizeableNodes = [
   'CodeOp',
   'DuckDbOp',
   'JSONOp',
+  'StringOp',
 ] as const
 
 function toPascal(str: string) {

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -235,8 +235,13 @@ export abstract class Field<
 export class StringField extends Field<z.ZodString> {
   static type = 'string'
   static defaultValue = ''
+  multiline?: boolean
   createSchema() {
     return z.string()
+  }
+  constructor(defaultValue = '', options?: BaseFieldOptions & { multiline?: boolean }) {
+    super(defaultValue, options)
+    this.multiline = options?.multiline
   }
 }
 

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -438,6 +438,16 @@
   background: var(--node-input-disaabled-color);
 }
 
+.fieldTextarea {
+  text-align: left;
+  resize: vertical;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1.4;
+  padding: 4px 6px;
+  min-height: 60px;
+}
+
 .fieldInputGroup {
   gap: 8px;
 }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -665,7 +665,7 @@ export class StringOp extends Operator<StringOp> {
   static description = 'A string'
   createInputs() {
     return {
-      val: new StringField(''),
+      val: new StringField('', { multiline: true }),
     }
   }
   createOutputs() {


### PR DESCRIPTION
## Summary

Adds multiline textarea support to StringField and makes StringOp resizable for better multi-line string editing.

Before:
<img width="1987" height="508" alt="Screenshot 2026-01-04 at 4 58 01 PM" src="https://github.com/user-attachments/assets/50194d81-ecbd-4274-b09c-4aaab1a65964" />

After:

<img width="2078" height="343" alt="Screenshot 2026-01-04 at 9 05 23 PM" src="https://github.com/user-attachments/assets/5e953753-59d5-4ca8-b301-ab50f6e1f497" />

## Changes

### StringField (fields.ts)
- Added `multiline` option to constructor
- Automatically uses textarea for fields with multiline=true or values containing newlines

### Field Rendering (field-components.tsx)
- Render textarea instead of input for multiline strings
- Track node height to dynamically resize textarea
- Auto-size textarea to fill node (nodeHeight - 40px for header)

### StringOp Node (op-components.tsx)
- Added to `resizeableNodes` array
- Minimum height: 100px
- Allows users to resize node for comfortable multiline editing

### Styles (noodles.module.css)
- Added `fieldTextarea` styles
- No scrollbar, auto-resizing height
- Consistent with input field styling

### StringOp Default (operators.ts)
- Enabled `multiline: true` by default for StringOp

## Benefits

- Better UX for editing long strings or multi-line content
- Resizable node adapts to content needs
- Automatic detection of newlines triggers textarea mode
- Clean, native textarea experience

## Testing

1. Create a StringOp node
2. Resize the node vertically
3. Enter multi-line text and verify textarea expands
4. Verify existing single-line strings still work
5. Test with fields that have `multiline: true` option
