### PR TITLE
test: Add tests for Theatre.js cold prism fix

### DIFF
--- a/noodles-editor/src/noodles/__tests__/theatre-bindings.test.ts
+++ b/noodles-editor/src/noodles/__tests__/theatre-bindings.test.ts
@@ -826,4 +826,66 @@ describe('theatre-bindings', () => {
       cleanup?.()
     })
   })
+
+  describe('cold prism fix', () => {
+    it('should not produce cold prism warnings during field updates', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn')
+
+      const numberField = createField(
+        NumberField,
+        10,
+        { min: 0, max: 100, step: 1 },
+        '/test-op',
+        'value'
+      )
+
+      const mockOp = {
+        id: '/test-op',
+        inputs: { value: numberField },
+        outputs: {},
+        locked: { value: false },
+      } as any
+
+      const cleanup = bindOperatorToTheatre(mockOp, testSheet)
+
+      numberField.setValue(50)
+      numberField.setValue(75)
+      numberField.setValue(100)
+
+      const coldPrismWarnings = consoleWarnSpy.mock.calls.filter(call =>
+        String(call[0]).includes('cold prism')
+      )
+      expect(coldPrismWarnings).toHaveLength(0)
+
+      cleanup?.()
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should not produce cold prism warnings with color field conversions', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn')
+
+      const colorField = new ColorField('#00ff00')
+      colorField.pathToProps = ['/test-op', 'par', 'color']
+
+      const mockOp = {
+        id: '/test-op',
+        inputs: { color: colorField },
+        outputs: {},
+        locked: { value: false },
+      } as any
+
+      const cleanup = bindOperatorToTheatre(mockOp, testSheet)
+
+      colorField.setValue('#ff0000')
+      colorField.setValue('#0000ff')
+
+      const coldPrismWarnings = consoleWarnSpy.mock.calls.filter(call =>
+        String(call[0]).includes('cold prism')
+      )
+      expect(coldPrismWarnings).toHaveLength(0)
+
+      cleanup?.()
+      consoleWarnSpy.mockRestore()
+    })
+  })
 })

--- a/noodles-editor/src/render/renderer.test.ts
+++ b/noodles-editor/src/render/renderer.test.ts
@@ -2,21 +2,9 @@ import { renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { useRenderer } from './renderer'
 
-// Mock Theatre.js functions
-vi.mock('@theatre/core', async () => {
-  const actual = await vi.importActual('@theatre/core')
-  return {
-    ...actual,
-    val: vi.fn((pointer: any) => {
-      // Return the mocked value from the pointer
-      return pointer?._mockValue ?? 10
-    }),
-    onChange: vi.fn(() => {
-      // Return a no-op unsubscribe function
-      return () => {}
-    }),
-  }
-})
+vi.mock('@theatre/react', () => ({
+  useVal: vi.fn((pointer: any) => pointer?._mockValue ?? 10),
+}))
 
 describe('useRenderer', () => {
   it('handles cancellation of the file save dialog', async () => {


### PR DESCRIPTION
#### Background

Follow-up to PR #258 which fixed the Theatre.js 'prism.effect() does not run in cold prisms' warning. This PR adds tests to ensure the fix continues working correctly.

#### Change List

- Add tests in `theatre-bindings.test.ts` verifying the subscription ordering fix
- Add new `theatre-useval.test.tsx` testing `useVal` integration with sheet objects
- Update `renderer.test.ts` mock from `@theatre/core` val/onChange to `@theatre/react` useVal