### PR TITLE
fix: always use getJsDelivrBundles() for DuckDB WASM

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -1729,54 +1729,7 @@ export class FileOp extends Operator<FileOp> {
 }
 
 const duckDbInstance = (async () => {
-  // Use CDN bundles for Cloudflare Pages (which has a 25 MiB file size limit)
-  // Use local bundles for development and GitHub Actions (which can access local files)
-  let bundles: duckdb.DuckDBBundles
-
-  // Use import.meta.env directly in the condition for proper tree-shaking
-  if (import.meta.env.VITE_USE_CDN_DUCKDB === 'true') {
-    // jsdelivr CDN hosts the large WASM files externally
-    bundles = duckdb.getJsDelivrBundles()
-  } else {
-    // Dynamically import the WASM files only when not using CDN
-    // Vite will tree-shake this entire branch when VITE_USE_CDN_DUCKDB is 'true'
-    const [
-      duckdb_wasm,
-      mvp_worker,
-      duckdb_wasm_eh,
-      eh_worker,
-      duckdb_wasm_coi,
-      coi_worker,
-      duckdb_pthread_worker,
-    ] = await Promise.all([
-      import('@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url').then(m => m.default),
-      import('@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url').then(m => m.default),
-      import('@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url').then(m => m.default),
-      import('@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url').then(m => m.default),
-      import('@duckdb/duckdb-wasm/dist/duckdb-coi.wasm?url').then(m => m.default),
-      import('@duckdb/duckdb-wasm/dist/duckdb-browser-coi.worker.js?url').then(m => m.default),
-      import('@duckdb/duckdb-wasm/dist/duckdb-browser-coi.pthread.worker.js?url').then(
-        m => m.default
-      ),
-    ])
-
-    // Bundle the WASM files locally for environments that support it
-    bundles = {
-      mvp: {
-        mainModule: duckdb_wasm,
-        mainWorker: mvp_worker,
-      },
-      eh: {
-        mainModule: duckdb_wasm_eh,
-        mainWorker: eh_worker,
-      },
-      coi: {
-        mainModule: duckdb_wasm_coi,
-        mainWorker: coi_worker,
-        pthreadWorker: duckdb_pthread_worker,
-      },
-    }
-  }
+  const bundles = duckdb.getJsDelivrBundles()
 
   // Select a bundle based on browser checks
   const bundle = await duckdb.selectBundle(bundles)


### PR DESCRIPTION
## Problem

`operators.ts` loads all three DuckDB WASM bundles via Vite `?url` imports:

```ts
import('@duckdb/duckdb-wasm/dist/duckdb-coi.wasm?url').then(m => m.default),
// ... etc
```

This causes Vite to copy all WASM binaries into the build output. The COI bundle alone is **34 MB**, which exceeds Cloudflare Pages' hard 26.2 MB per-file limit and likely other static host limits too.

## Fix

DuckDB officially ships `getJsDelivrBundles()` for exactly this use case. It returns CDN URLs baked into the duckdb-wasm package at its own build time — version-correct, no `?url` imports, no WASM in the build output:

```ts
bundles = duckdb.getJsDelivrBundles();
```

This replaces the entire `Promise.all` of `?url` imports and the manual bundle construction.

cc @akre54

## Workaround

Currently working around this in NEW_HEAT with a Vite plugin that intercepts the `?url` imports at build time and substitutes jsDelivr CDN URLs. It works but is fragile (reads installed version from `node_modules`, depends on dev npm versions staying on the registry).

Closes #319