### PR TITLE
feat(TextLayerOp): add depthTest and depthWriteEnabled parameters

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4074,6 +4074,8 @@ export class TextLayerOp extends Operator<TextLayerOp> {
       extensions: new ListField(new ExtensionField(), { showByDefault: false }),
       parameters: new CompoundPropsField(
         {
+          depthTest: new BooleanField(true),
+          depthWriteEnabled: new BooleanField(true),
           cullMode: new StringLiteralField('none', {
             values: ['none', 'back', 'front'],
           }),


### PR DESCRIPTION
## Summary
- Add WebGL depth buffer parameters to TextLayerOp for better control over text rendering in 3D scenes

### New parameters:
- `depthTest`: Enable/disable depth testing (default: true)
- `depthWriteEnabled`: Enable/disable depth buffer writes (default: true)

## Motivation
These parameters are useful when rendering text on GlobeView or in scenes with overlapping 3D elements where depth ordering matters.

## Test plan
- [ ] Verify parameters appear in TextLayerOp node
- [ ] Test with GlobeView to confirm proper text rendering
- [ ] Test toggling depthTest off for overlay text effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)