### PR TITLE
feat: add wrangler configuration for Cloudflare Pages

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "noodles-gl"
+pages_build_output_dir = "./website/build"
+
+[build]
+command = "yarn install:all && yarn build:all:cloudflare"


### PR DESCRIPTION
#### Background

Add wrangler.toml configuration file to enable deployment to Cloudflare Pages.

#### Change List
- Add wrangler.toml with build command (yarn build:all:cloudflare) and output directory (website/build)
- Configuration specifies the combined build output: documentation at root, editor app at /app/