### PR TITLE
fix: Surface accurate error messages for connection constraint violations

### DIFF
--- a/noodles-editor/src/noodles/utils/can-connect.test.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.test.ts
@@ -172,4 +172,47 @@ describe('ValidateConnection', () => {
     expect(result.error).toBeDefined()
     expect(result.error).toContain('Type mismatch')
   })
+
+  it('returns constraint violation error for number exceeding max', () => {
+    const source = new NumberField(100) // Value is 100
+    const target = new NumberField(0, { max: 50 }) // Max is 50
+
+    const result = validateConnection(source, target)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Constraint violation')
+    expect(result.error).not.toContain('Type mismatch')
+    expect(result.error).toContain('50') // Should mention the constraint
+  })
+
+  it('returns constraint violation error for number below min', () => {
+    const source = new NumberField(-10)
+    const target = new NumberField(0, { min: 0 })
+
+    const result = validateConnection(source, target)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Constraint violation')
+    expect(result.error).not.toContain('Type mismatch')
+  })
+
+  it('returns type mismatch for different types even when values could parse', () => {
+    const source = new StringField('test')
+    const target = new NumberField(0)
+
+    const result = validateConnection(source, target)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Type mismatch')
+    expect(result.error).toContain('string')
+    expect(result.error).toContain('number')
+  })
+
+  it('returns type mismatch for nested type errors in arrays', () => {
+    const source = new ArrayField(new StringField())
+    source.setValue(['a', 'b'])
+    const target = new ArrayField(new NumberField())
+
+    const result = validateConnection(source, target)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Type mismatch')
+    expect(result.error).not.toContain('Constraint violation')
+  })
 })

--- a/noodles-editor/src/noodles/utils/can-connect.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.ts
@@ -1,8 +1,29 @@
+import type z from 'zod/v4'
 import { type Field, ListField, UnknownField } from '../fields'
 
 export type ConnectionValidationResult = {
   valid: boolean
   error?: string
+}
+
+// Format a Zod issue into a human-readable message
+// The error callback in safeParse overrides issue.message, so we construct messages from properties
+function formatZodIssue(issue: z.core.$ZodIssue): string {
+  switch (issue.code) {
+    case 'invalid_type':
+      return `Expected ${issue.expected}, received ${issue.received}`
+    case 'too_big':
+      return `Number must be ${issue.inclusive ? '<=' : '<'} ${issue.maximum}`
+    case 'too_small':
+      return `Number must be ${issue.inclusive ? '>=' : '>'} ${issue.minimum}`
+    case 'invalid_string':
+      return `Invalid string: ${issue.validation}`
+    case 'custom':
+      return issue.message || 'Custom validation failed'
+    default:
+      // Fall back to issue.message for other codes
+      return issue.message || `Validation failed (${issue.code})`
+  }
 }
 
 // Validates if two fields can be connected. Returns both validity and error message.
@@ -22,10 +43,23 @@ export function validateConnection(from: Field, to: Field): ConnectionValidation
   if (!result.success) {
     const fromType = (from.constructor as typeof Field).type
     const toType = (to.constructor as typeof Field).type
-    const issueMessages = result.error.issues.map(issue => issue.message).join(', ')
+    const issueMessages = result.error.issues.map(formatZodIssue).join(', ')
+
+    // Check if this is a type mismatch (different field types OR zod reports invalid_type)
+    const hasTypeMismatch =
+      fromType !== toType || result.error.issues.some(issue => issue.code === 'invalid_type')
+
+    if (hasTypeMismatch) {
+      return {
+        valid: false,
+        error: `Type mismatch: ${fromType} cannot connect to ${toType}. ${issueMessages}`,
+      }
+    }
+
+    // Constraint violation - types match but value fails validation (e.g., min/max)
     return {
       valid: false,
-      error: `Type mismatch: ${fromType} cannot connect to ${toType}. ${issueMessages}`,
+      error: `Constraint violation: ${issueMessages}`,
     }
   }
   return { valid: true }


### PR DESCRIPTION
#### Background

PR #224 surfaced connection errors but always showed "Type mismatch: X cannot connect to Y" even when types matched but a constraint (like min/max) was violated.

#### Change List
- Add `formatZodIssue()` helper to construct human-readable messages from Zod issue properties
- Differentiate between type mismatches and constraint violations in error messages
- Type mismatches show: "Type mismatch: string cannot connect to number..."
- Constraint violations show: "Constraint violation: Number must be <= 50"
- Add 4 new tests for constraint violation scenarios