### PR TITLE
fix: enable layer reordering by fixing edge handle format matching

### DIFF
--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -340,7 +340,11 @@ export function NodeProperties({ node }: { node: NodeJSON<unknown> }) {
 
     setEdges(edges => {
       // Get all edges connected to this input
-      const relevantEdges = edges.filter(e => e.target === node.id && e.targetHandle === inputName)
+      const relevantEdges = edges.filter(
+        e =>
+          e.target === node.id &&
+          (e.targetHandle === inputName || e.targetHandle === `${IN_NS}.${inputName}`)
+      )
       if (relevantEdges.length < 2) return edges
 
       // Create new array with reordered edges

--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -170,6 +170,50 @@ describe('ListField', () => {
     field1.setValue(10)
     expect(listField.value).toEqual([10, 2])
   })
+
+  it('reorders inputs with reorderInputs', () => {
+    const field1 = new NumberField(1)
+    const field2 = new NumberField(2)
+    const field3 = new NumberField(3)
+    const listField = new ListField(new NumberField())
+
+    listField.addConnection('field-1', field1, 'value')
+    listField.addConnection('field-2', field2, 'value')
+    listField.addConnection('field-3', field3, 'value')
+
+    expect(listField.value).toEqual([1, 2, 3])
+
+    listField.reorderInputs(0, 2)
+    expect(listField.value).toEqual([2, 3, 1])
+
+    listField.reorderInputs(2, 0)
+    expect(listField.value).toEqual([1, 2, 3])
+
+    listField.reorderInputs(1, 2)
+    expect(listField.value).toEqual([1, 3, 2])
+  })
+
+  it('reorderInputs does nothing when fromIndex equals toIndex', () => {
+    const field1 = new NumberField(1)
+    const field2 = new NumberField(2)
+    const listField = new ListField(new NumberField())
+
+    listField.addConnection('field-1', field1, 'value')
+    listField.addConnection('field-2', field2, 'value')
+
+    listField.reorderInputs(0, 0)
+    expect(listField.value).toEqual([1, 2])
+  })
+
+  it('reorderInputs throws for out-of-bounds indices', () => {
+    const field1 = new NumberField(1)
+    const listField = new ListField(new NumberField())
+
+    listField.addConnection('field-1', field1, 'value')
+
+    expect(() => listField.reorderInputs(-1, 0)).toThrow()
+    expect(() => listField.reorderInputs(0, 5)).toThrow()
+  })
 })
 
 describe('JSONUrlField', () => {


### PR DESCRIPTION
The drag-to-reorder UI in node properties was broken for multi-input fields like layers. handleMoveConnection filtered edges by bare name (e.g., \"layers\") but edge targetHandle values include the namespace prefix (e.g., \"par.layers\"), causing relevantEdges to always be empty and the reorder handler to bail out.

Fixed by checking both bare and namespaced formats, matching the pattern already used by the incomers filter. This allows TextLayer and other layer connections to be dragged to control draw order.

Also added comprehensive tests for ListField.reorderInputs() covering forward/backward movement and edge cases.