### PR TITLE
Fix: Increase GitHub Pages deployment timeout to 20 minutes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -90,3 +90,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          timeout: 1200000 # 20 minutes (default is 10 min, sometimes exceeded due to 62MB artifact)


### PR DESCRIPTION
#### Background
Recent deployments have been timing out intermittently. The 62.8 MB artifact sometimes takes longer than the default 10-minute timeout due to GitHub infrastructure variability.

#### Change List
- Increase deploy-pages action timeout from 10 to 20 minutes