### PR TITLE
refactor: replace MapStyleOp with typeahead on MaplibreBasemapOp

### DIFF
--- a/noodles-editor/src/noodles/__migrations__/014-remove-map-style-op.test.ts
+++ b/noodles-editor/src/noodles/__migrations__/014-remove-map-style-op.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+import type { NoodlesProjectJSON } from '../utils/serialization'
+import { down, up } from './014-remove-map-style-op'
+
+const CARTO_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json'
+const CARTO_LIGHT = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'
+
+function makeProject(overrides: Partial<NoodlesProjectJSON> = {}): NoodlesProjectJSON {
+  return {
+    version: 13,
+    nodes: [],
+    edges: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+    timeline: {},
+    ...overrides,
+  }
+}
+
+describe('014-remove-map-style-op', () => {
+  it('inlines the map style value onto the connected MaplibreBasemapOp', async () => {
+    const project = makeProject({
+      nodes: [
+        {
+          id: '/map-style',
+          type: 'MapStyleOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: { mapStyle: CARTO_LIGHT } },
+        },
+        {
+          id: '/basemap',
+          type: 'MaplibreBasemapOp',
+          position: { x: 320, y: 0 },
+          data: { inputs: {} },
+        },
+      ],
+      edges: [
+        {
+          id: '/map-style.out.mapStyle->/basemap.par.mapStyle',
+          source: '/map-style',
+          target: '/basemap',
+          sourceHandle: 'out.mapStyle',
+          targetHandle: 'par.mapStyle',
+        },
+      ],
+    })
+
+    const migrated = await up(project)
+
+    expect(migrated.nodes).toHaveLength(1)
+    expect(migrated.nodes[0].type).toBe('MaplibreBasemapOp')
+    expect((migrated.nodes[0].data?.inputs as Record<string, unknown>).mapStyle).toBe(CARTO_LIGHT)
+    expect(migrated.edges).toHaveLength(0)
+  })
+
+  it('uses CARTO_DARK as fallback when MapStyleOp has no value', async () => {
+    const project = makeProject({
+      nodes: [
+        {
+          id: '/map-style',
+          type: 'MapStyleOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: {} },
+        },
+        {
+          id: '/basemap',
+          type: 'MaplibreBasemapOp',
+          position: { x: 320, y: 0 },
+          data: { inputs: {} },
+        },
+      ],
+      edges: [
+        {
+          id: '/map-style.out.mapStyle->/basemap.par.mapStyle',
+          source: '/map-style',
+          target: '/basemap',
+          sourceHandle: 'out.mapStyle',
+          targetHandle: 'par.mapStyle',
+        },
+      ],
+    })
+
+    const migrated = await up(project)
+    expect((migrated.nodes[0].data?.inputs as Record<string, unknown>).mapStyle).toBe(CARTO_DARK)
+  })
+
+  it('is a no-op when there are no MapStyleOp nodes', async () => {
+    const project = makeProject({
+      nodes: [
+        {
+          id: '/basemap',
+          type: 'MaplibreBasemapOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: { mapStyle: CARTO_LIGHT } },
+        },
+      ],
+      edges: [],
+    })
+
+    const migrated = await up(project)
+    expect(migrated).toBe(project)
+  })
+
+  it('removes a MapStyleOp that is not connected to anything', async () => {
+    const project = makeProject({
+      nodes: [
+        {
+          id: '/map-style',
+          type: 'MapStyleOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: { mapStyle: CARTO_LIGHT } },
+        },
+      ],
+      edges: [],
+    })
+
+    const migrated = await up(project)
+    expect(migrated.nodes).toHaveLength(0)
+  })
+
+  it('is reversible', async () => {
+    const original = makeProject({
+      nodes: [
+        {
+          id: '/map-style',
+          type: 'MapStyleOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: { mapStyle: CARTO_LIGHT } },
+        },
+        {
+          id: '/basemap',
+          type: 'MaplibreBasemapOp',
+          position: { x: 320, y: 0 },
+          data: { inputs: {} },
+        },
+      ],
+      edges: [
+        {
+          id: '/map-style.out.mapStyle->/basemap.par.mapStyle',
+          source: '/map-style',
+          target: '/basemap',
+          sourceHandle: 'out.mapStyle',
+          targetHandle: 'par.mapStyle',
+        },
+      ],
+    })
+
+    const migrated = await up(original)
+    const reverted = await down(migrated)
+
+    // MapStyleOp should be recreated with the correct value
+    const mapStyleNode = reverted.nodes.find(n => n.type === 'MapStyleOp')
+    expect(mapStyleNode).toBeDefined()
+    expect((mapStyleNode?.data?.inputs as Record<string, unknown>).mapStyle).toBe(CARTO_LIGHT)
+
+    // mapStyle should be removed from basemap inputs
+    const basemapNode = reverted.nodes.find(n => n.type === 'MaplibreBasemapOp')
+    expect((basemapNode?.data?.inputs as Record<string, unknown>).mapStyle).toBeUndefined()
+
+    // Edge should be recreated
+    expect(reverted.edges).toHaveLength(1)
+    expect(reverted.edges[0].sourceHandle).toBe('out.mapStyle')
+    expect(reverted.edges[0].targetHandle).toBe('par.mapStyle')
+  })
+
+  it('down does not recreate MapStyleOp when mapStyle is fed by an existing edge', async () => {
+    const project = makeProject({
+      nodes: [
+        {
+          id: '/basemap',
+          type: 'MaplibreBasemapOp',
+          position: { x: 320, y: 0 },
+          data: { inputs: {} },
+        },
+        {
+          id: '/custom-style',
+          type: 'StringOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: {} },
+        },
+      ],
+      edges: [
+        {
+          id: '/custom-style.out.value->/basemap.par.mapStyle',
+          source: '/custom-style',
+          target: '/basemap',
+          sourceHandle: 'out.value',
+          targetHandle: 'par.mapStyle',
+        },
+      ],
+    })
+
+    const reverted = await down(project)
+    expect(reverted.nodes.find(n => n.type === 'MapStyleOp')).toBeUndefined()
+    expect(reverted.edges).toHaveLength(1)
+  })
+})

