### PR TITLE
Add conversation compaction and Zod validation for AI chat

### DIFF
--- a/noodles-editor/src/ai-chat/conversation-compaction.ts
+++ b/noodles-editor/src/ai-chat/conversation-compaction.ts
@@ -1,0 +1,106 @@
+// Conversation compaction utilities for managing long conversation history
+import type Anthropic from '@anthropic-ai/sdk'
+import type { Message } from './types'
+
+const SUMMARY_SYSTEM_PROMPT = `You are summarizing a conversation to preserve context while reducing length.
+Create a concise but complete summary that preserves:
+- The user's original request and goals
+- Key decisions made during the conversation
+- Important technical details and code changes
+- Any unfinished tasks or next steps
+- Errors encountered and how they were resolved
+
+Format as a structured summary the AI can use to continue the conversation.`
+
+// Estimate token count for a message (rough approximation: 4 chars = 1 token)
+export function estimateTokens(content: string | unknown): number {
+  const text = typeof content === 'string' ? content : JSON.stringify(content)
+  return Math.ceil(text.length / 4)
+}
+
+// Estimate total tokens in conversation history
+export function estimateConversationTokens(messages: Message[]): number {
+  return messages.reduce((total, msg) => {
+    const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content)
+    return total + estimateTokens(content)
+  }, 0)
+}
+
+// Check if conversation history should be compacted
+export function shouldCompact(messages: Message[], threshold = 50000): boolean {
+  return estimateConversationTokens(messages) > threshold
+}
+
+// Create a compacted conversation history by summarizing older messages.
+// Keeps the most recent messages intact and summarizes earlier context.
+export async function compactConversation(
+  client: Anthropic,
+  messages: Message[],
+  model: string,
+  keepRecent = 2
+): Promise<Message[]> {
+  // Keep last N exchanges (2 messages per exchange)
+  const recentCount = keepRecent * 2
+  if (messages.length <= recentCount) {
+    return messages // Nothing to compact
+  }
+
+  const messagesToSummarize = messages.slice(0, -recentCount)
+  const recentMessages = messages.slice(-recentCount)
+
+  // Format messages for summarization
+  const conversationText = messagesToSummarize
+    .map(m => {
+      const content = typeof m.content === 'string' ? m.content : JSON.stringify(m.content)
+      return `${m.role.toUpperCase()}: ${content}`
+    })
+    .join('\n\n')
+
+  try {
+    // Generate summary using Claude
+    const response = await client.messages.create({
+      model,
+      max_tokens: 2000,
+      system: SUMMARY_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: `Summarize this conversation history:\n\n${conversationText}`,
+        },
+      ],
+    })
+
+    // Extract summary text
+    const summaryText = response.content
+      .filter((c): c is Anthropic.TextBlock => c.type === 'text')
+      .map(c => c.text)
+      .join('\n')
+
+    // Anthropic API requires alternating user/assistant roles.
+    // Prepend the summary to the first user message to maintain proper alternation.
+    const firstUserIndex = recentMessages.findIndex(m => m.role === 'user')
+    if (firstUserIndex === -1) {
+      // No user message in recent - just return recent messages
+      return recentMessages
+    }
+
+    // Create a copy with the summary prepended to the first user message
+    const compactedMessages = [...recentMessages]
+    const firstUserMsg = compactedMessages[firstUserIndex]
+    const originalContent =
+      typeof firstUserMsg.content === 'string'
+        ? firstUserMsg.content
+        : JSON.stringify(firstUserMsg.content)
+
+    compactedMessages[firstUserIndex] = {
+      ...firstUserMsg,
+      content: `[Previous conversation summary]\n${summaryText}\n\n[Current message]\n${originalContent}`,
+    }
+
+    return compactedMessages
+  } catch (error) {
+    console.error('[Compaction] Failed to generate summary:', error)
+    // Fallback: just return recent messages without summary
+    return recentMessages
+  }
+}

