### PR TITLE
feat: Add createFromSQL query parameter for projects

### DIFF
--- a/noodles-editor/src/noodles/__tests__/create-from-sql-integration.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/create-from-sql-integration.test.tsx
@@ -1,7 +1,7 @@
-import { describe, expect, it, beforeEach } from 'vitest'
-import { createProjectFromSQL } from '../utils/create-from-sql'
-import { transformGraph } from '../transform-graph'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { getOpStore } from '../store'
+import { transformGraph } from '../transform-graph'
+import { createProjectFromSQL } from '../utils/create-from-sql'
 
 describe('createFromSQL integration', () => {
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe('createFromSQL integration', () => {
     const operators = transformGraph({ nodes: project.nodes, edges: project.edges })
 
     // Find DuckDBOp
-    const duckDbOp = operators.find((op) => op.constructor.name === 'DuckDbOp')
+    const duckDbOp = operators.find(op => op.constructor.name === 'DuckDbOp')
     expect(duckDbOp).toBeDefined()
 
     // Should have the SQL query
@@ -41,7 +41,7 @@ describe('createFromSQL integration', () => {
     const operators = transformGraph({ nodes: project.nodes, edges: project.edges })
 
     // Check for complete pipeline
-    const opTypes = operators.map((op) => op.constructor.name)
+    const opTypes = operators.map(op => op.constructor.name)
     expect(opTypes).toContain('DuckDbOp')
     expect(opTypes).toContain('ScatterplotLayerOp')
     expect(opTypes).toContain('AccessorOp')
@@ -56,7 +56,7 @@ describe('createFromSQL integration', () => {
     const operators = transformGraph({ nodes: project.nodes, edges: project.edges })
 
     // Find ScatterplotLayer
-    const scatterplotOp = operators.find((op) => op.constructor.name === 'ScatterplotLayerOp')
+    const scatterplotOp = operators.find(op => op.constructor.name === 'ScatterplotLayerOp')
     expect(scatterplotOp).toBeDefined()
 
     // Check that data input is connected
@@ -82,7 +82,7 @@ describe('createFromSQL integration', () => {
     const operators = transformGraph({ nodes: project.nodes, edges: project.edges })
 
     // Find DeckRenderer
-    const deckOp = operators.find((op) => op.constructor.name === 'DeckRendererOp')
+    const deckOp = operators.find(op => op.constructor.name === 'DeckRendererOp')
     expect(deckOp).toBeDefined()
 
     // Layers field should be connected
@@ -98,7 +98,7 @@ describe('createFromSQL integration', () => {
     const operators = transformGraph({ nodes: project.nodes, edges: project.edges })
 
     // Find OutOp
-    const outOp = operators.find((op) => op.constructor.name === 'OutOp')
+    const outOp = operators.find(op => op.constructor.name === 'OutOp')
     expect(outOp).toBeDefined()
 
     // Vis field should be connected
@@ -114,17 +114,17 @@ describe('createFromSQL integration', () => {
     const operators = transformGraph({ nodes: project.nodes, edges: project.edges })
 
     // Find accessor operators
-    const accessors = operators.filter((op) => op.constructor.name === 'AccessorOp')
+    const accessors = operators.filter(op => op.constructor.name === 'AccessorOp')
     expect(accessors.length).toBeGreaterThanOrEqual(2)
 
     // Check position accessor
-    const positionAccessor = accessors.find((op) => op.id === '/position')
+    const positionAccessor = accessors.find(op => op.id === '/position')
     expect(positionAccessor).toBeDefined()
     expect(positionAccessor?.inputs.expression.value).toContain('lng')
     expect(positionAccessor?.inputs.expression.value).toContain('lat')
 
     // Check color accessor
-    const colorAccessor = accessors.find((op) => op.id === '/color')
+    const colorAccessor = accessors.find(op => op.id === '/color')
     expect(colorAccessor).toBeDefined()
     expect(colorAccessor?.inputs.expression.value).toBe('[255, 100, 100]')
   })
@@ -136,10 +136,10 @@ describe('createFromSQL integration', () => {
     const operators = transformGraph({ nodes: project.nodes, edges: project.edges })
 
     // Find key operators by ID
-    const duckDbOp = operators.find((op) => op.id === '/query')
-    const scatterplotOp = operators.find((op) => op.id === '/points')
-    const positionAccessor = operators.find((op) => op.id === '/position')
-    const colorAccessor = operators.find((op) => op.id === '/color')
+    const duckDbOp = operators.find(op => op.id === '/query')
+    const scatterplotOp = operators.find(op => op.id === '/points')
+    const positionAccessor = operators.find(op => op.id === '/position')
+    const colorAccessor = operators.find(op => op.id === '/color')
 
     expect(duckDbOp).toBeDefined()
     expect(scatterplotOp).toBeDefined()
@@ -154,11 +154,11 @@ describe('createFromSQL integration', () => {
     const operators = transformGraph({ nodes: project.nodes, edges: project.edges })
 
     // Should include MaplibreBasemap from base template
-    const maplibreOp = operators.find((op) => op.constructor.name === 'MaplibreBasemapOp')
+    const maplibreOp = operators.find(op => op.constructor.name === 'MaplibreBasemapOp')
     expect(maplibreOp).toBeDefined()
 
     // Check basemap is connected to DeckRenderer
-    const deckOp = operators.find((op) => op.constructor.name === 'DeckRendererOp')
+    const deckOp = operators.find(op => op.constructor.name === 'DeckRendererOp')
     expect(deckOp).toBeDefined()
     expect(deckOp?.inputs.basemap.subscriptions.size).toBeGreaterThan(0)
   })

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -68,6 +68,7 @@ import { getOp, getOpStore, getUIStore, useNestingStore, useUIStore } from './st
 import { bindOperatorToTheatre, cleanupRemovedOperators } from './theatre-bindings'
 import { transformGraph } from './transform-graph'
 import { canConnect } from './utils/can-connect'
+import { createProjectFromSQL, validateSQL } from './utils/create-from-sql'
 import { directoryHandleCache } from './utils/directory-handle-cache'
 import {
   fileExists,
@@ -88,7 +89,6 @@ import {
   serializeNodes,
 } from './utils/serialization'
 import { calculateViewerPosition } from './utils/viewer-position'
-import { createProjectFromSQL, validateSQL } from './utils/create-from-sql'
 
 /*
  * CSS Architecture:
@@ -1092,7 +1092,9 @@ export function getNoodles(): Visualization {
       // Always navigate to /projects since this is a user project
       loadProjectFile(projectToCreate, directoryName, '/projects')
 
-      analytics.track('project_created', { method: sqlParam && validateSQL(sqlParam).valid ? 'createFromSQL' : 'new' })
+      analytics.track('project_created', {
+        method: sqlParam && validateSQL(sqlParam).valid ? 'createFromSQL' : 'new',
+      })
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         // User cancelled the picker

--- a/noodles-editor/src/noodles/utils/create-from-sql.test.ts
+++ b/noodles-editor/src/noodles/utils/create-from-sql.test.ts
@@ -12,7 +12,7 @@ describe('createProjectFromSQL', () => {
     expect(project.edges).toBeDefined()
 
     // Check for required nodes
-    const nodeTypes = project.nodes.map((n) => n.type)
+    const nodeTypes = project.nodes.map(n => n.type)
     expect(nodeTypes).toContain('DuckDbOp')
     expect(nodeTypes).toContain('ScatterplotLayerOp')
     expect(nodeTypes).toContain('AccessorOp')
@@ -20,7 +20,7 @@ describe('createProjectFromSQL', () => {
     expect(nodeTypes).toContain('OutOp')
 
     // Check DuckDB node has SQL
-    const duckDbNode = project.nodes.find((n) => n.type === 'DuckDbOp')
+    const duckDbNode = project.nodes.find(n => n.type === 'DuckDbOp')
     expect(duckDbNode?.data.inputs.query).toBe(sql)
   })
 
@@ -29,7 +29,7 @@ describe('createProjectFromSQL', () => {
     const project = createProjectFromSQL({ sql })
 
     // Check key connections exist
-    const edgeIds = project.edges.map((e) => e.id)
+    const edgeIds = project.edges.map(e => e.id)
     expect(edgeIds).toContain('/query.out.data->/points.par.data')
     expect(edgeIds).toContain('/position.out.accessor->/points.par.getPosition')
     expect(edgeIds).toContain('/color.out.accessor->/points.par.getFillColor')
@@ -41,16 +41,16 @@ describe('createProjectFromSQL', () => {
     const sql = 'SELECT * FROM data'
     const project = createProjectFromSQL({ sql })
 
-    const accessorNodes = project.nodes.filter((n) => n.type === 'AccessorOp')
+    const accessorNodes = project.nodes.filter(n => n.type === 'AccessorOp')
     expect(accessorNodes.length).toBeGreaterThanOrEqual(2)
 
     // Check position accessor
-    const positionNode = accessorNodes.find((n) => n.id === '/position')
+    const positionNode = accessorNodes.find(n => n.id === '/position')
     expect(positionNode).toBeDefined()
     expect(positionNode?.data.inputs.expression).toContain('lng')
 
     // Check color accessor
-    const colorNode = accessorNodes.find((n) => n.id === '/color')
+    const colorNode = accessorNodes.find(n => n.id === '/color')
     expect(colorNode).toBeDefined()
     expect(colorNode?.data.inputs.expression).toBe('[255, 100, 100]')
   })
@@ -59,9 +59,9 @@ describe('createProjectFromSQL', () => {
     const sql = 'SELECT * FROM data'
     const project = createProjectFromSQL({ sql })
 
-    const duckDbNode = project.nodes.find((n) => n.type === 'DuckDbOp')
-    const scatterplotNode = project.nodes.find((n) => n.type === 'ScatterplotLayerOp')
-    const deckNode = project.nodes.find((n) => n.type === 'DeckRendererOp')
+    const duckDbNode = project.nodes.find(n => n.type === 'DuckDbOp')
+    const scatterplotNode = project.nodes.find(n => n.type === 'ScatterplotLayerOp')
+    const deckNode = project.nodes.find(n => n.type === 'DeckRendererOp')
 
     // Verify left-to-right positioning (x coordinates increase)
     expect(duckDbNode?.position.x).toBeLessThan(scatterplotNode?.position.x || 0)
@@ -73,11 +73,11 @@ describe('createProjectFromSQL', () => {
     const project = createProjectFromSQL({ sql })
 
     // Should have MaplibreBasemapOp from base template
-    const nodeTypes = project.nodes.map((n) => n.type)
+    const nodeTypes = project.nodes.map(n => n.type)
     expect(nodeTypes).toContain('MaplibreBasemapOp')
 
     // Should have base edge from maplibre to deck
-    const edgeIds = project.edges.map((e) => e.id)
+    const edgeIds = project.edges.map(e => e.id)
     expect(edgeIds).toContain('/maplibre-basemap.out.maplibre->/deck.par.basemap')
   })
 
@@ -85,7 +85,7 @@ describe('createProjectFromSQL', () => {
     const sql = 'SELECT * FROM data'
     const project = createProjectFromSQL({ sql })
 
-    const scatterplotNode = project.nodes.find((n) => n.type === 'ScatterplotLayerOp')
+    const scatterplotNode = project.nodes.find(n => n.type === 'ScatterplotLayerOp')
     expect(scatterplotNode).toBeDefined()
     expect(scatterplotNode?.data.inputs.opacity).toBe(0.8)
     expect(scatterplotNode?.data.inputs.getRadius).toBe(50)

--- a/noodles-editor/src/noodles/utils/create-from-sql.ts
+++ b/noodles-editor/src/noodles/utils/create-from-sql.ts
@@ -1,6 +1,6 @@
+import newProjectJSON from '../new.json'
 import type { NoodlesProjectJSON } from './serialization'
 import { NOODLES_VERSION } from './serialization'
-import newProjectJSON from '../new.json'
 
 export interface CreateFromSQLOptions {
   sql: string
@@ -65,7 +65,7 @@ export function createProjectFromSQL({ sql }: CreateFromSQLOptions): NoodlesProj
   }
 
   // Update deck renderer position for better layout
-  const updatedNodes = baseProject.nodes.map((node) => {
+  const updatedNodes = baseProject.nodes.map(node => {
     if (node.type === 'DeckRendererOp') {
       return { ...node, position: { x: 1000, y: 200 } }
     }
@@ -76,7 +76,13 @@ export function createProjectFromSQL({ sql }: CreateFromSQLOptions): NoodlesProj
   })
 
   // Add new nodes
-  const nodes = [...updatedNodes, duckDbNode, positionAccessorNode, colorAccessorNode, scatterplotNode]
+  const nodes = [
+    ...updatedNodes,
+    duckDbNode,
+    positionAccessorNode,
+    colorAccessorNode,
+    scatterplotNode,
+  ]
 
   // Create edges connecting the graph
   const newEdges = [


### PR DESCRIPTION
Add a new `createFromSQL` query parameter that creates a new project with a pre-configured DuckDBOp containing the SQL query from the parameter. The generated graph includes ScatterplotLayerOp, AccessorOps for position and color, and all standard rendering nodes.

Changes:
- Extract SQL validation and graph generation into pure function (create-from-sql.ts)
- Intercept at onNewProject() to check for and process createFromSQL parameter
- Remove query param from URL after project creation
- Add 16 unit tests for graph generation and SQL validation
- Add 9 integration tests verifying operator creation and connections
- Track analytics with method: 'createFromSQL'

All tests passing (25/25 ✓) and lint clean.