### PR TITLE
fix: Exclude light and sky from MapLibre props

### DIFF
--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -197,6 +197,8 @@ export default function TimelineEditor() {
     },
   }
 
+  // Destructure light and sky since they're applied imperatively via setLight/setSky
+  const { light, sky, ...basemapProps } = visualization.mapProps ?? {}
   const mapProps: MapProps = {
     interactive: false,
     antialias: true,
@@ -206,17 +208,14 @@ export default function TimelineEditor() {
       mapRef.current = map
       redraw()
     },
-    ...visualization.mapProps,
-    maxPitch: Math.min(visualization.mapProps?.maxPitch ?? 85, 85),
+    ...basemapProps,
+    maxPitch: Math.min(basemapProps?.maxPitch ?? 85, 85),
   }
 
   // Apply light and sky settings imperatively to avoid style reloading
   useEffect(() => {
     const map = mapRef.current
     if (!map || !map.isStyleLoaded()) return
-
-    const light = visualization.mapProps?.light
-    const sky = visualization.mapProps?.sky
 
     // Note: light settings only apply to globe projection
     if (light) {
@@ -239,7 +238,7 @@ export default function TimelineEditor() {
       // Disable sky - requires MapLibre GL JS 4.6.0+
       map.setSky(undefined)
     }
-  }, [visualization.mapProps?.light, visualization.mapProps?.sky])
+  }, [light, sky])
 
   // Expose deck.gl canvas and instance for Claude AI visual debugging
   useEffect(() => {


### PR DESCRIPTION
#### Background

MapLibre GL was receiving untransformed noodles field names (skyHorizonBlend, azimuthal, polar) as props when spreading visualization.mapProps into the Map component, causing "unknown property" errors in the console.

#### Change List

- Destructure `light` and `sky` from `visualization.mapProps` before spreading into `<ReactMapGL>`
- Use the destructured variables in the useEffect dependency array
- These properties are already handled imperatively via `setLight()` and `setSky()` with proper MapLibre property name transformations

🤖 Generated with [Claude Code](https://claude.com/claude-code)