### PR TITLE
fix: Navigate to /projects route when opening user projects from any route

### DIFF
--- a/noodles-editor/src/noodles/components/project-not-found-dialog.tsx
+++ b/noodles-editor/src/noodles/components/project-not-found-dialog.tsx
@@ -29,7 +29,7 @@ export const ProjectNotFoundDialog = ({
   const [error, setError] = useState<string | null>(null)
   const [isLocating, setIsLocating] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
-  const { setCurrentDirectory } = useFileSystemStore()
+  const { setCurrentDirectory, setActiveStorageType } = useFileSystemStore()
 
   const onLocateFolder = useCallback(async () => {
     setIsLocating(true)
@@ -51,6 +51,7 @@ export const ProjectNotFoundDialog = ({
         try {
           const project = await migrateProject(result.data.projectData)
           setCurrentDirectory(result.data.directoryHandle, projectName)
+          setActiveStorageType('fileSystemAccess')
           onProjectLoaded(project, projectName)
           onClose()
         } catch (error) {
@@ -71,7 +72,7 @@ export const ProjectNotFoundDialog = ({
     } finally {
       setIsLocating(false)
     }
-  }, [projectName, onProjectLoaded, onClose, setCurrentDirectory])
+  }, [projectName, onProjectLoaded, onClose, setCurrentDirectory, setActiveStorageType])
 
   const onImport = useCallback(async () => {
     setIsImporting(true)

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -622,7 +622,7 @@ export function getNoodles(): Visualization {
   // Use useRenderSettings() hook to read them
 
   const loadProjectFile = useCallback(
-    (project: NoodlesProjectJSON, name?: string) => {
+    (project: NoodlesProjectJSON, name?: string, targetRoutePrefix?: string) => {
       const { nodes, edges, viewport, timeline, editorSettings, apiKeys } = project
 
       // Mark that we've programmatically loading this project BEFORE any state changes
@@ -661,7 +661,8 @@ export function getNoodles(): Visualization {
 
       // Update URL query parameter with project name
       if (name) {
-        navigate(`${routePrefix}/${name ?? ''}`, { replace: true })
+        const effectiveRoutePrefix = targetRoutePrefix ?? routePrefix
+        navigate(`${effectiveRoutePrefix}/${name}`, { replace: true })
       }
 
       // Clear unsaved changes flag when loading a project
@@ -1054,11 +1055,13 @@ export function getNoodles(): Visualization {
       // Cache the directory handle
       await directoryHandleCache.cacheHandle(directoryName, directoryHandle, directoryHandle.name)
 
-      // Update store with directory handle
+      // Update store with directory handle and storage type
       setCurrentDirectory(directoryHandle, directoryName)
+      setActiveStorageType('fileSystemAccess')
 
       // Load the project directly (already in memory, no need to reload from disk)
-      loadProjectFile(starterProject, directoryName)
+      // Always navigate to /projects since this is a user project
+      loadProjectFile(starterProject, directoryName, '/projects')
 
       analytics.track('project_created', { method: 'new' })
     } catch (error) {
@@ -1068,7 +1071,7 @@ export function getNoodles(): Visualization {
       }
       console.error('Failed to create new project:', error)
     }
-  }, [setCurrentDirectory, loadProjectFile])
+  }, [setCurrentDirectory, setActiveStorageType, loadProjectFile])
 
   const onImport = useCallback(async () => {
     try {
@@ -1202,11 +1205,13 @@ export function getNoodles(): Visualization {
       // Cache the directory handle
       await directoryHandleCache.cacheHandle(directoryName, directoryHandle, directoryHandle.name)
 
-      // Update store with directory handle
+      // Update store with directory handle and storage type
       setCurrentDirectory(directoryHandle, directoryName)
+      setActiveStorageType('fileSystemAccess')
 
       // Load the project directly (already in memory, no need to reload from disk)
-      loadProjectFile(projectData, directoryName)
+      // Always navigate to /projects since this is a user project
+      loadProjectFile(projectData, directoryName, '/projects')
 
       analytics.track('project_imported', { format: isZip ? 'zip' : 'json' })
     } catch (error) {
@@ -1216,7 +1221,7 @@ export function getNoodles(): Visualization {
       }
       console.error('Failed to import project:', error)
     }
-  }, [setCurrentDirectory, loadProjectFile])
+  }, [setCurrentDirectory, setActiveStorageType, loadProjectFile])
 
   // Handlers for ExampleNotFoundDialog
   const onBrowseExamples = useCallback(() => {
@@ -1238,12 +1243,12 @@ export function getNoodles(): Visualization {
         let finalProjectName: string
 
         if (projectName) {
-          // Load project by name (for recent projects and OPFS list)
-          // Cache-aware: load will prompt user if project directory not cached for fileSystemAccess
+          // Load project by name (for recent projects)
+          // Recent projects from directoryHandleCache are always fileSystemAccess
           finalProjectName = projectName
-          result = await load(storageType, projectName)
+          result = await load('fileSystemAccess', projectName)
         } else {
-          // Show the native folder picker
+          // Show the native folder picker (File System Access API)
           const projectDirectory = await selectDirectory()
           finalProjectName = projectDirectory.name
 
@@ -1255,18 +1260,24 @@ export function getNoodles(): Visualization {
           )
 
           // Load project from the selected directory
-          result = await load(storageType, projectDirectory)
+          result = await load('fileSystemAccess', projectDirectory)
         }
 
         if (result.success) {
           const project = await migrateProject(result.data.projectData)
-          loadProjectFile(project, finalProjectName)
+          // Always navigate to /projects since this is a user project
+          loadProjectFile(project, finalProjectName, '/projects')
           // Update store with directory handle returned from load
           setCurrentDirectory(result.data.directoryHandle, finalProjectName)
-          analytics.track('project_opened', { storageType })
+          // Set storage type to fileSystemAccess since we used File System Access API
+          setActiveStorageType('fileSystemAccess')
+          analytics.track('project_opened', { storageType: 'fileSystemAccess' })
         } else {
           setError(result.error)
-          analytics.track('project_open_failed', { storageType, error: 'load_error' })
+          analytics.track('project_open_failed', {
+            storageType: 'fileSystemAccess',
+            error: 'load_error',
+          })
         }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
@@ -1284,12 +1295,12 @@ export function getNoodles(): Visualization {
           originalError: error,
         })
         analytics.track('project_open_failed', {
-          storageType,
+          storageType: 'fileSystemAccess',
           error: projectName ? 'migration_error' : 'unknown',
         })
       }
     },
-    [storageType, loadProjectFile, setCurrentDirectory, setError]
+    [loadProjectFile, setCurrentDirectory, setActiveStorageType, setError]
   )
 
   const flowGraph = theatreReady && (
@@ -1337,7 +1348,8 @@ export function getNoodles(): Visualization {
           projectName={projectName || ''}
           open={showProjectNotFoundDialog}
           onProjectLoaded={(project, name) => {
-            loadProjectFile(project, name)
+            // Always navigate to /projects since this is a user project
+            loadProjectFile(project, name, '/projects')
             setShowProjectNotFoundDialog(false)
           }}
           onNewProject={onNewProject}


### PR DESCRIPTION
## Summary

- Fix incorrect routing when opening user projects from `/examples` route
- Ensure storage type is correctly set to `fileSystemAccess` when opening recent projects
- Add missing `setActiveStorageType` call after successful project open

## Root Cause Analysis

### Problem 1: Wrong route navigation

When opening a recent project, creating a new project, or importing a project while on an `/examples` route, the app would incorrectly navigate to `/examples/project-name` instead of `/projects/project-name`.

**Root cause:** The `loadProjectFile` function used the URL-derived `routePrefix` to navigate:

```javascript
const routePrefix = location.startsWith('/projects/') ? '/projects' : '/examples'
// ...
navigate(`${routePrefix}/${name}`, { replace: true })
```

User projects should always be on the `/projects` route regardless of the current URL.

**Fix:** Added a `targetRoutePrefix` parameter to `loadProjectFile` that allows callers to explicitly specify the route, overriding the URL-derived prefix.

### Problem 2: Wrong storage type used

The `onOpen` callback used the reactive `storageType` from the Zustand store, which could be `'publicFolder'` if currently viewing an example. This caused the `load()` function to attempt loading with the wrong storage backend.

**Root cause:** Recent projects from `directoryHandleCache` are **always** File System Access API projects by design—OPFS projects don't use this cache mechanism. The code incorrectly assumed the store's `storageType` was relevant.

**Fix:** Hardcode `'fileSystemAccess'` in `onOpen` since:
1. Recent projects come from `directoryHandleCache`
2. `directoryHandleCache` only stores `FileSystemDirectoryHandle` objects (File System Access API)
3. The folder picker also uses File System Access API

Note from @chrisgervang: We can extend this to include OPFS projects in the near future. `onOpen` would configure for project's storage type

### Problem 3: Storage type state not updated

After successfully opening a project via `onOpen`, the `setActiveStorageType` call was missing, leaving the store in an inconsistent state.

**Fix:** Added `setActiveStorageType('fileSystemAccess')` after successful project load.

## Test plan

- [x] Open an example (e.g., `/examples/nyc-taxis`)
- [x] From File menu, click "Open Recent" and select a user project
- [x] Verify URL changes to `/projects/project-name` (not `/examples/project-name`)
- [x] Verify project loads correctly with working `@/` asset paths
- [x] Create a new project from `/examples` route, verify it navigates to `/projects`
- [ ] Import a project from `/examples` route, verify it navigates to `/projects` (cant test, was broken in prod: see #293)

🤖 Generated with [Claude Code](https://claude.com/claude-code)