### PR TITLE
feat(operators): add IconClusterLayerOp for Supercluster-based clustering

### DIFF
--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -44,6 +44,7 @@ export const categories = {
     'H3HexagonLayer',
     'HeatmapLayer',
     'HexagonLayer',
+    'IconClusterLayer',
     'IconLayer',
     'LineLayer',
     'MVTLayer',

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4158,6 +4158,91 @@ export class IconLayerOp extends Operator<IconLayerOp> {
   }
 }
 
+/**
+ * IconClusterLayerOp - Supercluster-based point clustering with globe visibility support
+ *
+ * This operator creates an IconClusterLayer that:
+ * - Uses Supercluster for efficient point clustering
+ * - Supports dynamic clustering (re-clusters based on visible points)
+ * - Has built-in globe visibility constraints (opacity fading for back-of-globe)
+ * - Renders clusters as circles with count labels, individual points when unclustered
+ *
+ * Note: Requires IconClusterLayer to be registered in deck.gl's layer registry.
+ */
+interface IconClusterLayerProps extends LayerProps {
+  data: unknown[]
+  getPosition?: ((d: unknown) => [number, number]) | [number, number]
+  getPointId?: ((d: unknown) => string | number) | string | number
+  clusterRadius?: number
+  clusterMaxZoom?: number
+  clusterFillColor?: [number, number, number, number]
+  clusterTextColor?: [number, number, number, number]
+  clusterRadiusScale?: number
+  clusterRadiusMinPixels?: number
+  clusterRadiusMaxPixels?: number
+  pointFillColor?: [number, number, number, number]
+  pointRadiusMinPixels?: number
+  pointRadiusMaxPixels?: number
+  fontFamily?: string
+  fontWeight?: string
+  sizeScale?: number
+  dynamicClustering?: boolean
+  sizeByCount?: boolean
+}
+
+export class IconClusterLayerOp extends Operator<IconClusterLayerOp> {
+  static displayName = 'IconClusterLayer'
+  static description =
+    'Cluster points using Supercluster with globe visibility support. Renders clusters as circles with counts.'
+  static cacheable = false
+  createInputs() {
+    return {
+      data: new DataField(),
+      visible: new BooleanField(true),
+      opacity: new NumberField(1, { min: 0, max: 1, step: 0.01 }),
+      getPosition: new Point3DField([0, 0, 0], { returnType: 'tuple', accessor: true }),
+      // Clustering configuration
+      clusterRadius: new NumberField(80, { min: 1, max: 500 }),
+      clusterMaxZoom: new NumberField(16, { min: 0, max: 24 }),
+      dynamicClustering: new BooleanField(false),
+      sizeByCount: new BooleanField(false),
+      // Cluster circle styling
+      clusterFillColor: new ColorField('#3366cc', { transform: hexToColor }),
+      clusterTextColor: new ColorField('#ffffff', { transform: hexToColor }),
+      clusterRadiusMinPixels: new NumberField(20, { min: 1, max: 200 }),
+      clusterRadiusMaxPixels: new NumberField(100, { min: 1, max: 500 }),
+      // Individual point styling
+      pointFillColor: new ColorField('#ff8c00', { transform: hexToColor }),
+      pointRadiusMinPixels: new NumberField(8, { min: 1, max: 100 }),
+      pointRadiusMaxPixels: new NumberField(20, { min: 1, max: 200 }),
+      // Text styling
+      fontFamily: new StringField('Monaco, monospace'),
+      fontWeight: new StringField('bold'),
+      clusterTextSize: new NumberField(16, { min: 1, max: 100 }),
+      // Parameters for WebGL settings
+      parameters: new CompoundPropsField({
+        depthTest: new BooleanField(true),
+        cull: new BooleanField(true),
+      }),
+      extensions: new ListField(new ExtensionField()),
+    }
+  }
+  createOutputs() {
+    return {
+      layer: new LayerField<IconClusterLayerProps>(),
+    }
+  }
+  execute(props: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    const layer = {
+      ...parseLayerProps<IconClusterLayerProps>(props as Parameters<typeof parseLayerProps>[0]),
+      type: 'IconClusterLayer' as const,
+      id: this.id,
+      updateTriggers: gatherTriggers(this.inputs, props),
+    }
+    return { layer }
+  }
+}
+
 export class ScenegraphLayerOp extends Operator<ScenegraphLayerOp> {
   static displayName = 'ScenegraphLayer'
   static description = 'Render a 3D model on the map'
@@ -6440,6 +6525,7 @@ export const opTypes = {
   HexagonLayerOp,
   HSLOp,
   HueSaturationExtensionOp,
+  IconClusterLayerOp,
   IconLayerOp,
   JSONOp,
   KmlToGeoJsonOp,


### PR DESCRIPTION
## Summary
Add a new IconClusterLayerOp that provides efficient point clustering using Supercluster.

### Features:
- Supercluster-based clustering algorithm
- Dynamic clustering (re-clusters based on visible points)
- Globe visibility support (opacity fading for back-of-globe)
- Configurable cluster styling (fill color, text color, radius)
- Configurable point styling for unclustered items
- Text label customization (font family, weight, size)
- WebGL parameters for depth testing

### Props:
- clusterRadius: Clustering radius in pixels (default: 80)
- clusterMaxZoom: Max zoom level for clustering (default: 16)
- dynamicClustering: Re-cluster on viewport change
- sizeByCount: Scale cluster size by point count
- Styling props for clusters and individual points

## Note
This operator requires a compatible clustering layer to be registered in deck.gl layer registry. 

**WIP**: Planning to update this to use deck.gl-community/layers GlobalClusterLayer for broader compatibility.

## Test plan
- [ ] Verify operator appears in Layers category
- [ ] Test clustering with sample point data
- [ ] Test on GlobeView for back-of-globe handling
- [ ] Test dynamic clustering toggle