### PR TITLE
feat: add /projects page with modal routes and File menu links

### DIFF
--- a/noodles-editor/src/app.tsx
+++ b/noodles-editor/src/app.tsx
@@ -2,10 +2,12 @@ import { Component, lazy, type ReactNode, Suspense } from 'react'
 import { Redirect, Route, Router, Switch, useRoute, useSearchParams } from 'wouter'
 import { AnalyticsConsentBanner } from './components/analytics-consent-banner'
 import { ExternalControlProvider } from './external-control'
+import { PageModal } from './page-modal'
 import TimelineEditor from './timeline-editor'
 
-// Lazy-load ExamplesPage to reduce main bundle size
+// Lazy-load page components to reduce main bundle size
 const ExamplesPage = lazy(() => import('./examples-page'))
+const ProjectsPage = lazy(() => import('./projects-page'))
 
 // Error boundary to catch analytics failures
 class AnalyticsErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
@@ -66,9 +68,20 @@ function App() {
 
         {/* Examples list page */}
         <Route path="/examples">
-          <Suspense fallback={<div>Loading...</div>}>
-            <ExamplesPage />
-          </Suspense>
+          <PageModal>
+            <Suspense fallback={<div>Loading...</div>}>
+              <ExamplesPage />
+            </Suspense>
+          </PageModal>
+        </Route>
+
+        {/* Projects list page */}
+        <Route path="/projects">
+          <PageModal>
+            <Suspense fallback={<div>Loading...</div>}>
+              <ProjectsPage />
+            </Suspense>
+          </PageModal>
         </Route>
 
         {/* Catch-all for root path, 404s, and redirects */}
@@ -114,9 +127,10 @@ function FallbackRoute() {
     return <Redirect to={`/examples/${projectParam}`} />
   }
 
-  // Default: navigate to /examples
-  console.log('Default redirect to /examples')
-  return <Redirect to="/examples" />
+  // Default: navigate to /projects in dev, /examples in prod
+  const defaultRoute = import.meta.env.DEV ? '/projects' : '/examples'
+  console.log('Default redirect to', defaultRoute)
+  return <Redirect to={defaultRoute} />
 }
 
 export default App

--- a/noodles-editor/src/noodles/components/top-menu-bar.tsx
+++ b/noodles-editor/src/noodles/components/top-menu-bar.tsx
@@ -2,6 +2,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { ChevronDownIcon, ExternalLinkIcon } from '@radix-ui/react-icons'
 import { useReactFlow } from '@xyflow/react'
 import { type RefObject, useCallback, useEffect, useMemo, useState } from 'react'
+import { useLocation } from 'wouter'
 import logoSvg from '/noodles-favicon.svg'
 import { SettingsDialog } from '../../components/settings-dialog'
 import { ExternalControlButton } from '../../external-control/components/external-control-button'
