### PR TITLE
feat: add tree nav sidebar search and start collapsed

### DIFF
--- a/noodles-editor/src/noodles/components/node-tree-sidebar.module.css
+++ b/noodles-editor/src/noodles/components/node-tree-sidebar.module.css
@@ -1,7 +1,52 @@
 .treeContainer {
+  display: flex;
+  flex-direction: column;
   height: 100%;
+  overflow: hidden;
+}
+
+.treeList {
+  flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+.searchContainer {
+  position: relative;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.searchInput {
+  width: 100%;
+  background: var(--color-bg-base);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 4px 24px 4px 8px;
+  font-size: 12px;
+  color: var(--color-text-primary);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.searchInput:focus {
+  border-color: var(--color-text-accent);
+}
+
+.searchClear {
+  position: absolute;
+  right: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  font-size: 10px;
 }
 
 .treeItem {

--- a/noodles-editor/src/noodles/components/node-tree-sidebar.tsx
+++ b/noodles-editor/src/noodles/components/node-tree-sidebar.tsx
@@ -2,10 +2,10 @@ import * as Tooltip from '@radix-ui/react-tooltip'
 import studio from '@theatre/studio'
 import { useReactFlow } from '@xyflow/react'
 import cx from 'classnames'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { analytics } from '../../utils/analytics'
 import type { IOperator, Operator } from '../operators'
-import { getOpStore, hasOp, useNestingStore, useOperatorStore } from '../store'
+import { getOpStore, hasOp, useNestingStore, useOperatorStore, useUIStore } from '../store'
 import { generateQualifiedPath, getBaseName } from '../utils/path-utils'
 import { categories } from './categories'
 import s from './node-tree-sidebar.module.css'
@@ -326,9 +326,40 @@ export function NodeTreeSidebar({ updateOperatorId }: NodeTreeSidebarProps) {
   const operators = useOperatorStore(state => state.operators)
   const reactFlow = useReactFlow()
   const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set())
+  const [searchQuery, setSearchQuery] = useState('')
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const focusTrigger = useUIStore(state => state.sidebarSearchFocusTrigger)
+
+  // Focus search input whenever the trigger increments
+  useEffect(() => {
+    if (focusTrigger > 0) searchInputRef.current?.focus()
+  }, [focusTrigger])
 
   // Build tree from operators
   const tree = useMemo(() => buildTree(operators), [operators])
+
+  // Flat filtered list when searching
+  const filteredNodes = useMemo(() => {
+    if (!searchQuery.trim()) return null
+    const q = searchQuery.toLowerCase()
+    return Array.from(operators.values())
+      .filter(op => {
+        const name = getBaseName(op.id) ?? ''
+        const displayName = (op.constructor as typeof Operator).displayName
+        return name.toLowerCase().includes(q) || displayName.toLowerCase().includes(q)
+      })
+      .map(op => {
+        const displayName = (op.constructor as typeof Operator).displayName
+        return {
+          id: op.id,
+          name: getBaseName(op.id) ?? op.id,
+          displayName,
+          children: [],
+          depth: 1,
+        } satisfies TreeNode
+      })
+      .sort((a, b) => a.id.localeCompare(b.id))
+  }, [searchQuery, operators])
 
   // Get selected node IDs from React Flow (reactive)
   const nodes = reactFlow.getNodes()
@@ -427,21 +458,45 @@ export function NodeTreeSidebar({ updateOperatorId }: NodeTreeSidebarProps) {
     })
   }, [])
 
+  const renderNodes = filteredNodes ?? tree
+
   return (
     <div className={s.treeContainer}>
-      {tree.map(node => (
-        <TreeItem
-          key={node.id}
-          node={node}
-          selectedNodeIds={selectedNodeIds}
-          onSelect={handleSelect}
-          onNavigate={handleNavigate}
-          onNavigateInto={handleNavigateInto}
-          collapsedNodes={collapsedNodes}
-          onToggleCollapse={handleToggleCollapse}
-          updateOperatorId={updateOperatorId}
+      <div className={s.searchContainer}>
+        <input
+          ref={searchInputRef}
+          className={s.searchInput}
+          placeholder="Find node…"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Escape') {
+              setSearchQuery('')
+              searchInputRef.current?.blur()
+            }
+          }}
         />
-      ))}
+        {searchQuery && (
+          <button type="button" className={s.searchClear} onClick={() => setSearchQuery('')}>
+            <i className="pi pi-times" />
+          </button>
+        )}
+      </div>
+      <div className={s.treeList}>
+        {renderNodes.map(node => (
+          <TreeItem
+            key={node.id}
+            node={node}
+            selectedNodeIds={selectedNodeIds}
+            onSelect={handleSelect}
+            onNavigate={handleNavigate}
+            onNavigateInto={handleNavigateInto}
+            collapsedNodes={collapsedNodes}
+            onToggleCollapse={handleToggleCollapse}
+            updateOperatorId={updateOperatorId}
+          />
+        ))}
+      </div>
     </div>
   )
 }

