### PR TITLE
fix: Poor performance when dragging from layer/deck output ports

### DIFF
--- a/noodles-editor/src/noodles/utils/can-connect.test.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.test.ts
@@ -132,12 +132,19 @@ describe('CanConnect', () => {
     )
   })
 
-  it('fast-rejects heavy types connecting to incompatible types', () => {
+  it('fast-rejects heavy values connecting to incompatible types', () => {
     const layerField = new LayerField()
     const numberField = new NumberField(5)
     const stringField = new StringField('test')
 
-    // Heavy types should be rejected fast without running expensive Zod validation
+    // Set a value with accessor functions (like real layer props)
+    layerField.next({
+      type: 'ScatterplotLayer',
+      data: [],
+      getPosition: (_d: unknown) => [0, 0], // Accessor function makes it "heavy"
+    })
+
+    // Heavy values should be rejected fast without running expensive Zod validation
     expect(canConnect(layerField, numberField), 'LayerField cannot connect to NumberField').toBe(
       false
     )
@@ -146,28 +153,90 @@ describe('CanConnect', () => {
     )
   })
 
-  it('allows heavy types to connect to flexible targets', () => {
+  it('allows heavy values to connect to flexible targets', () => {
     const layerField = new LayerField()
     const dataField = new DataField()
     const unknownField = new UnknownField()
 
-    // Heavy types can connect to DataField (accepts anything)
+    // Set a value with accessor functions
+    layerField.next({
+      type: 'ScatterplotLayer',
+      getPosition: (_d: unknown) => [0, 0],
+    })
+
+    // Heavy values can connect to DataField (accepts anything)
     expect(canConnect(layerField, dataField), 'LayerField can connect to DataField').toBe(true)
 
-    // Heavy types can connect to UnknownField
+    // Heavy values can connect to UnknownField
     expect(canConnect(layerField, unknownField), 'LayerField can connect to UnknownField').toBe(
       true
     )
   })
 
-  it('allows heavy types to connect to same type', () => {
+  it('allows heavy values to connect to same type', () => {
     const layerField1 = new LayerField()
     const layerField2 = new LayerField()
 
-    // Give the source field a valid value that matches LayerField schema
-    layerField1.next({ type: 'ScatterplotLayer', data: [] })
+    // Give the source field a valid value with accessor functions
+    layerField1.next({
+      type: 'ScatterplotLayer',
+      data: [],
+      getPosition: (_d: unknown) => [0, 0],
+    })
 
     expect(canConnect(layerField1, layerField2), 'LayerField can connect to LayerField').toBe(true)
+  })
+
+  it('does not fast-reject non-heavy values', () => {
+    const layerField = new LayerField()
+    const numberField = new NumberField(5)
+
+    // Set a value WITHOUT functions - should go through normal Zod validation
+    layerField.next({ type: 'ScatterplotLayer', data: [] })
+
+    // This will fail Zod validation (not fast path) because the value doesn't have functions
+    // but the schema mismatch will still cause rejection
+    expect(canConnect(layerField, numberField), 'Non-heavy LayerField rejected by Zod').toBe(false)
+  })
+
+  it('fast-rejects values with large nested arrays', () => {
+    const layerField = new LayerField()
+    const numberField = new NumberField(5)
+
+    // Create a value with large nested data array (like visualization with 100k+ rows)
+    const largeData = Array.from({ length: 2000 }, (_, i) => ({ id: i, value: i * 2 }))
+    layerField.next({
+      type: 'ScatterplotLayer',
+      data: largeData, // Large array makes it heavy
+    })
+
+    // Should be rejected fast without running expensive Zod validation
+    expect(canConnect(layerField, numberField), 'LayerField with large data cannot connect').toBe(
+      false
+    )
+  })
+
+  it('fast-rejects values with nested functions', () => {
+    const dataField = new DataField()
+    const numberField = new NumberField(5)
+
+    // Nested structure like visualization: { deckProps: { layers: [{ getPosition: ... }] } }
+    dataField.next({
+      deckProps: {
+        layers: [
+          {
+            type: 'ScatterplotLayer',
+            getPosition: (_d: unknown) => [0, 0], // Nested function
+          },
+        ],
+      },
+    })
+
+    // Should be rejected fast by detecting nested function
+    expect(
+      canConnect(dataField, numberField),
+      'DataField with nested functions cannot connect'
+    ).toBe(false)
   })
 })
 

--- a/noodles-editor/src/noodles/utils/can-connect.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.ts
@@ -6,9 +6,36 @@ export type ConnectionValidationResult = {
   error?: string
 }
 
-// Field types that contain large/complex objects and can only connect to themselves or flexible types
-// These are expensive to validate with Zod, so we short-circuit obvious mismatches
-const HEAVY_TYPES = new Set(['layer', 'visualization', 'view', 'effect', 'widget', 'extension'])
+// Detect values that are expensive to validate with Zod (large objects with functions or class instances)
+// These values would cause performance issues if passed through safeParse for every connection check
+function isHeavyValue(value: unknown, depth = 0): boolean {
+  if (value == null || typeof value !== 'object') return false
+
+  // Class instance check (e.g., View instances have custom prototypes)
+  const proto = Object.getPrototypeOf(value)
+  if (proto !== Object.prototype && proto !== Array.prototype && proto !== null) {
+    return true
+  }
+
+  // Check for large arrays (e.g., visualization with 100k+ data rows)
+  if (Array.isArray(value) && value.length > 1000) {
+    return true
+  }
+
+  // Only check one level deep to avoid expensive traversal
+  if (depth === 0) {
+    for (const val of Object.values(value as object)) {
+      // Has function properties (e.g., Layer props have accessor functions)
+      if (typeof val === 'function') return true
+      // Check nested objects/arrays one level deep
+      if (typeof val === 'object' && val !== null && isHeavyValue(val, depth + 1)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
 
 // Format a Zod issue into a human-readable message
 // The error callback in safeParse overrides issue.message, so we construct messages from properties
@@ -75,12 +102,11 @@ export function canConnect(from: Field, to: Field): boolean {
     return true
   }
 
-  const fromType = (from.constructor as typeof Field).type
-  const toType = (to.constructor as typeof Field).type
-
-  // Fast path: heavy types (layer, visualization, etc.) can only connect to same type or flexible types
-  // This avoids running Zod validation on large objects when the result is obviously false
-  if (HEAVY_TYPES.has(fromType)) {
+  // Fast path: skip Zod for heavy values (objects with functions or class instances)
+  // These are expensive to validate and can only connect to same type or flexible types
+  if (isHeavyValue(from.value)) {
+    const fromType = (from.constructor as typeof Field).type
+    const toType = (to.constructor as typeof Field).type
     const isFlexibleTarget = to instanceof UnknownField || to instanceof DataField
     if (fromType !== toType && !isFlexibleTarget) {
       return false


### PR DESCRIPTION
## Summary
- Remove `reportInput: true` from Zod `safeParse` in `validateConnection()` - fixes UI hang
- Add runtime value detection to skip Zod for heavy values - fixes performance regression
- Replace hardcoded `HEAVY_TYPES` list with automatic detection

## Root Cause
The issue was introduced by the combination of:

1. **"Dim unconnectable nodes during connection drag" (#250)** - Added exhaustive compatibility checking that calls `canConnect()` for every operator/field combination on drag start
2. **`reportInput: true` in `safeParse()`** - Original code that tells Zod to include the input value in error objects
3. **Large output values** - Layer/deck outputs contain massive objects after execution

Before #250, `canConnect()` was only called when completing a drag to a specific target. Most connections were valid, so validation succeeded without error formatting.

After #250, `canConnect()` runs for every possible connection on drag start. Most checks fail (incompatible types), and each failure triggered Zod to `JSON.stringify` the large layer/deck value for error reporting → `RangeError: Invalid string length` and UI hang.

## Solution

### Fix 1: Remove `reportInput: true`
The `reportInput` data wasn't actually used in our error messages - `formatZodIssue()` only uses issue properties like `expected`/`received`, not the raw input. Removing it prevents the stringify attempt.

### Fix 2: Runtime heavy value detection
Instead of maintaining a hardcoded `HEAVY_TYPES` list, detect heavy values at runtime by checking for:
- **Class instances** - Custom prototypes (e.g., View instances)
- **Function properties** - Accessor functions like `getPosition: (d) => [...]` in layer props
- **Large arrays** - Arrays with >1000 items (e.g., visualization with 100k+ data rows)
- **Nested checks** - Checks one level deep to catch nested functions and large arrays

This automatically handles any future field types without needing to update a list.

```typescript
function isHeavyValue(value: unknown, depth = 0): boolean {
  // Class instance check
  const proto = Object.getPrototypeOf(value)
  if (proto !== Object.prototype && proto !== Array.prototype) return true

  // Large array check (visualization with 100k+ rows)
  if (Array.isArray(value) && value.length > 1000) return true

  // Check one level deep for functions and heavy nested structures
  if (depth === 0) {
    for (const val of Object.values(value)) {
      if (typeof val === 'function') return true
      if (typeof val === 'object' && val !== null && isHeavyValue(val, depth + 1)) {
        return true
      }
    }
  }
  return false
}
```

## Test plan
- [ ] Open a project with executed layer/deck operators
- [ ] Click and drag from a layer output port - should no longer hang
- [ ] Drag from visualization output with 100k+ data rows - should be fast
- [ ] Verify edge connections still work correctly
- [ ] Verify incompatible connection errors still display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)