### PR TITLE
Add error capture toggle to settings menu

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -7,6 +7,7 @@ We use Posthog to collect anonymized, aggregate analytics on site usage to help 
 ## Data Collection
 
 - **Data collected:** Aggregate event data (e.g., page views, feature usage), no personally identifiable information (PII).
+- **Error reports:** Error reports are sent by default to help us identify and fix bugs. Error reports contain only technical information (error messages and stack traces) and do not include any personal data or project content. You can disable error reporting in the Settings dialog.
 - **What we don't collect:** We never collect your project data, node content, code, SQL queries, or any personal information.
 
 ## Data Usage and Sharing

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -5,6 +5,7 @@ Noodles.gl uses limited, privacy-preserving analytics through Posthog to underst
 ## What We Collect
 
 - **Aggregate event data:** Page views, feature usage, and interaction patterns
+- **Error reports:** Error reports are sent by default to help us identify and fix bugs. These contain only technical information (error messages and stack traces), not personal data or project content. You can disable this in the Settings dialog.
 - **No personally identifiable information (PII):** We never collect names, email addresses, IP addresses, or any personal data
 - **No project data:** Your projects, node content, code, SQL queries, and visualizations are never collected or transmitted
 

--- a/noodles-editor/src/components/settings-dialog.tsx
+++ b/noodles-editor/src/components/settings-dialog.tsx
@@ -109,6 +109,7 @@ const KeyGroup = ({
 
 export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
   const [analyticsEnabled, setAnalyticsEnabled] = useState(false)
+  const [errorCaptureEnabled, setErrorCaptureEnabled] = useState(true)
 
   // Store subscriptions
   const browserKeys = useKeysStore(state => state.browserKeys)
@@ -121,11 +122,12 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
   // Environment keys (static)
   const envKeys = getEnvKeys()
 
-  // Sync analytics setting when dialog opens
+  // Sync analytics settings when dialog opens
   useEffect(() => {
     if (open) {
       const consent = analytics.getConsent()
       setAnalyticsEnabled(consent?.enabled ?? false)
+      setErrorCaptureEnabled(analytics.getErrorCaptureEnabled())
     }
   }, [open])
 
@@ -135,6 +137,15 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
 
     if (enabled) {
       analytics.track('analytics_enabled_in_settings')
+    }
+  }
+
+  const handleErrorCaptureToggle = (enabled: boolean) => {
+    setErrorCaptureEnabled(enabled)
+    analytics.setErrorCaptureConsent(enabled)
+
+    if (enabled) {
+      analytics.track('error_capture_enabled_in_settings')
     }
   }
 
@@ -170,6 +181,24 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                   <div className={s.settingDescription}>
                     Help improve Noodles.gl by sharing anonymous feature usage data. We never
                     collect your project data, node content, API keys, or personal information.
+                  </div>
+                </div>
+              </label>
+            </div>
+
+            <div className={s.settingItem}>
+              <label className={s.settingLabel}>
+                <input
+                  type="checkbox"
+                  checked={errorCaptureEnabled}
+                  onChange={e => handleErrorCaptureToggle(e.target.checked)}
+                  className={s.checkbox}
+                />
+                <div className={s.settingContent}>
+                  <div className={s.settingName}>Send error reports (recommended)</div>
+                  <div className={s.settingDescription}>
+                    Automatically send error reports when something goes wrong. This helps us
+                    identify and fix bugs. No personal data is included in error reports.
                   </div>
                 </div>
               </label>


### PR DESCRIPTION
Follow up to #245

#### Background
Adds user control over error capture, which was previously always enabled. Error capture is still on by default but can now be toggled off in Settings.

#### Change List
- Add `errorCaptureEnabled` to analytics consent interface with backward-compatible default (true)
- Add `setErrorCaptureConsent()` and `getErrorCaptureEnabled()` methods to AnalyticsManager
- Update `captureException()` to respect the error capture setting
- Add "Send error reports (recommended)" toggle in Settings dialog
- Update PRIVACY.md and docs/privacy.md to document error capture behavior