### PR TITLE
fix: Pass PostHog API key to GitHub Actions build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Build all for GitHub Pages
         run: yarn build:all
+        env:
+          VITE_POSTHOG_API_KEY: ${{ secrets.VITE_POSTHOG_API_KEY }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
The VITE_POSTHOG_API_KEY environment variable was not available during production builds, preventing PostHog initialization in deployed versions.

This PR adds the secret to the GitHub Actions deploy workflow so analytics can function properly after adding the VITE_POSTHOG_API_KEY secret to the repository.

**To use this PR:**
1. Add VITE_POSTHOG_API_KEY as a GitHub repository secret with your PostHog project key
2. Merge this PR
3. Re-deploy to GitHub Pages