### PR TITLE
Add error popover on execution state change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,6 +607,7 @@ Any field can be keyframed via Theatre.js. Changes in timeline propagate through
 8. **Testing is expected** - Add tests for new features and changes to critical components
 9. **Document edge cases** - Users may not expect implementation-specific behavior
 10. **Keep PRs focused** - Split large changes into reviewable chunks when possible
+11. **Use inline comments** - Prefer `//` style comments over JSDoc-style `/** */` block comments
 
 ---
 

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -200,6 +200,36 @@
   fill: var(--tooltip-background-color);
 }
 
+.errorTooltipContent {
+  background: var(--node-execution-error-color, #ef4444);
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  max-width: 300px;
+  z-index: var(--z-index-menu);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  animation-duration: 200ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+}
+
+.errorTooltipContent[data-state='delayed-open'][data-side='top'],
+.errorTooltipContent[data-state='instant-open'][data-side='top'] {
+  animation-name: slideDownAndFade;
+}
+
+@keyframes slideDownAndFade {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .headerActions {
   display: flex;
   gap: 5px;


### PR DESCRIPTION
#### Background

When an operator has an error, the error indicator (red triangle) appears immediately but the error message was only visible on hover. This change adds a popover that automatically shows the error message if the error persists for 5 seconds, giving users time to fix transient errors while still surfacing persistent issues.

#### Change List
- Add ErrorIndicator component with delayed popover (5s delay, 4s auto-dismiss)
- Hovering immediately shows the popover and disables timers
- Add errorTooltipContent CSS styles for the popover
- Add inline comment style guideline to AGENTS.md