### PR TITLE
hotfix: Prevent UI hang when dragging from layer/deck output ports

### DIFF
--- a/noodles-editor/src/noodles/utils/can-connect.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.ts
@@ -37,7 +37,6 @@ export function validateConnection(from: Field, to: Field): ConnectionValidation
   // rather than just the value
   const schema = to instanceof ListField ? to.schema.unwrap() : to.schema
   const result = schema.safeParse(from.value, {
-    reportInput: true,
     error: _iss => from.pathToProps.join('.'),
   })
   if (!result.success) {


### PR DESCRIPTION
## Repro

https://github.com/user-attachments/assets/c1921c86-c0dc-422c-bca8-3a823521014a

## Summary
- Remove `reportInput: true` from Zod safeParse in canConnect validation to prevent UI hang

## Problem
The app was hanging when trying to drag connections from layer output and deck output ports. The hang occurred during the `mousedown` event on an output port, just before rendering an edge, with an app hang on layer ops and an `Uncaught RangeError: Invalid string length` error on deck ops.

## Root Cause Analysis
The issue was introduced by the combination of:

1. **"Dim unconnectable nodes during connection drag" (#250)** - Added exhaustive compatibility checking that calls `canConnect()` for every operator/field combination on drag start
2. **`reportInput: true` in `safeParse()`** - Original code that tells Zod to include the input value in error objects
3. **Large output values** - Layer/deck outputs contain massive objects after execution

Before #250, `canConnect()` was only called when completing a drag to a specific target. Most connections were valid, so validation succeeded without error formatting.

After #250, `canConnect()` runs for every possible connection on drag start. Most checks fail (incompatible types), and each failure triggered Zod to `JSON.stringify` the large layer/deck value for error reporting → `RangeError: Invalid string length` and UI hang.

## Solution
Remove the `reportInput: true` option from the `safeParse()` call in `can-connect.ts`. This single-line change:
- Prevents the hang by avoiding stringification of large objects
- Maintains all validation functionality
- Still provides field path via the error callback for debugging

## Testing
Tested dragging from layer and deck output ports with large datasets - no major hang occurs and connections work normally, but some poor performance was noticed.

## Related Work
See #274 for performance optimization work that adds fast pre-checks for heavy field types to further improve drag performance with large objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)