--- a/noodles-editor/src/noodles/__migrations__/014-remove-map-style-op.ts
+++ b/noodles-editor/src/noodles/__migrations__/014-remove-map-style-op.ts
@@ -1,0 +1,113 @@
+// Migration to remove MapStyleOp nodes and inline their value onto connected
+// MaplibreBasemapOp inputs. The MapStyleOp was a pass-through node that only
+// existed to expose a preset map style URL as a string output.
+
+import type { NoodlesProjectJSON } from '../utils/serialization'
+
+const CARTO_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json'
+
+export async function up(project: NoodlesProjectJSON): Promise<NoodlesProjectJSON> {
+  const mapStyleNodes = project.nodes.filter(n => n.type === 'MapStyleOp')
+  if (mapStyleNodes.length === 0) return project
+
+  const mapStyleIds = new Set(mapStyleNodes.map(n => n.id))
+
+  // Build a map of mapStyleOpId -> the style URL value it held
+  const styleValues = new Map<string, string>()
+  for (const node of mapStyleNodes) {
+    const val = (node.data?.inputs as Record<string, unknown> | undefined)?.mapStyle
+    styleValues.set(node.id, typeof val === 'string' ? val : CARTO_DARK)
+  }
+
+  // Find edges from MapStyleOp.out.mapStyle -> MaplibreBasemapOp.par.mapStyle
+  // and record what value each target node should receive
+  const targetValues = new Map<string, string>()
+  for (const edge of project.edges) {
+    if (mapStyleIds.has(edge.source) && edge.sourceHandle === 'out.mapStyle') {
+      const styleUrl = styleValues.get(edge.source)
+      if (styleUrl !== undefined) {
+        targetValues.set(edge.target, styleUrl)
+      }
+    }
+  }
+
+  // Apply values to target nodes and remove MapStyleOp nodes + their edges
+  const nodes = project.nodes
+    .filter(n => !mapStyleIds.has(n.id))
+    .map(node => {
+      const val = targetValues.get(node.id)
+      if (val === undefined) return node
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          inputs: {
+            ...(node.data?.inputs as Record<string, unknown> | undefined),
+            mapStyle: val,
+          },
+        },
+      }
+    })
+
+  const edges = project.edges.filter(
+    e => !mapStyleIds.has(e.source) && !mapStyleIds.has(e.target)
+  )
+
+  return { ...project, nodes, edges }
+}
+
+export async function down(project: NoodlesProjectJSON): Promise<NoodlesProjectJSON> {
+  // For each MaplibreBasemapOp with a mapStyle input value and no incoming edge
+  // for par.mapStyle, recreate a MapStyleOp node and connecting edge
+  const connectedTargets = new Set(
+    project.edges
+      .filter(e => e.targetHandle === 'par.mapStyle')
+      .map(e => e.target)
+  )
+
+  const newNodes = [...project.nodes]
+  const newEdges = [...project.edges]
+
+  for (const node of project.nodes) {
+    if (node.type !== 'MaplibreBasemapOp') continue
+    if (connectedTargets.has(node.id)) continue
+
+    const val = (node.data?.inputs as Record<string, unknown> | undefined)?.mapStyle
+    if (typeof val !== 'string') continue
+
+    const mapStyleId = `${node.id}-map-style`
+    newNodes.push({
+      id: mapStyleId,
+      type: 'MapStyleOp',
+      position: { x: node.position.x - 320, y: node.position.y },
+      data: { inputs: { mapStyle: val } },
+    })
+
+    newEdges.push({
+      id: `${mapStyleId}.out.mapStyle->${node.id}.par.mapStyle`,
+      source: mapStyleId,
+      target: node.id,
+      sourceHandle: 'out.mapStyle',
+      targetHandle: 'par.mapStyle',
+    })
+  }
+
+  // Remove mapStyle from MaplibreBasemapOp inputs where we just created a MapStyleOp
+  const createdIds = new Set(newNodes.filter(n => n.type === 'MapStyleOp').map(n => n.id))
+  const targetIds = new Set(
+    newEdges
+      .filter(e => createdIds.has(e.source))
+      .map(e => e.target)
+  )
+
+  const nodes = newNodes.map(node => {
+    if (!targetIds.has(node.id)) return node
+    const { mapStyle: _, ...restInputs } = (node.data?.inputs as Record<string, unknown>) ?? {}
+    return {
+      ...node,
+      data: { ...node.data, inputs: restInputs },
+    }
+  })
+
+  return { ...project, nodes, edges: newEdges }
+}

