### PR TITLE
Update ReactFlow API: convert parentNode to parentId

### DIFF
--- a/noodles-editor/src/noodles/__migrations__/005-qualified-paths.test.ts
+++ b/noodles-editor/src/noodles/__migrations__/005-qualified-paths.test.ts
@@ -320,6 +320,38 @@ describe('migration 005 up', () => {
     expect(migrated.edges[0].sourceHandle).toBe('par.val')
     expect(migrated.edges[0].targetHandle).toBe(null)
   })
+
+  it('converts deprecated parentNode to parentId (ReactFlow v11 to v12 migration)', async () => {
+    // Old ReactFlow v11 format used parentNode, v12+ uses parentId
+    const project = {
+      version: 4,
+      nodes: [
+        {
+          id: 'group1',
+          type: 'group',
+          position: { x: 0, y: 0 },
+          data: { inputs: {} },
+        },
+        {
+          id: 'child1',
+          type: 'CodeOp',
+          position: { x: 10, y: 10 },
+          data: { inputs: {} },
+          parentNode: 'group1', // Old v11 format
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {},
+    } as NoodlesProjectJSON
+
+    const migrated = await up(project)
+
+    // Should convert parentNode to parentId
+    expect(migrated.nodes[1].parentId).toBe('/group1')
+    // Should not have the old parentNode property
+    expect((migrated.nodes[1] as any).parentNode).toBeUndefined()
+  })
 })
 
 describe('migration 005 down', () => {

--- a/noodles-editor/src/noodles/__migrations__/005-qualified-paths.ts
+++ b/noodles-editor/src/noodles/__migrations__/005-qualified-paths.ts
@@ -95,12 +95,15 @@ export async function up(project: NoodlesProjectJSON): Promise<NoodlesProjectJSO
       return node
     }
 
-    let parentId = node.parentId
+    // Support both parentId (v12+) and parentNode (v11) for backwards compatibility
+    let parentId = node.parentId || (node as any).parentNode
     if (parentId) {
       parentId = idMapping.get(parentId) || parentId
     }
 
     delete node.containerId
+    // Remove deprecated parentNode property if present
+    delete (node as any).parentNode
 
     return {
       ...node,

--- a/noodles-editor/src/noodles/__migrations__/010-parent-node-to-parent-id.test.ts
+++ b/noodles-editor/src/noodles/__migrations__/010-parent-node-to-parent-id.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest'
+import type { NoodlesProjectJSON } from '../utils/serialization'
+import { down, up } from './010-parent-node-to-parent-id'
+
+describe('migration 010 up', () => {
+  it('converts parentNode to parentId for ForLoop nodes', async () => {
+    // ForLoop creates a group node with ForLoopBeginOp and ForLoopEndOp as children
+    const project = {
+      version: 9,
+      nodes: [
+        {
+          id: '/for-loop-body-1',
+          type: 'group',
+          position: { x: 0, y: 0 },
+          style: { width: 1200, height: 300 },
+        },
+        {
+          id: '/for-loop-begin-1',
+          type: 'ForLoopBeginOp',
+          position: { x: 0, y: 100 },
+          data: { inputs: {} },
+          parentNode: '/for-loop-body-1', // Old v11 format
+          expandParent: true,
+        },
+        {
+          id: '/for-loop-end-1',
+          type: 'ForLoopEndOp',
+          position: { x: 900, y: 100 },
+          data: { inputs: {} },
+          parentNode: '/for-loop-body-1', // Old v11 format
+          expandParent: true,
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {},
+    } as NoodlesProjectJSON
+
+    const migrated = await up(project)
+
+    // Should have parentId instead of parentNode
+    expect(migrated.nodes[1].parentId).toBe('/for-loop-body-1')
+    expect(migrated.nodes[2].parentId).toBe('/for-loop-body-1')
+    expect((migrated.nodes[1] as any).parentNode).toBeUndefined()
+    expect((migrated.nodes[2] as any).parentNode).toBeUndefined()
+  })
+
+  it('preserves existing parentId over parentNode', async () => {
+    const project = {
+      version: 9,
+      nodes: [
+        {
+          id: '/for-loop-body-1',
+          type: 'group',
+          position: { x: 0, y: 0 },
+          style: { width: 1200, height: 300 },
+        },
+        {
+          id: '/for-loop-begin-1',
+          type: 'ForLoopBeginOp',
+          position: { x: 0, y: 100 },
+          data: { inputs: {} },
+          parentId: '/for-loop-body-1',
+          parentNode: '/wrong-parent', // Should be ignored since parentId exists
+          expandParent: true,
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {},
+    } as NoodlesProjectJSON
+
+    const migrated = await up(project)
+
+    // Should keep existing parentId
+    expect(migrated.nodes[1].parentId).toBe('/for-loop-body-1')
+    expect((migrated.nodes[1] as any).parentNode).toBeUndefined()
+  })
+
+  it('leaves nodes without parentNode unchanged', async () => {
+    const project = {
+      version: 9,
+      nodes: [
+        {
+          id: '/standalone',
+          type: 'CodeOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: {} },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {},
+    } as NoodlesProjectJSON
+
+    const migrated = await up(project)
+
+    expect(migrated.nodes[0].parentId).toBeUndefined()
+    expect((migrated.nodes[0] as any).parentNode).toBeUndefined()
+  })
+
+  it('handles multiple nested children', async () => {
+    const project = {
+      version: 9,
+      nodes: [
+        {
+          id: '/container',
+          type: 'ContainerOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: {} },
+        },
+        {
+          id: '/container/child1',
+          type: 'CodeOp',
+          position: { x: 10, y: 10 },
+          data: { inputs: {} },
+          parentNode: '/container',
+        },
+        {
+          id: '/container/child2',
+          type: 'NumberOp',
+          position: { x: 20, y: 20 },
+          data: { inputs: {} },
+          parentNode: '/container',
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {},
+    } as NoodlesProjectJSON
+
+    const migrated = await up(project)
+
+    expect(migrated.nodes[0].parentId).toBeUndefined()
+    expect(migrated.nodes[1].parentId).toBe('/container')
+    expect(migrated.nodes[2].parentId).toBe('/container')
+    expect((migrated.nodes[1] as any).parentNode).toBeUndefined()
+    expect((migrated.nodes[2] as any).parentNode).toBeUndefined()
+  })
+})
+
+describe('migration 010 down', () => {
+  it('converts parentId back to parentNode', async () => {
+    const project = {
+      version: 10,
+      nodes: [
+        {
+          id: '/for-loop-body-1',
+          type: 'group',
+          position: { x: 0, y: 0 },
+          style: { width: 1200, height: 300 },
+        },
+        {
+          id: '/for-loop-begin-1',
+          type: 'ForLoopBeginOp',
+          position: { x: 0, y: 100 },
+          data: { inputs: {} },
+          parentId: '/for-loop-body-1',
+          expandParent: true,
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {},
+    } as NoodlesProjectJSON
+
+    const reverted = await down(project)
+
+    // Should have parentNode instead of parentId
+    expect((reverted.nodes[1] as any).parentNode).toBe('/for-loop-body-1')
+    expect(reverted.nodes[1].parentId).toBeUndefined()
+  })
+
+  it('leaves nodes without parentId unchanged', async () => {
+    const project = {
+      version: 10,
+      nodes: [
+        {
+          id: '/standalone',
+          type: 'CodeOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: {} },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {},
+    } as NoodlesProjectJSON
+
+    const reverted = await down(project)
+
+    expect(reverted.nodes[0].parentId).toBeUndefined()
+    expect((reverted.nodes[0] as any).parentNode).toBeUndefined()
+  })
+
+  it('is reversible with up migration', async () => {
+    const originalProject = {
+      version: 9,
+      nodes: [
+        {
+          id: '/for-loop-body-1',
+          type: 'group',
+          position: { x: 0, y: 0 },
+          style: { width: 1200, height: 300 },
+        },
+        {
+          id: '/for-loop-begin-1',
+          type: 'ForLoopBeginOp',
+          position: { x: 0, y: 100 },
+          data: { inputs: {} },
+          parentNode: '/for-loop-body-1',
+          expandParent: true,
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      timeline: {},
+    } as NoodlesProjectJSON
+
+    // Migrate up then down
+    const migrated = await up(originalProject)
+    const reverted = await down(migrated)
+
+    // Should be back to parentNode format
+    expect((reverted.nodes[1] as any).parentNode).toBe('/for-loop-body-1')
+    expect(reverted.nodes[1].parentId).toBeUndefined()
+  })
+})

--- a/noodles-editor/src/noodles/__migrations__/010-parent-node-to-parent-id.ts
+++ b/noodles-editor/src/noodles/__migrations__/010-parent-node-to-parent-id.ts
@@ -1,0 +1,56 @@
+import type { NoodlesProjectJSON } from '../utils/serialization'
+
+// Migration to convert deprecated ReactFlow v11 `parentNode` property to v12+ `parentId`
+//
+// ReactFlow renamed `parentNode` to `parentId` in v12. This migration:
+// 1. Converts any nodes with `parentNode` to use `parentId` instead
+// 2. Removes the deprecated `parentNode` property
+
+export async function up(project: NoodlesProjectJSON): Promise<NoodlesProjectJSON> {
+  const { nodes, ...rest } = project
+
+  const newNodes = nodes.map(node => {
+    // Check if node has the deprecated parentNode property
+    const parentNode = (node as any).parentNode
+    if (parentNode === undefined) {
+      return node
+    }
+
+    // Remove parentNode and add parentId if not already present
+    const { parentNode: _, ...nodeWithoutParentNode } = node as any
+
+    return {
+      ...nodeWithoutParentNode,
+      // Use existing parentId if present, otherwise use parentNode value
+      parentId: node.parentId || parentNode,
+    }
+  })
+
+  return {
+    ...rest,
+    nodes: newNodes,
+  }
+}
+
+export async function down(project: NoodlesProjectJSON): Promise<NoodlesProjectJSON> {
+  const { nodes, ...rest } = project
+
+  // Convert parentId back to parentNode for backwards compatibility
+  const newNodes = nodes.map(node => {
+    if (!node.parentId) {
+      return node
+    }
+
+    const { parentId, ...nodeWithoutParentId } = node
+
+    return {
+      ...nodeWithoutParentId,
+      parentNode: parentId,
+    }
+  })
+
+  return {
+    ...rest,
+    nodes: newNodes,
+  }
+}

--- a/noodles-editor/src/noodles/utils/node-creation-utils.ts
+++ b/noodles-editor/src/noodles/utils/node-creation-utils.ts
@@ -56,7 +56,7 @@ export function createNodesForType(
       id: makeOpId('ForLoopBeginOp', currentContainerId),
       type: 'ForLoopBeginOp',
       data: undefined,
-      parentNode: bodyId,
+      parentId: bodyId,
       expandParent: true,
       position: { x: 0, y: 100 },
     }
@@ -64,7 +64,7 @@ export function createNodesForType(
       id: makeOpId('ForLoopEndOp', currentContainerId),
       type: 'ForLoopEndOp',
       data: undefined,
-      parentNode: bodyId,
+      parentId: bodyId,
       expandParent: true,
       position: { x: 900, y: 100 },
     }


### PR DESCRIPTION
## Background

ReactFlow v12 renamed the `parentNode` property to `parentId`. This PR updates the codebase to be fully compatible with ReactFlow v12+ while maintaining backward compatibility with existing projects that may still have the old property.

## Change List

- Updated ForLoop node creation to use `parentId` instead of deprecated `parentNode`
- Added migration 010 to convert `parentNode` to `parentId` for existing projects saved with the old property
- Enhanced migration 005 to handle `parentNode` for projects predating the v5 migration
- Added comprehensive test coverage for both migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)