### PR TITLE
Reset deploy timeout to default. Max is 10 minutes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -90,5 +90,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          timeout: 1200000 # 20 minutes (default is 10 min, sometimes exceeded due to 62MB artifact)


### PR DESCRIPTION
Silence warning (i.e. https://github.com/joby-aviation/noodles.gl/actions/runs/21193965578)