### PR TITLE
Remove Cloudflare app SPA redirect rule

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,4 +1,0 @@
-# SPA routing for the app - redirect any /app/* path that's not a file to /app/index.html
-# Exclude index.html itself to avoid infinite loop
-/app/index.html  200
-/app/*  /app/index.html  200


### PR DESCRIPTION
#### Background

Cloudflare Pages rejected the existing /app redirects as invalid and looping. Our app works correctly without it so fine to remove