### PR TITLE
fix: prevent NumberField display reset during digit deletion

### DIFF
--- a/noodles-editor/src/noodles/components/field-components.test.tsx
+++ b/noodles-editor/src/noodles/components/field-components.test.tsx
@@ -963,3 +963,69 @@ describe('NumberFieldComponent edge cases', () => {
     expect(label).toBeInTheDocument()
   })
 })
+
+describe('NumberFieldComponent editing behavior', () => {
+  afterEach(() => {
+    cleanup()
+    clearOps()
+    vi.restoreAllMocks()
+  })
+
+  it('does not update field when intermediate edit produces a multi-character zero string', () => {
+    // Reproduces the bug: deleting "1" from "100" leaves "00" which parses to 0,
+    // but the field should stay at 100 until the user types a non-zero digit
+    const field = new NumberField(100)
+    render(<NumberFieldComponent id="test-field" field={field} disabled={false} />)
+
+    const input = screen.getByRole('spinbutton')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '00' } })
+
+    expect(field.value).toBe(100)
+  })
+
+  it('updates field to 0 when the user explicitly types a single "0"', () => {
+    const field = new NumberField(100)
+    render(<NumberFieldComponent id="test-field" field={field} disabled={false} />)
+
+    const input = screen.getByRole('spinbutton')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '0' } })
+
+    expect(field.value).toBe(0)
+  })
+
+  it('does not update field when input is cleared to empty string', () => {
+    const field = new NumberField(100)
+    render(<NumberFieldComponent id="test-field" field={field} disabled={false} />)
+
+    const input = screen.getByRole('spinbutton')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '' } })
+
+    expect(field.value).toBe(100)
+  })
+
+  it('does not update field for intermediate decimal zero strings like "0."', () => {
+    const field = new NumberField(100)
+    render(<NumberFieldComponent id="test-field" field={field} disabled={false} />)
+
+    const input = screen.getByRole('spinbutton')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '0.' } })
+
+    expect(field.value).toBe(100)
+  })
+
+  it('updates field once the user completes a decimal value starting with zero', () => {
+    const field = new NumberField(100)
+    render(<NumberFieldComponent id="test-field" field={field} disabled={false} />)
+
+    const input = screen.getByRole('spinbutton')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '0.' } })
+    fireEvent.change(input, { target: { value: '0.5' } })
+
+    expect(field.value).toBe(0.5)
+  })
+})

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -1086,7 +1086,7 @@ function DraggableNumberInput({
     (e: React.FormEvent<HTMLInputElement>) => {
       const newValue = e.currentTarget.value
       setDisplayValue(newValue)
-      if (newValue !== '') {
+      if (!(+newValue === 0 && newValue.length !== 1)) {
         onChange(+newValue)
       }
     },


### PR DESCRIPTION
#### Background

Editing NumberField values was broken when deleting digits. For example, changing 100 to 200 would fail because deleting the '1' leaves '00', which parses to 0, triggering a field update that reset the display mid-edit.

#### Change List
- Modified onChange condition in DraggableNumberInput to skip updates when parsed value is 0 but string length is not exactly 1
- This skips intermediate garbage states like '00', '0.', '' while still committing explicit '0' and completed decimals like '0.5'
- Preserves live updating, scrubbing, and timeline keyframe animations
- Added 5 tests covering the bug case, explicit zero, empty string, partial decimals, and completed decimals