### PR TITLE
feat: show fully qualified handle names in property list connections

### DIFF
--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -598,7 +598,9 @@ export function NodeProperties({ node }: { node: NodeJSON<unknown> }) {
                           onDragEnd={e => handleDragEnd(e, input.name, incomers)}
                         >
                           {incomers.length > 1 && <div className={s.dragHandle} />}
-                          <div className={s.connectionSource}>{getBaseName(edge.source)}.{edge.sourceHandle}</div>
+                          <div className={s.connectionSource}>
+                            {getBaseName(edge.source)}.{edge.sourceHandle}
+                          </div>
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
## Background

When multiple nodes connect to a ListField input, the connection source display was ambiguous — it only showed the handle name (e.g., 'out.data' repeated multiple times).

## Change List

- Display fully qualified handle names in property list connections (e.g., 'SF.out.data', 'Dallas.out.data')
- Import and use getBaseName() utility to extract source node ID from edge source
- Updated node-properties.tsx to prepend source node name to handle display

Before:
<img width="580" height="280" alt="image" src="https://github.com/user-attachments/assets/4e2fe6ad-ab68-480b-acbc-164f91899bca" />

After:
<img width="556" height="322" alt="image" src="https://github.com/user-attachments/assets/9ed0d506-fa40-443e-8db5-63e5332508f3" />