--- a/noodles-editor/src/noodles/components/top-menu-bar.tsx
+++ b/noodles-editor/src/noodles/components/top-menu-bar.tsx
@@ -74,6 +74,8 @@ export function TopMenuBar({
 }: TopMenuBarProps) {
   const settingsDialogOpen = useUIStore(state => state.settingsDialogOpen)
   const setSettingsDialogOpen = useUIStore(state => state.setSettingsDialogOpen)
+  const setSidebarVisible = useUIStore(state => state.setSidebarVisible)
+  const triggerSidebarSearch = useUIStore(state => state.triggerSidebarSearch)
   const [, navigate] = useLocation()
   const [recentProjects, setRecentProjects] = useState<string[]>([])
   const [showPointWizard, setShowPointWizard] = useState(false)
@@ -111,12 +113,17 @@ export function TopMenuBar({
         e.preventDefault()
         onImport()
         analytics.track('keyboard_shortcut_used', { action: 'import' })
+      } else if (isMod && e.key === 'f') {
+        e.preventDefault()
+        setSidebarVisible(true)
+        triggerSidebarSearch()
+        analytics.track('keyboard_shortcut_used', { action: 'find' })
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [onSaveProject, onNewProject, onOpen, onImport])
+  }, [onSaveProject, onNewProject, onOpen, onImport, setSidebarVisible, triggerSidebarSearch])
 
   // Detect platform for keyboard shortcuts
   const isMac = useMemo(() => navigator.platform.toUpperCase().indexOf('MAC') >= 0, [])
@@ -352,6 +359,18 @@ export function TopMenuBar({
                       >
                         <span>Paste</span>
                         <span className={s.shortcut}>{mod}+V</span>
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Separator className={s.dropdownSeparator} />
+                      <DropdownMenu.Item
+                        className={s.dropdownItem}
+                        onSelect={() => {
+                          setSidebarVisible(true)
+                          triggerSidebarSearch()
+                          analytics.track('keyboard_shortcut_used', { action: 'find' })
+                        }}
+                      >
+                        <span>Find</span>
+                        <span className={s.shortcut}>{mod}+F</span>
                       </DropdownMenu.Item>
                     </DropdownMenu.SubContent>
                   </DropdownMenu.Portal>

--- a/noodles-editor/src/noodles/store.tsx
+++ b/noodles-editor/src/noodles/store.tsx
@@ -118,6 +118,8 @@ interface UIStoreState {
   setConnectionDragState: (state: ConnectionDragState | null) => void
   sidebarVisible: boolean
   setSidebarVisible: (visible: boolean) => void
+  sidebarSearchFocusTrigger: number
+  triggerSidebarSearch: () => void
   settingsDialogOpen: boolean
   setSettingsDialogOpen: (open: boolean) => void
 }
@@ -127,8 +129,11 @@ export const useUIStore = create<UIStoreState>(set => ({
   setHoveredOutputHandle: handle => set({ hoveredOutputHandle: handle }),
   connectionDragState: null,
   setConnectionDragState: state => set({ connectionDragState: state }),
-  sidebarVisible: true,
+  sidebarVisible: false,
   setSidebarVisible: visible => set({ sidebarVisible: visible }),
+  sidebarSearchFocusTrigger: 0,
+  triggerSidebarSearch: () =>
+    set(state => ({ sidebarSearchFocusTrigger: state.sidebarSearchFocusTrigger + 1 })),
   settingsDialogOpen: false,
   setSettingsDialogOpen: open => set({ settingsDialogOpen: open }),
 }))


### PR DESCRIPTION
## Summary

Sidebar now starts collapsed by default and includes a search feature to quickly find nodes.

## Change List
- Sidebar starts collapsed (sidebarVisible: false) on page load
- Add Cmd+F / Ctrl+F keyboard shortcut to open sidebar and focus search
- Add "Find" menu item to Edit menu with keyboard shortcut
- Search input filters nodes by name or operator type (case-insensitive)
- Search results display as flat list; press Escape to clear
- Normal hierarchical tree shown when search is empty
- Search box pinned at top while tree list scrolls below
- All comments inline style per user preferences
- Lint passes, existing tests not affected

🤖 Generated with Claude Code