### PR TITLE
style: Convert JSDoc comments to inline comments

### DIFF
--- a/noodles-editor/src/ai-chat/agents/migration-generator.ts
+++ b/noodles-editor/src/ai-chat/agents/migration-generator.ts
@@ -1,9 +1,7 @@
-/**
- * Migration Generator Agent
- *
- * Generates schema migration files for operator changes.
- * This is a CLI tool for developers, not usable from AI chat.
- */
+// Migration Generator Agent
+//
+// Generates schema migration files for operator changes.
+// This is a CLI tool for developers, not usable from AI chat.
 
 export interface MigrationParams {
   operatorType: string
@@ -29,9 +27,7 @@ export interface GeneratedMigration {
 }
 
 export class MigrationGeneratorAgent {
-  /**
-   * Generate a migration file for an operator change
-   */
+  // Generate a migration file for an operator change
   generateMigration(params: MigrationParams, nextVersion: number): GeneratedMigration {
     const { operatorType, changeType, changes } = params
 
@@ -74,9 +70,7 @@ export class MigrationGeneratorAgent {
     }
   }
 
-  /**
-   * Get the next migration version number
-   */
+  // Get the next migration version number
   getNextVersion(existingMigrations: string[]): number {
     const versions = existingMigrations
       .map(file => {

--- a/noodles-editor/src/ai-chat/agents/project-generator.ts
+++ b/noodles-editor/src/ai-chat/agents/project-generator.ts
@@ -1,9 +1,7 @@
-/**
- * Project Generator Agent
- *
- * Generates complete Noodles.gl projects from natural language descriptions.
- * Can be invoked from the AI chat to create new visualizations.
- */
+// Project Generator Agent
+//
+// Generates complete Noodles.gl projects from natural language descriptions.
+// Can be invoked from the AI chat to create new visualizations.
 
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import {
@@ -16,13 +14,13 @@ import {
 } from './project-templates'
 
 export interface GenerateProjectParams {
-  /** Natural language description of the visualization */
+  // Natural language description of the visualization
   description: string
-  /** Data source URL or path (optional, will use placeholder if not provided) */
+  // Data source URL or path (optional, will use placeholder if not provided)
   dataSource?: string
-  /** Visualization type hint (optional, will infer from description) */
+  // Visualization type hint (optional, will infer from description)
   visualizationType?: string
-  /** Whether to include a basemap */
+  // Whether to include a basemap
   includeBasemap?: boolean
 }
 
@@ -33,9 +31,7 @@ export interface GeneratedProject {
 }
 
 export class ProjectGeneratorAgent {
-  /**
-   * Generate a complete project from a description
-   */
+  // Generate a complete project from a description
   async generateProject(params: GenerateProjectParams): Promise<GeneratedProject> {
     const {
       description,
@@ -209,9 +205,7 @@ export class ProjectGeneratorAgent {
     }
   }
 
-  /**
-   * Infer visualization type from description
-   */
+  // Infer visualization type from description
   private inferVisualizationType(description: string): string {
     const lower = description.toLowerCase()
 
@@ -237,9 +231,7 @@ export class ProjectGeneratorAgent {
     return 'scatter'
   }
 
-  /**
-   * Infer data format from file extension
-   */
+  // Infer data format from file extension
   private inferDataFormat(url: string): string {
     if (url.endsWith('.csv')) return 'csv'
     if (url.endsWith('.json')) return 'json'
@@ -248,9 +240,7 @@ export class ProjectGeneratorAgent {
     return 'csv' // default
   }
 
-  /**
-   * Get layer-specific configuration
-   */
+  // Get layer-specific configuration
   private getLayerConfig(layerType: string, _description: string): Record<string, unknown> {
     const baseConfig = OPERATOR_CONFIGS.layers[layerType as keyof typeof OPERATOR_CONFIGS.layers]
     if (baseConfig) {
@@ -259,9 +249,7 @@ export class ProjectGeneratorAgent {
     return {}
   }
 
-  /**
-   * Generate accessor functions based on layer type
-   */
+  // Generate accessor functions based on layer type
   private generateAccessors(layerType: string, description: string): Record<string, string> {
     const accessors: Record<string, string> = {}
 
@@ -284,9 +272,7 @@ export class ProjectGeneratorAgent {
     return accessors
   }
 
-  /**
-   * Check if layer needs position accessor
-   */
+  // Check if layer needs position accessor
   private needsPositionAccessor(layerType: string): boolean {
     return [
       'ScatterplotLayerOp',
@@ -297,9 +283,7 @@ export class ProjectGeneratorAgent {
     ].includes(layerType)
   }
 
-  /**
-   * Infer position accessor from description
-   */
+  // Infer position accessor from description
   private inferPositionAccessor(description: string): string {
     const lower = description.toLowerCase()
 
@@ -319,9 +303,7 @@ export class ProjectGeneratorAgent {
     return '[d.longitude, d.latitude]'
   }
 
-  /**
-   * Get the layer input field name for an accessor type
-   */
+  // Get the layer input field name for an accessor type
   private getLayerAccessorField(layerType: string, accessorType: string): string | null {
     const mapping: Record<string, Record<string, string>> = {
       ScatterplotLayerOp: {
@@ -364,9 +346,7 @@ export class ProjectGeneratorAgent {
     return mapping[layerType]?.[accessorType] || null
   }
 
-  /**
-   * Validate generated project structure
-   */
+  // Validate generated project structure
   validateProject(project: GeneratedProject): { valid: boolean; errors: string[] } {
     const errors: string[] = []
 

--- a/noodles-editor/src/ai-chat/agents/project-templates.ts
+++ b/noodles-editor/src/ai-chat/agents/project-templates.ts
@@ -1,9 +1,7 @@
-/**
- * Project Templates and Common Patterns
- *
- * This file contains template configurations for common Noodles.gl project patterns.
- * Used by the Project Generator Agent to create well-structured projects.
- */
+// Project Templates and Common Patterns
+//
+// This file contains template configurations for common Noodles.gl project patterns.
+// Used by the Project Generator Agent to create well-structured projects.
 
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 
@@ -14,10 +12,8 @@ export interface ProjectTemplate {
   edges: Partial<ReactFlowEdge>[]
 }
 
-/**
- * Basic visualization pipeline pattern:
- * Data Source → Data Transform → Deck.gl Layer → DeckRenderer → Viewer
- */
+// Basic visualization pipeline pattern:
+// Data Source → Data Transform → Deck.gl Layer → DeckRenderer → Viewer
 export const BASIC_VIZ_PATTERN: ProjectTemplate = {
   name: 'Basic Visualization',
   description: 'Standard data visualization pipeline with viewer output',
@@ -93,23 +89,19 @@ export const BASIC_VIZ_PATTERN: ProjectTemplate = {
   ],
 }
 
-/**
- * Common node positioning utilities
- */
+// Common node positioning utilities
 export const LAYOUT = {
-  /** Standard horizontal spacing between nodes */
+  // Standard horizontal spacing between nodes
   HORIZONTAL_GAP: 300,
-  /** Standard vertical spacing between nodes */
+  // Standard vertical spacing between nodes
   VERTICAL_GAP: 150,
-  /** Starting X position for first node */
+  // Starting X position for first node
   START_X: 100,
-  /** Starting Y position for first node */
+  // Starting Y position for first node
   START_Y: 100,
 }
 
-/**
- * Common operator configurations by category
- */
+// Common operator configurations by category
 export const OPERATOR_CONFIGS = {
   dataSources: {
     FileOp: {
@@ -217,9 +209,7 @@ export const OPERATOR_CONFIGS = {
   },
 }
 
-/**
- * Basemap style URLs
- */
+// Basemap style URLs
 export const BASEMAP_STYLES = {
   darkNoLabels: 'https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json',
   dark: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
@@ -229,9 +219,7 @@ export const BASEMAP_STYLES = {
   voyagerNoLabels: 'https://basemaps.cartocdn.com/gl/voyager-nolabels-gl-style/style.json',
 }
 
-/**
- * Common accessor patterns for Deck.gl layers
- */
+// Common accessor patterns for Deck.gl layers
 export const ACCESSOR_PATTERNS = {
   position: {
     latLng: '[d.longitude, d.latitude]',
@@ -250,9 +238,7 @@ export const ACCESSOR_PATTERNS = {
   },
 }
 
-/**
- * Helper: Generate a unique node ID
- */
+// Helper: Generate a unique node ID
 export function generateNodeId(type: string, existing: Set<string>): string {
   const baseName = type.replace(/Op$/, '').toLowerCase()
   let counter = 1
@@ -266,9 +252,7 @@ export function generateNodeId(type: string, existing: Set<string>): string {
   return id
 }
 
-/**
- * Helper: Calculate node position in a flow layout
- */
+// Helper: Calculate node position in a flow layout
 export function calculatePosition(_index: number, column = 0, row = 0): { x: number; y: number } {
   return {
     x: LAYOUT.START_X + column * LAYOUT.HORIZONTAL_GAP,
@@ -276,9 +260,7 @@ export function calculatePosition(_index: number, column = 0, row = 0): { x: num
   }
 }
 
-/**
- * Helper: Create an edge ID from source/target
- */
+// Helper: Create an edge ID from source/target
 export function createEdgeId(
   sourceId: string,
   sourceHandle: string,
@@ -288,9 +270,7 @@ export function createEdgeId(
   return `${sourceId}.${sourceHandle}->${targetId}.${targetHandle}`
 }
 
-/**
- * Visualization type to layer mapping
- */
+// Visualization type to layer mapping
 export const VIZ_TYPE_TO_LAYER: Record<string, string> = {
   scatter: 'ScatterplotLayerOp',
   scatterplot: 'ScatterplotLayerOp',
@@ -325,9 +305,7 @@ export const VIZ_TYPE_TO_LAYER: Record<string, string> = {
   labels: 'TextLayerOp',
 }
 
-/**
- * Data format detection patterns
- */
+// Data format detection patterns
 export const DATA_FORMAT_PATTERNS = {
   csv: /\.csv$/i,
   json: /\.json$/i,

--- a/noodles-editor/src/ai-chat/agents/refactoring-assistant.ts
+++ b/noodles-editor/src/ai-chat/agents/refactoring-assistant.ts
@@ -1,9 +1,7 @@
-/**
- * Refactoring Assistant Agent
- *
- * Analyzes operator code and suggests improvements based on best practices.
- * Read-only analysis - does not automatically apply changes.
- */
+// Refactoring Assistant Agent
+//
+// Analyzes operator code and suggests improvements based on best practices.
+// Read-only analysis - does not automatically apply changes.
 
 import type { ContextLoader } from '../context-loader'
 
@@ -53,9 +51,7 @@ export interface CodeMetrics {
 export class RefactoringAssistantAgent {
   constructor(private contextLoader: ContextLoader) {}
 
-  /**
-   * Analyze an operator for common issues and improvement opportunities
-   */
+  // Analyze an operator for common issues and improvement opportunities
   async analyzeOperator(params: { operatorType: string }): Promise<CodeAnalysisResult> {
     const { operatorType } = params
     const codeIndex = this.contextLoader.getCodeIndex()
@@ -99,9 +95,7 @@ export class RefactoringAssistantAgent {
     }
   }
 
-  /**
-   * Find duplicate code patterns across operators
-   */
+  // Find duplicate code patterns across operators
   async findDuplicates(params: { minLines?: number; category?: string }): Promise<{
     duplicates: Array<{
       pattern: string
@@ -139,9 +133,7 @@ export class RefactoringAssistantAgent {
     return { duplicates }
   }
 
-  /**
-   * Suggest refactorings for an operator
-   */
+  // Suggest refactorings for an operator
   async suggestRefactorings(params: { operatorType: string }): Promise<{
     refactorings: Array<{
       type: string

--- a/noodles-editor/src/examples-page.test.tsx
+++ b/noodles-editor/src/examples-page.test.tsx
@@ -1,13 +1,11 @@
-/**
- * Tests for the ExamplesPage component
- *
- * Note: The ExamplesPage uses Vite's import.meta.glob() which is a compile-time feature
- * that can't be easily mocked at runtime. Therefore, these tests focus on:
- * 1. The description extraction logic (unit tests)
- * 2. Smoke test that the page renders with real examples
- *
- * Full integration testing of project discovery should be done in E2E tests.
- */
+// Tests for the ExamplesPage component
+//
+// Note: The ExamplesPage uses Vite's import.meta.glob() which is a compile-time feature
+// that can't be easily mocked at runtime. Therefore, these tests focus on:
+// 1. The description extraction logic (unit tests)
+// 2. Smoke test that the page renders with real examples
+//
+// Full integration testing of project discovery should be done in E2E tests.
 
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, test, vi } from 'vitest'

--- a/noodles-editor/src/noodles/pull-benchmark.test.ts
+++ b/noodles-editor/src/noodles/pull-benchmark.test.ts
@@ -1,11 +1,9 @@
-/**
- * Performance benchmark tests for pull-based execution model
- */
+// Performance benchmark tests for pull-based execution model
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { Operator, PullExecutionStatus } from './operators'
-import { NumberField, DataField } from './fields'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DataField, NumberField } from './fields'
 import { GraphExecutor, topologicalSort } from './graph-executor'
+import { Operator, PullExecutionStatus } from './operators'
 import type { ExtractProps } from './utils/extract-props'
 
 // Test operator that simulates computation
@@ -113,7 +111,6 @@ describe('Pull-based execution benchmarks', () => {
   })
 
   it('should execute operators only when needed', async () => {
-
     // Create operator chain
     const compute = new ComputeOp('/compute')
     const chain = new ChainOp('/chain')
@@ -153,7 +150,6 @@ describe('Pull-based execution benchmarks', () => {
   })
 
   it('should handle parallel execution efficiently', async () => {
-
     // Create multiple independent operators
     const ops: ComputeOp[] = []
     for (let i = 0; i < 5; i++) {
@@ -187,7 +183,6 @@ describe('Pull-based execution benchmarks', () => {
   })
 
   it('should prevent unnecessary cascading updates', async () => {
-
     // Create a deep chain
     const depth = 10
     const operators: ComputeOp[] = []
@@ -285,7 +280,6 @@ describe('Pull-based execution benchmarks', () => {
   })
 
   it('should measure performance metrics correctly', async () => {
-
     // Create operators
     const source = new DataSourceOp('/source')
     const compute1 = new ComputeOp('/compute1')

--- a/noodles-editor/src/noodles/utils/serialization.ts
+++ b/noodles-editor/src/noodles/utils/serialization.ts
@@ -157,9 +157,7 @@ const exampleAssetUrls: Record<string, string> = import.meta.glob('../../example
   query: '?url',
 })
 
-/**
- * Export a project as a downloadable zip file containing noodles.json and data files
- */
+// Export a project as a downloadable zip file containing noodles.json and data files
 export async function saveProjectLocally(
   projectName: string,
   projectJson: NoodlesProjectJSON,

--- a/noodles-editor/src/utils/kml-to-geojson.ts
+++ b/noodles-editor/src/utils/kml-to-geojson.ts
@@ -1,11 +1,7 @@
 import { kml } from '@tmcw/togeojson'
 import type { FeatureCollection } from 'geojson'
 
-/**
- * Convert KML string to GeoJSON FeatureCollection
- * @param kmlString - KML string to convert
- * @returns GeoJSON FeatureCollection
- */
+// Convert KML string to GeoJSON FeatureCollection
 export function kmlToGeoJson(kmlString: string): FeatureCollection {
   // Parse KML string to XML DOM
   const parser = new DOMParser()


### PR DESCRIPTION
## Summary
- Replace multi-line JSDoc-style comments (`/* */`) with single-line inline comments (`//`) across the codebase for consistency
- Applied biome formatting to all changed files

## Files Updated
- `serialization.ts`
- `pull-benchmark.test.ts`
- `kml-to-geojson.ts`
- `migration-generator.ts`
- `project-templates.ts`
- `project-generator.ts`
- `refactoring-assistant.ts`
- `examples-page.test.tsx`

## Test plan
- [ ] Run `yarn lint` to verify no new lint errors introduced
- [ ] Run `yarn test` to verify all tests pass
- [ ] Visual inspection of changed files to confirm comments are correctly converted

🤖 Generated with [Claude Code](https://claude.com/claude-code)