### PR TITLE
refactor(examples): migrate external-control to ES modules

### DIFF
--- a/examples/external-control/create-pipeline.js
+++ b/examples/external-control/create-pipeline.js
@@ -15,7 +15,7 @@
  */
 
 // Import the client (in a real scenario, this would be from npm package)
-const { NoodlesClient } = require('../../noodles-editor/src/external-control/client')
+import { NoodlesClient } from '../../noodles-editor/src/external-control/client.js'
 
 async function main() {
   // Create client instance

--- a/examples/external-control/mcp-proxy.js
+++ b/examples/external-control/mcp-proxy.js
@@ -21,8 +21,8 @@
 //    http://localhost:5173/examples/nyc-taxis?externalControl=true
 // 3. The proxy will connect automatically when Claude Desktop starts
 
-const WebSocket = require('ws')
-const readline = require('readline')
+import { WebSocketServer, WebSocket } from 'ws'
+import readline from 'readline'
 
 // Configuration
 const CONFIG = {
@@ -453,7 +453,7 @@ function handleBrowserMessage(data) {
 
 // Start WebSocket server for browser connections
 function startWebSocketServer() {
-  wsServer = new WebSocket.Server({ port: CONFIG.wsPort })
+  wsServer = new WebSocketServer({ port: CONFIG.wsPort })
 
   wsServer.on('listening', () => {
     log(`WebSocket server listening on ws://${CONFIG.wsHost}:${CONFIG.wsPort}`)

--- a/examples/external-control/package.json
+++ b/examples/external-control/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Examples for controlling Noodles externally via WebSocket and MCP",
   "private": true,
+  "type": "module",
   "scripts": {
     "server": "node server-example.js",
     "mcp-proxy": "node mcp-proxy.js",

--- a/examples/external-control/server-example.js
+++ b/examples/external-control/server-example.js
@@ -8,20 +8,20 @@
  * External Tool <-> This Server <-> Noodles Browser App
  *
  * Usage:
- * 1. Install dependencies: npm install ws
+ * 1. Install dependencies: yarn install
  * 2. Run server: node server-example.js
  * 3. Open Noodles with external control enabled
  * 4. Connect external tools to this server
  */
 
-const WebSocket = require('ws')
+import { WebSocketServer, WebSocket } from 'ws'
 
 const PORT = 8765
 const clients = new Set()
 const noodlesConnections = new Set()
 
 // Create WebSocket server
-const wss = new WebSocket.Server({
+const wss = new WebSocketServer({
   port: PORT,
   clientTracking: true,
 })


### PR DESCRIPTION
## Summary
- Add `"type": "module"` to `examples/external-control/package.json`
- Convert `require()` to ES module imports in example scripts
- Update `WebSocket.Server` to `WebSocketServer` named import
- Update install commands from npm to yarn

Split out from #297 per reviewer request.

## Test plan
- [ ] Run `node examples/external-control/server-example.js` - verify it starts
- [ ] Run `node examples/external-control/create-pipeline.js` - verify imports resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)