### PR TITLE
Set up PostHog error tracking with React 19 error hooks

### DIFF
--- a/dev-docs/analytics.md
+++ b/dev-docs/analytics.md
@@ -11,6 +11,7 @@ Noodles.gl uses PostHog for product analytics with a privacy-first approach:
 - **Manual events only**: No automatic capture or session recording
 - **Easy opt-out**: Users can disable anytime in Settings
 - **Ad-blocker resilient**: Gracefully handles blocking without breaking the app
+- **Error tracking for all users**: Exceptions are logged regardless of consent to maintain application stability
 
 ## Setup
 
@@ -53,6 +54,7 @@ VITE_POSTHOG_HOST=https://app.posthog.com  # Optional
    - `autocapture: false`
    - `disable_session_recording: true`
    - `capture_pageview: false`
+   - `capture_exceptions: true`
 
 ## Currently Tracked Events
 
@@ -89,6 +91,19 @@ VITE_POSTHOG_HOST=https://app.posthog.com  # Optional
 | Event | Properties | Location |
 |-------|-----------|----------|
 | `web_vital_measured` | `name, value, rating` | reportWebVitals.ts |
+
+### Error Tracking
+
+Errors are tracked for all users regardless of consent to maintain application stability.
+
+| Event | Properties | Location |
+|-------|-----------|----------|
+| `$exception` | `source, componentStack` | index.tsx (React 19 error hooks) |
+
+Error sources:
+- `react_error_boundary` - Errors caught by an Error Boundary
+- `react_uncaught` - Errors not caught by any Error Boundary
+- `react_recoverable` - Errors React automatically recovered from
 
 ## Adding New Tracking
 

--- a/noodles-editor/src/index.tsx
+++ b/noodles-editor/src/index.tsx
@@ -17,21 +17,21 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement,
   onCaughtError: (error, errorInfo) => {
     analytics.captureException(error, {
       source: 'react_error_boundary',
-      componentStack: errorInfo.componentStack ?? undefined,
+      componentStack: errorInfo.componentStack,
     })
   },
   // Called when an error is thrown and not caught by an Error Boundary
   onUncaughtError: (error, errorInfo) => {
     analytics.captureException(error, {
       source: 'react_uncaught',
-      componentStack: errorInfo.componentStack ?? undefined,
+      componentStack: errorInfo.componentStack,
     })
   },
   // Called when React automatically recovers from errors
   onRecoverableError: (error, errorInfo) => {
     analytics.captureException(error, {
       source: 'react_recoverable',
-      componentStack: errorInfo.componentStack ?? undefined,
+      componentStack: errorInfo.componentStack,
     })
   },
 })

--- a/noodles-editor/src/noodles/components/error-boundary.tsx
+++ b/noodles-editor/src/noodles/components/error-boundary.tsx
@@ -36,8 +36,6 @@ export class ErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('Node graph error:', error, errorInfo)
 
-    // Error is captured by React 19's onCaughtError hook in index.tsx
-
     // Increment reset count if error occurs within timeout period
     const now = Date.now()
     const { lastResetTime, resetCount } = this.state


### PR DESCRIPTION
## Background
PostHog error tracking was not previously integrated into the application. This PR sets up automatic exception capture to track all errors in production.

## Change List
- Enable `capture_exceptions: true` in PostHog config for automatic unhandled exception capture
- Integrate React 19's createRoot error hooks (onCaughtError, onUncaughtError, onRecoverableError) to track all error scenarios with component stack traces
- Add `captureException()` method to AnalyticsManager for manual error reporting
- Error tracking bypasses consent checks since it's essential for application stability