--- a/noodles-editor/src/ai-chat/types.test.ts
+++ b/noodles-editor/src/ai-chat/types.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import { parseModifications, validateModification } from './types'
+
+describe('parseModifications', () => {
+  it('parses valid modifications array from object', () => {
+    const input = {
+      modifications: [
+        { type: 'add_node', data: { id: '/node-1', type: 'NumberOp' } },
+        { type: 'delete_node', data: { id: '/node-2' } },
+      ],
+    }
+
+    const result = parseModifications(input)
+
+    expect(result).toHaveLength(2)
+    expect(result?.[0].type).toBe('add_node')
+    expect(result?.[1].type).toBe('delete_node')
+  })
+
+  it('parses valid modifications from direct array', () => {
+    const input = [
+      { type: 'add_node', data: { id: '/node-1', type: 'CodeOp' } },
+      { type: 'add_edge', data: { id: 'edge-1', source: '/a', target: '/b' } },
+    ]
+
+    const result = parseModifications(input)
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('parses valid modifications from JSON string', () => {
+    const input = JSON.stringify({
+      modifications: [{ type: 'delete_edge', data: { id: 'edge-1' } }],
+    })
+
+    const result = parseModifications(input)
+
+    expect(result).toHaveLength(1)
+    expect(result?.[0].type).toBe('delete_edge')
+  })
+
+  it('returns null for invalid modification type', () => {
+    const input = {
+      modifications: [{ type: 'invalid_type', data: {} }],
+    }
+
+    const result = parseModifications(input)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for missing required data fields', () => {
+    const input = {
+      modifications: [{ type: 'add_node', data: { type: 'NumberOp' } }], // missing id
+    }
+
+    const result = parseModifications(input)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for malformed JSON string', () => {
+    const input = '{ invalid json }'
+
+    const result = parseModifications(input)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for non-object input', () => {
+    expect(parseModifications(null)).toBeNull()
+    expect(parseModifications(123)).toBeNull()
+    expect(parseModifications('not json')).toBeNull()
+  })
+
+  it('validates update_node with partial data', () => {
+    const input = {
+      modifications: [
+        {
+          type: 'update_node',
+          data: { id: '/node-1', position: { x: 100, y: 200 } },
+        },
+      ],
+    }
+
+    const result = parseModifications(input)
+
+    expect(result).toHaveLength(1)
+    expect(result?.[0].type).toBe('update_node')
+  })
+
+  it('validates edge with optional handles', () => {
+    const input = {
+      modifications: [
+        {
+          type: 'add_edge',
+          data: {
+            id: 'edge-1',
+            source: '/a',
+            target: '/b',
+            sourceHandle: 'out.data',
+            targetHandle: 'par.input',
+          },
+        },
+      ],
+    }
+
+    const result = parseModifications(input)
+
+    expect(result).toHaveLength(1)
+    const edge = result?.[0]
+    if (edge?.type === 'add_edge') {
+      expect(edge.data.sourceHandle).toBe('out.data')
+      expect(edge.data.targetHandle).toBe('par.input')
+    }
+  })
+})
+
+describe('validateModification', () => {
+  it('validates a single add_node modification', () => {
+    const mod = { type: 'add_node', data: { id: '/test', type: 'NumberOp' } }
+
+    const result = validateModification(mod)
+
+    expect(result).not.toBeNull()
+    expect(result?.type).toBe('add_node')
+  })
+
+  it('returns null for invalid modification', () => {
+    const mod = { type: 'add_node', data: {} } // missing id and type
+
+    const result = validateModification(mod)
+
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Add conversation compaction for Claude AI chat to handle longer conversations
- Increase conversation history limit from 4 to 10 messages
- Auto-compact when exceeding ~50k tokens threshold
- Prepend summary to first user message to maintain proper alternating roles (Anthropic API requirement)
- Add Zod schema validation for type-safe project modification parsing
- Add unit tests for validation logic

## Test plan
- [ ] Run `yarn test src/ai-chat` to verify tests pass
- [ ] Test AI chat functionality with a multi-turn conversation
- [ ] Verify project modifications still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)