@@ -69,6 +70,7 @@ export function TopMenuBar({
 }: TopMenuBarProps) {
   const settingsDialogOpen = useUIStore(state => state.settingsDialogOpen)
   const setSettingsDialogOpen = useUIStore(state => state.setSettingsDialogOpen)
+  const [, navigate] = useLocation()
   const [recentProjects, setRecentProjects] = useState<string[]>([])
   const [showPointWizard, setShowPointWizard] = useState(false)
   const [showDataImporter, setShowDataImporter] = useState(false)
@@ -266,6 +268,13 @@ export function TopMenuBar({
                         </DropdownMenu.SubTrigger>
                         <DropdownMenu.Portal>
                           <DropdownMenu.SubContent className={s.dropdownContent} sideOffset={2}>
+                            <DropdownMenu.Item
+                              className={s.dropdownItem}
+                              onSelect={() => navigate('/projects')}
+                            >
+                              View Recent...
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Separator className={s.dropdownSeparator} />
                             {recentProjects.length === 0 ? (
                               <DropdownMenu.Item className={s.dropdownItem} disabled>
                                 No recent projects
@@ -284,6 +293,13 @@ export function TopMenuBar({
                           </DropdownMenu.SubContent>
                         </DropdownMenu.Portal>
                       </DropdownMenu.Sub>
+                      <DropdownMenu.Separator className={s.dropdownSeparator} />
+                      <DropdownMenu.Item
+                        className={s.dropdownItem}
+                        onSelect={() => navigate('/examples')}
+                      >
+                        Examples
+                      </DropdownMenu.Item>
                     </DropdownMenu.SubContent>
                   </DropdownMenu.Portal>
                 </DropdownMenu.Sub>

--- a/noodles-editor/src/page-modal.module.css
+++ b/noodles-editor/src/page-modal.module.css
@@ -1,0 +1,77 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 100;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: var(--color-bg-primary);
+  border-bottom: 1px solid var(--mauve-6);
+  z-index: 1;
+  gap: 1rem;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.navLink {
+  padding: 0.375rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  text-decoration: none;
+  color: var(--mauve-11);
+  transition: background 0.15s, color 0.15s;
+}
+
+.navLink:hover {
+  background: var(--mauve-4);
+  color: var(--mauve-12);
+}
+
+.navLinkActive {
+  background: var(--violet-3);
+  color: var(--violet-11);
+}
+
+.navLinkActive:hover {
+  background: var(--violet-4);
+  color: var(--violet-11);
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: var(--mauve-11);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+
+.closeButton:hover {
+  background: var(--mauve-4);
+  color: var(--mauve-12);
+}
+
+.body {
+  flex: 1;
+  background: var(--color-bg-primary);
+}

--- a/noodles-editor/src/page-modal.tsx
+++ b/noodles-editor/src/page-modal.tsx
@@ -1,0 +1,60 @@
+import { Cross2Icon } from '@radix-ui/react-icons'
+import { type ReactNode, useCallback, useEffect } from 'react'
+import { Link, useLocation } from 'wouter'
+import s from './page-modal.module.css'
+
+interface PageModalProps {
+  children: ReactNode
+}
+
+export function PageModal({ children }: PageModalProps) {
+  const [location, navigate] = useLocation()
+
+  const handleClose = useCallback(() => {
+    if (window.history.length > 1) {
+      window.history.back()
+    } else {
+      navigate('/')
+    }
+  }, [navigate])
+
+  // Close on Escape key
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [handleClose])
+
+  return (
+    <div className={s.overlay}>
+      <div className={s.header}>
+        <nav className={s.nav}>
+          <Link
+            href="/projects"
+            className={`${s.navLink} ${location === '/projects' ? s.navLinkActive : ''}`}
+          >
+            Projects
+          </Link>
+          <Link
+            href="/examples"
+            className={`${s.navLink} ${location === '/examples' ? s.navLinkActive : ''}`}
+          >
+            Examples
+          </Link>
+        </nav>
+        <button
+          type="button"
+          className={s.closeButton}
+          onClick={handleClose}
+          title="Close (Esc)"
+          aria-label="Close"
+        >
+          <Cross2Icon width={14} height={14} />
+        </button>
+      </div>
+      <div className={s.body}>{children}</div>
+    </div>
+  )
+}

--- a/noodles-editor/src/projects-page.tsx
+++ b/noodles-editor/src/projects-page.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useLocation } from 'wouter'
+import s from './examples-page.module.css'
+import { directoryHandleCache } from './noodles/utils/directory-handle-cache'
+import { checkFileSystemSupport, getOPFSRoot, selectDirectory } from './noodles/utils/filesystem'
+
+interface UserProject {
+  name: string
+  path: string
+  storageType: 'fileSystemAccess' | 'opfs'
+  cachedAt?: number
+}
+
+export default function ProjectsPage() {
+  const [projects, setProjects] = useState<UserProject[]>([])
+  const [loading, setLoading] = useState(true)
+  const [, navigate] = useLocation()
+  const support = checkFileSystemSupport()
+
+  const loadProjects = useCallback(async () => {
+    setLoading(true)
+    const result: UserProject[] = []
+
+    // Load fileSystemAccess handles from IndexedDB cache
+    if (support.fileSystemAccess) {
+      try {
+        const handles = await directoryHandleCache.getAllCachedHandles()
+        for (const entry of handles) {
+          result.push({
+            name: entry.handle.name,
+            path: `/projects/${entry.projectName}`,
+            storageType: 'fileSystemAccess',
+            cachedAt: entry.cachedAt,
+          })
+        }
+      } catch (err) {
+        console.error('Failed to load cached directory handles', err)
+      }
+    }
+
+    // Load OPFS projects by iterating root
+    if (support.opfs) {
+      try {
+        const root = await getOPFSRoot()
+        for await (const entry of root.values()) {
+          if (entry.kind === 'directory') {
+            // Only include dirs not already in fileSystemAccess list
+            const alreadyListed = result.some(p => p.name === entry.name)
+            if (!alreadyListed) {
+              // Check if this directory has a noodles.json
+              try {
+                const dir = await root.getDirectoryHandle(entry.name)
+                dir.getFileHandle('noodles.json')
+                result.push({
+                  name: entry.name,
+                  path: `/projects/${entry.name}`,
+                  storageType: 'opfs',
+                })
+              } catch {
+                // No noodles.json — skip this directory
+              }
+            }
+          }
+        }
+      } catch (err) {
+        console.error('Failed to enumerate OPFS projects', err)
+      }
+    }
+
+    setProjects(result)
+    setLoading(false)
+  }, [support.fileSystemAccess, support.opfs])
+
+  useEffect(() => {
+    loadProjects()
+  }, [loadProjects])
+
+  async function handleOpenFolder() {
+    try {
+      const handle = await selectDirectory()
+      await directoryHandleCache.cacheHandle(handle.name, handle, handle.name)
+      navigate(`/projects/${handle.name}`)
+    } catch {
+      // User cancelled or permission denied — ignore
+    }
+  }
+
+  function formatDate(timestamp?: number) {
+    if (!timestamp) return null
+    return new Date(timestamp).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
+
+  return (
+    <div className={s.examplesPage} data-testid="projects-page">
+      <h1>Projects</h1>
+      <p>Your saved projects from local folders and browser storage.</p>
+
+      {support.fileSystemAccess && (
+        <div style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
+          <button
+            type="button"
+            onClick={handleOpenFolder}
+            style={{
+              padding: '0.5rem 1.25rem',
+              borderRadius: '6px',
+              border: '1px solid var(--violet-7)',
+              background: 'var(--violet-3)',
+              color: 'var(--violet-11)',
+              cursor: 'pointer',
+              fontSize: '0.9rem',
+            }}
+          >
+            Open folder…
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <p style={{ textAlign: 'center', color: 'var(--mauve-11)' }}>Loading projects…</p>
+      ) : projects.length === 0 ? (
+        <div style={{ textAlign: 'center', color: 'var(--mauve-11)', marginTop: '3rem' }}>
+          <p>No projects found.</p>
+          {support.fileSystemAccess && (
+            <p>Use "Open folder…" to open a project from your file system.</p>
+          )}
+        </div>
+      ) : (
+        <div className={s.examplesGrid}>
+          {projects.map(project => (
+            <Link key={project.path} href={project.path} className={s.exampleCard}>
+              <h3>{project.name}</h3>
+              <p>
+                <span
+                  style={{
+                    display: 'inline-block',
+                    fontSize: '0.75rem',
+                    padding: '0.1rem 0.4rem',
+                    borderRadius: '3px',
+                    background: 'var(--mauve-4)',
+                    color: 'var(--mauve-11)',
+                    marginRight: '0.5rem',
+                  }}
+                >
+                  {project.storageType === 'opfs' ? 'OPFS' : 'Local folder'}
+                </span>
+                {project.cachedAt && (
+                  <span style={{ fontSize: '0.85rem' }}>{formatDate(project.cachedAt)}</span>
+                )}
+              </p>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Add a new /projects route that displays user-saved projects from FileSystemAccess API handles (cached in IndexedDB) and OPFS directories. Both /projects and /examples routes now render as full-screen modal overlays over the app with a close button and navigation strip, allowing users to easily dismiss them via ESC key, back button, or the X icon. Add "View Recent..." menu item to File > Open Recent that navigates to /projects, and add "Examples" link to File menu. In dev mode, the app defaults to /projects; in prod mode, it defaults to /examples.