### PR TITLE
Revert: Disable source maps for prod builds

### DIFF
--- a/noodles-editor/vite.config.js
+++ b/noodles-editor/vite.config.js
@@ -101,11 +101,6 @@ export default defineConfig(({ mode }) => {
 
   return {
     base: mode === 'development' ? '/' : '/app/',
-    build: {
-      // CF_PAGES=1 is set automatically by Cloudflare Pages; disable sourcemaps there
-      // due to the 25 MiB per-file limit. GitHub Pages has no such limit.
-      sourcemap: !process.env.CF_PAGES,
-    },
     server: {
       open: true,
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "install:app": "(cd noodles-editor && yarn install)",
     "install:all": "yarn install:website && yarn install:app",
     "build:app": "(cd noodles-editor && yarn build)",
-    "build:app:cloudflare": "(cd noodles-editor && yarn generate:context && NODE_OPTIONS='--max-old-space-size=8192' VITE_USE_CDN_DUCKDB=true yarn build)",
+    "build:app:cloudflare": "(cd noodles-editor && yarn generate:context && VITE_USE_CDN_DUCKDB=true yarn build)",
     "build:website": "(cd website && yarn build)",
     "build:all": "yarn build:app && yarn build:website && mkdir -p website/build/app && cp -r noodles-editor/dist/* website/build/app/",
     "build:all:cloudflare": "yarn build:website && yarn build:app:cloudflare && mkdir -p website/build/app && cp -r noodles-editor/dist/* website/build/app/",


### PR DESCRIPTION
#### Background
Source maps in production builds are causing deploy failures.

#### Change List
- Remove sourcemap configuration from vite.config.js that was conditionally enabling source maps based on CF_PAGES environment variable
- Remove NODE_OPTIONS memory flag from build:app:cloudflare script in package.json