--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -90,7 +90,6 @@ export const categories = {
     'Project',
     'Reroute',
     'Unproject',
-    'MapStyle',
   ],
   vector: ['CombineXY', 'CombineXYZ', 'SplitXY', 'SplitXYZ'],
   view: [

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -837,6 +837,7 @@ export function FileUrlFieldComponent({
         <div className={cx('p-inputgroup', field.accept ? s.fieldFileInputGroup : undefined)}>
           <InputText
             id={id}
+            list={field.suggestions.length > 0 ? `${id}-suggestions` : undefined}
             placeholder="https://"
             className={cx(s.fieldInput, field.accept ? s.fieldInputFileUrl : undefined)}
             value={value}
@@ -845,6 +846,13 @@ export function FileUrlFieldComponent({
             onChange={onChange}
             disabled={disabled}
           />
+          {field.suggestions.length > 0 && (
+            <datalist id={`${id}-suggestions`}>
+              {field.suggestions.map(({ value: val, label }) => (
+                <option key={val} value={val}>{label}</option>
+              ))}
+            </datalist>
+          )}
           {field.accept && (
             <Button
               icon="pi pi-upload"

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -725,6 +725,7 @@ export function FileUrlFieldComponent({
 }) {
   const [value, setValue] = useState(guardAccessorFallback(field.value))
   const { captureStart, commitChange } = usePropertyHistory()
+  const [suggestionsOpen, setSuggestionsOpen] = useState(false)
 
   useEffect(() => {
     const sub = field.subscribe(newVal => {
@@ -747,7 +748,23 @@ export function FileUrlFieldComponent({
       field.setValue(val)
     }
     commitChange('Change file')
+    // Delay closing so a suggestion click registers first
+    setTimeout(() => setSuggestionsOpen(false), 150)
   }
+
+  const onSuggestionSelect = (val: string) => {
+    captureStart()
+    field.setValue(val)
+    setValue(val)
+    commitChange('Change file')
+    setSuggestionsOpen(false)
+  }
+
+  const filteredSuggestions = field.suggestions.filter(
+    ({ value: v, label }) =>
+      v.toLowerCase().includes(value.toLowerCase()) ||
+      label.toLowerCase().includes(value.toLowerCase())
+  )
 
   const [replaceDialogOpen, setReplaceDialogOpen] = useState(false)
   const [pendingFile, setPendingFile] = useState<{ name: string; contents: Blob } | null>(null)
@@ -834,24 +851,33 @@ export function FileUrlFieldComponent({
         <label className={s.nodeFieldLabel} htmlFor={id}>
           {id}
         </label>
-        <div className={cx('p-inputgroup', s.fieldFileInputGroup)}>
+        <div className={cx('p-inputgroup', s.fieldFileInputGroup, s.fieldFileInputGroupSuggestions)}>
           <InputText
             id={id}
-            list={field.suggestions.length > 0 ? `${id}-suggestions` : undefined}
             placeholder="https://"
             className={cx(s.fieldInput, s.fieldInputFileUrl)}
             value={value}
-            onFocus={captureStart}
+            onFocus={() => { captureStart(); setSuggestionsOpen(true) }}
             onBlur={onBlur}
             onChange={onChange}
             disabled={disabled}
           />
-          {field.suggestions.length > 0 && (
-            <datalist id={`${id}-suggestions`}>
-              {field.suggestions.map(({ value: val, label }) => (
-                <option key={val} value={val}>{label}</option>
+          {field.suggestions.length > 0 && suggestionsOpen && filteredSuggestions.length > 0 && (
+            <ul className={s.fileUrlSuggestions}>
+              {filteredSuggestions.map(({ value: val, label }) => (
+                // biome-ignore lint/a11y/useSemanticElements: custom combobox option
+                <li
+                  key={val}
+                  role="option"
+                  aria-selected={val === value}
+                  className={cx(s.fileUrlSuggestion, { [s.fileUrlSuggestionActive]: val === value })}
+                  onMouseDown={() => onSuggestionSelect(val)}
+                >
+                  <span className={s.fileUrlSuggestionLabel}>{label}</span>
+                  <span className={s.fileUrlSuggestionUrl}>{val}</span>
+                </li>
               ))}
-            </datalist>
+            </ul>
           )}
           <Button
             icon="pi pi-upload"

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -261,16 +261,19 @@ export class StringField extends Field<z.ZodString> {
 
 type FileUrlFieldOptions = BaseFieldOptions & {
   accept?: string // e.g. '.glb,.gltf' — controls file picker filter and shows upload button
+  suggestions?: { value: string; label: string }[] // typeahead suggestions shown in input
 }
 
 export class FileUrlField extends Field<z.ZodString, FileUrlFieldOptions> {
   static type = 'file-url'
   static defaultValue = ''
   accept?: string
+  suggestions: { value: string; label: string }[]
 
   constructor(initialValue?: string, options?: Partial<FileUrlFieldOptions>) {
     super(initialValue, options)
     this.accept = options?.accept
+    this.suggestions = options?.suggestions ?? []
   }
 
   createSchema(_options?: Partial<FileUrlFieldOptions>) {

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -705,8 +705,58 @@
   width: unset;
 }
 
+.fieldFileInputGroupSuggestions {
+  position: relative;
+}
+
 .fieldInputFileUrl {
   padding: 0 1em;
+}
+
+.fileUrlSuggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: var(--z-index-modal);
+  margin: 2px 0 0;
+  padding: 4px 0;
+  list-style: none;
+  background: rgba(22, 22, 24, 0.98);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.fileUrlSuggestion {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 6px 10px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.fileUrlSuggestion:hover,
+.fileUrlSuggestionActive {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.fileUrlSuggestionLabel {
+  font-size: 11px;
+  color: var(--node-text-color, rgba(255, 255, 255, 0.9));
+  font-weight: 500;
+}
+
+.fileUrlSuggestionUrl {
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.35);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .fieldInputButton {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3243,29 +3243,6 @@ export class MouseOp extends Operator<MouseOp> {
   }
 }
 
-class MapStyleOp extends Operator<MapStyleOp> {
-  static displayName = 'MapStyle'
-  static description = 'Map style for MapLibre'
-  createInputs() {
-    return {
-      mapStyle: new StringLiteralField(CARTO_DARK, {
-        values: Object.entries(MAP_STYLES).map(([url, name]) => ({
-          label: name,
-          value: url as string,
-        })),
-      }),
-    }
-  }
-  createOutputs() {
-    return {
-      mapStyle: new StringField(),
-    }
-  }
-  execute({ mapStyle }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    return { mapStyle }
-  }
-}
-
 export class ProjectOp extends Operator<ProjectOp> {
   static displayName = 'Project'
   static description =
@@ -3418,7 +3395,10 @@ export class MaplibreBasemapOp extends Operator<MaplibreBasemapOp> {
 
   createInputs() {
     return {
-      mapStyle: new FileUrlField(CARTO_DARK, { accept: '.json' }),
+      mapStyle: new FileUrlField(CARTO_DARK, {
+        accept: '.json',
+        suggestions: Object.entries(MAP_STYLES).map(([url, name]) => ({ value: url, label: name })),
+      }),
       projection: new StringLiteralField('mercator', {
         values: ['mercator', 'globe'],
         showByDefault: false,
@@ -6935,7 +6915,6 @@ export const opTypes = {
   LineLayerOp,
   MaplibreBasemapOp,
   MapRangeOp,
-  MapStyleOp,
   MapViewOp,
   MapViewStateOp,
   Mask3DExtensionOp,


### PR DESCRIPTION
#### Background

`MapStyleOp` existed solely as an intermediary to expose preset CARTO map styles as a dropdown, requiring users to wire it into `MaplibreBasemapOp`. This simplifies the pattern by removing that node and surfacing the presets directly on the basemap node itself.

#### Change List
- Add `suggestions` option to `FileUrlField` (and store on the instance) so any file-url input can show typeahead hints via an HTML5 `<datalist>`
- Update `FileUrlFieldComponent` to render the datalist when suggestions are present
- Update `MaplibreBasemapOp.inputs.mapStyle` to include the `MAP_STYLES` presets as suggestions
- Remove `MapStyleOp` class, its `opTypes` registration, and its category entry