### PR TITLE
fix: prevent stale frame from being encoded at render start

### DIFF
--- a/noodles-editor/src/render/renderer.ts
+++ b/noodles-editor/src/render/renderer.ts
@@ -211,6 +211,20 @@ export const useRenderer = ({
         mapRecorder?.reader?.releaseLock()
       }
 
+      // Seek to start frame and wait for render to complete before capturing.
+      // This prevents stale frames from being encoded if the playhead was
+      // at a different position when render started.
+      const warmupSimTime = startFrame / fps
+      getTimelineStore().setPosition(warmupSimTime)
+      redraw()
+
+      const warmupResult = await canvasFrameReady()
+      if (warmupResult?.error) {
+        debugRender('Error during render warmup:', warmupResult.error)
+        setIsRendering(false)
+        return
+      }
+
       for (; i < endFrame + 1; i++) {
         const simTime = i / fps
         getTimelineStore().setPosition(simTime)


### PR DESCRIPTION
#### Background

When starting a video render with the timeline playhead at a non-zero position, the first captured frame could contain stale visual content from the previous playhead position. This happened because the capture loop set the playhead position but the canvas buffer still contained content from before the render completed.

#### Change List

- Add warmup render cycle before capture loop to ensure canvas contains correct frame content
- Seek to start frame, tick Theatre.js, and wait for render completion before entering capture loop
- Remove outdated TODO comment about first frame capture