### PR TITLE
feat: add RampOp operator with interactive curve editor

### DIFF
--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -79,7 +79,7 @@ export const categories = {
     'TerrainExtension',
     'VibranceExtension',
   ],
-  number: ['Number', 'MapRange', 'Extent', 'Math', 'BezierCurve', 'Time'],
+  number: ['Number', 'MapRange', 'Extent', 'Math', 'BezierCurve', 'Ramp', 'Time'],
   string: ['String'],
   utility: [
     'Blending',

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -603,8 +603,8 @@ function NodeComponent({
 
 function makeDefaultStops(): RampStop[] {
   return [
-    { id: crypto.randomUUID(), pos: 0, val: 0 },
-    { id: crypto.randomUUID(), pos: 1, val: 1 },
+    { id: crypto.randomUUID(), pos: 0, val: 0, interp: 'smooth' },
+    { id: crypto.randomUUID(), pos: 1, val: 1, interp: 'smooth' },
   ]
 }
 
@@ -665,6 +665,10 @@ function RampOpComponent({
   const handlePosChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (!activeStopId || locked) return
+      const sorted = [...stops].sort((a, b) => a.pos - b.pos)
+      const isFirst = sorted[0]?.id === activeStopId
+      const isLast = sorted[sorted.length - 1]?.id === activeStopId
+      if (isFirst || isLast) return
       const pos = Math.max(0, Math.min(1, Number.parseFloat(e.target.value)))
       if (Number.isNaN(pos)) return
       handleChange(
@@ -677,7 +681,7 @@ function RampOpComponent({
   const handleValChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (!activeStopId || locked) return
-      const val = Number.parseFloat(e.target.value)
+      const val = Math.max(0, Math.min(1, Number.parseFloat(e.target.value)))
       if (Number.isNaN(val)) return
       handleChange(stops.map(s => (s.id === activeStopId ? { ...s, val } : s)))
     },
@@ -722,7 +726,13 @@ function RampOpComponent({
             {activeStop ? `stop ${stops.indexOf(activeStop) + 1}` : 'stop'}
           </label>
           <div className={cx(s.fieldInputWrapper, s.fieldInputWrapperVector)}>
-            <label className={cx(s.fieldLabel, s.fieldLabelVector)}>p</label>
+            <label
+              className={cx(s.fieldLabel, s.fieldLabelVector)}
+              title="position"
+              style={{ cursor: 'default' }}
+            >
+              p
+            </label>
             <input
               type="number"
               className={cx(s.fieldInput, s.fieldInputVector)}
@@ -732,37 +742,64 @@ function RampOpComponent({
               step={0.001}
               disabled={locked || !activeStop}
               onChange={handlePosChange}
+              style={{ minWidth: 52 }}
             />
-            <label className={cx(s.fieldLabel, s.fieldLabelVector)}>v</label>
+            <label
+              className={cx(s.fieldLabel, s.fieldLabelVector)}
+              title="value"
+              style={{ cursor: 'default' }}
+            >
+              v
+            </label>
             <input
               type="number"
               className={cx(s.fieldInput, s.fieldInputVector)}
               value={activeStop?.val.toFixed(3) ?? ''}
+              min={0}
+              max={1}
               step={0.001}
               disabled={locked || !activeStop}
               onChange={handleValChange}
+              style={{ minWidth: 52 }}
             />
           </div>
         </div>
         <div className={s.fieldWrapper}>
           <label className={s.fieldLabel}>interp</label>
-          <div style={{ display: 'flex', gap: 2 }}>
-            {(['linear', 'smooth', 'hold'] as RampInterpType[]).map(type => (
-              <button
-                key={type}
-                type="button"
-                className={s.fieldInputButton}
-                style={{
-                  padding: '2px 6px',
-                  opacity: !activeStop ? 0.4 : (activeStop.interp ?? 'linear') === type ? 1 : 0.5,
-                  fontWeight: (activeStop?.interp ?? 'linear') === type ? 600 : 400,
-                }}
-                disabled={locked || !activeStop}
-                onClick={() => handleInterpChange(type)}
-              >
-                {type}
-              </button>
-            ))}
+          <div
+            style={{
+              display: 'flex',
+              borderRadius: 12,
+              overflow: 'hidden',
+              border: '1px solid rgba(255,255,255,0.15)',
+              opacity: !activeStop ? 0.4 : 1,
+            }}
+          >
+            {(['linear', 'smooth', 'hold'] as RampInterpType[]).map((type, i) => {
+              const active = (activeStop?.interp ?? 'smooth') === type
+              return (
+                <button
+                  key={type}
+                  type="button"
+                  style={{
+                    flex: 1,
+                    padding: '3px 0',
+                    fontSize: '0.75em',
+                    fontWeight: active ? 600 : 400,
+                    cursor: locked || !activeStop ? 'default' : 'pointer',
+                    background: active ? '#3b82f6' : 'transparent',
+                    color: active ? '#fff' : 'rgba(255,255,255,0.55)',
+                    border: 'none',
+                    borderLeft: i > 0 ? '1px solid rgba(255,255,255,0.15)' : 'none',
+                    transition: 'background 0.1s, color 0.1s',
+                  }}
+                  disabled={locked || !activeStop}
+                  onClick={() => handleInterpChange(type)}
+                >
+                  {type}
+                </button>
+              )
+            })}
           </div>
         </div>
         <div className={s.outputHandleContainer}>

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -725,42 +725,42 @@ function RampOpComponent({
           <label className={s.fieldLabel} style={{ whiteSpace: 'nowrap' }}>
             {activeStop ? `stop ${stops.indexOf(activeStop) + 1}` : 'stop'}
           </label>
-          <div className={cx(s.fieldInputWrapper, s.fieldInputWrapperVector)}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 2, minWidth: 0 }}>
             <label
               className={cx(s.fieldLabel, s.fieldLabelVector)}
               title="position"
-              style={{ cursor: 'default' }}
+              style={{ cursor: 'default', flexShrink: 0 }}
             >
               p
             </label>
             <input
               type="number"
-              className={cx(s.fieldInput, s.fieldInputVector)}
+              className={s.fieldInput}
               value={activeStop?.pos.toFixed(3) ?? ''}
               min={0}
               max={1}
               step={0.001}
               disabled={locked || !activeStop}
               onChange={handlePosChange}
-              style={{ minWidth: 52 }}
+              style={{ flex: 1, minWidth: 0 }}
             />
             <label
               className={cx(s.fieldLabel, s.fieldLabelVector)}
               title="value"
-              style={{ cursor: 'default' }}
+              style={{ cursor: 'default', flexShrink: 0 }}
             >
               v
             </label>
             <input
               type="number"
-              className={cx(s.fieldInput, s.fieldInputVector)}
+              className={s.fieldInput}
               value={activeStop?.val.toFixed(3) ?? ''}
               min={0}
               max={1}
               step={0.001}
               disabled={locked || !activeStop}
               onChange={handleValChange}
-              style={{ minWidth: 52 }}
+              style={{ flex: 1, minWidth: 0 }}
             />
           </div>
         </div>
@@ -783,7 +783,7 @@ function RampOpComponent({
                   type="button"
                   style={{
                     flex: 1,
-                    padding: '3px 0',
+                    padding: '4px 8px',
                     fontSize: '0.75em',
                     fontWeight: active ? 600 : 400,
                     cursor: locked || !activeStop ? 'default' : 'pointer',

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -49,6 +49,7 @@ import {
   Operator,
   type OutOp,
   opTypes,
+  type RampOp,
   type RerouteOp,
   type TableEditorOp,
   type TimeOp,
@@ -70,6 +71,7 @@ import { generateQualifiedPath, getBaseName, getParentPath } from '../utils/path
 import { categories as baseCategories, nodeTypeToDisplayName } from './categories'
 import { FieldComponent, type inputComponents } from './field-components'
 import previewStyles from './handle-preview.module.css'
+import RampEditor, { type RampStop } from './ramp-editor'
 import { useObservable } from '../hooks/use-observable'
 
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
@@ -183,6 +185,7 @@ export const nodeComponents = {
   DirectionsOp: memo(DirectionsOpComponent, nodePropsAreEqual),
   MouseOp: memo(MouseOpComponent, nodePropsAreEqual),
   OutOp: memo(OutOpComponent, nodePropsAreEqual),
+  RampOp: memo(RampOpComponent, nodePropsAreEqual),
   RerouteOp: memo(RerouteOpComponent, nodePropsAreEqual),
   TableEditorOp: memo(TableEditorOpComponent, nodePropsAreEqual),
   TimeOp: memo(TimeOpComponent, nodePropsAreEqual),
@@ -591,6 +594,78 @@ function NodeComponent({
           {Object.entries(op.outputs).map(([key, field]) => (
             <OutputHandle key={key} id={key} field={field} />
           ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const DEFAULT_RAMP_STOPS: RampStop[] = [
+  { id: 'default-start', pos: 0, val: 0 },
+  { id: 'default-end', pos: 1, val: 1 },
+]
+
+function RampOpComponent({
+  id,
+  type,
+}: ReactFlowNodeProps<NodeDataJSON<RampOp>> & { type: 'RampOp' }) {
+  const op = getOp(id as string) as RampOp | undefined
+  if (!op) throw new Error(`Operator with id ${id} not found`)
+  const locked = useLocked(op)
+  const executionState = useExecutionState(op)
+  const connectionErrors = useConnectionErrors(op)
+  const hasConnectionErrors = connectionErrors.size > 0
+  const isDimmed = useNodeDimmed(id)
+
+  const [stops, setStops] = useState<RampStop[]>(() => {
+    const v = op.inputs.stops.value as RampStop[] | null
+    return v && v.length > 0 ? v : DEFAULT_RAMP_STOPS
+  })
+
+  // Subscribe to stops changes to handle undo/redo and project load
+  useEffect(() => {
+    const sub = op.inputs.stops.subscribe(newVal => {
+      const v = newVal as RampStop[] | null
+      setStops(v && v.length > 0 ? v : DEFAULT_RAMP_STOPS)
+    })
+    return () => sub.unsubscribe()
+  }, [op.inputs.stops])
+
+  // Seed default stops into the field on first render if empty
+  useEffect(() => {
+    const v = op.inputs.stops.value as RampStop[] | null
+    if (!v || v.length === 0) op.inputs.stops.setValue(DEFAULT_RAMP_STOPS)
+  }, [op.inputs.stops])
+
+  const handleChange = useCallback(
+    (newStops: RampStop[]) => {
+      if (locked) return
+      op.inputs.stops.setValue(newStops)
+    },
+    [op.inputs.stops, locked]
+  )
+
+  return (
+    <div
+      className={cx(s.wrapper, {
+        [s.wrapperError]: executionState.status === 'error' || hasConnectionErrors,
+        [s.wrapperExecuting]: executionState.status === 'executing',
+        [s.wrapperDimmed]: isDimmed,
+      })}
+    >
+      <NodeHeader id={id} type={type} op={op} connectionErrors={connectionErrors} />
+      <div className={s.content}>
+        <FieldComponent
+          id="position"
+          field={op.inputs.position}
+          disabled={locked}
+          handle={PAR_HANDLE_OPTIONS}
+        />
+        <div style={{ padding: '4px 0' }}>
+          <RampEditor stops={stops} onChange={handleChange} disabled={locked} />
+        </div>
+        <div className={s.outputHandleContainer}>
+          <OutputHandle id="value" field={op.outputs.value} />
         </div>
       </div>
     </div>

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -69,6 +69,11 @@ import type { NodeDataJSON } from '../transform-graph'
 import { canConnect } from '../utils/can-connect'
 import type { NodeType } from '../utils/node-creation-utils'
 import { generateQualifiedPath, getBaseName, getParentPath } from '../utils/path-utils'
+import {
+  captureOperatorInputs,
+  firePropertyMutation,
+  usePropertyHistory,
+} from '../utils/property-history'
 import { categories as baseCategories, nodeTypeToDisplayName } from './categories'
 import { FieldComponent, type inputComponents } from './field-components'
 import previewStyles from './handle-preview.module.css'
@@ -650,6 +655,10 @@ function RampOpComponent({
     if (!v || v.length === 0) op.inputs.stops.setValue(makeDefaultStops())
   }, [op.inputs.stops])
 
+  // History helpers
+  const { captureStart, commitChange } = usePropertyHistory()
+
+  // Continuous drag update — no history commit per frame; history bracketed by drag start/end
   const handleChange = useCallback(
     (newStops: RampStop[]) => {
       if (locked) return
@@ -658,9 +667,40 @@ function RampOpComponent({
     [op.inputs.stops, locked]
   )
 
+  // Structural change (add/delete from ramp-editor) — atomic history commit
+  const handleStructuralChange = useCallback(
+    (newStops: RampStop[], description: string) => {
+      if (locked) return
+      const before = captureOperatorInputs()
+      op.inputs.stops.setValue(newStops)
+      firePropertyMutation(description, before)
+    },
+    [op.inputs.stops, locked]
+  )
+
+  const handleDragStart = useCallback(() => captureStart(), [captureStart])
+  const handleDragEnd = useCallback(
+    () => commitChange('Move ramp stop'),
+    [commitChange]
+  )
+
   const activeStop = stops.find(s => s.id === activeStopId) ?? null
 
   const handleActivate = useCallback((stopId: string) => setActiveStopId(stopId), [])
+
+  // Debounced history commit for continuous text input
+  const inputBeforeRef = useRef<string | null>(null)
+  const inputTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const commitInputDebounced = useCallback((description: string) => {
+    if (inputTimerRef.current) clearTimeout(inputTimerRef.current)
+    inputTimerRef.current = setTimeout(() => {
+      if (inputBeforeRef.current !== null) {
+        firePropertyMutation(description, inputBeforeRef.current)
+        inputBeforeRef.current = null
+      }
+    }, 600)
+  }, [])
 
   const handlePosChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -671,11 +711,13 @@ function RampOpComponent({
       if (isFirst || isLast) return
       const pos = Math.max(0, Math.min(1, Number.parseFloat(e.target.value)))
       if (Number.isNaN(pos)) return
-      handleChange(
+      if (inputBeforeRef.current === null) inputBeforeRef.current = captureOperatorInputs()
+      op.inputs.stops.setValue(
         stops.map(s => (s.id === activeStopId ? { ...s, pos } : s)).sort((a, b) => a.pos - b.pos)
       )
+      commitInputDebounced('Update ramp stop position')
     },
-    [activeStopId, locked, stops, handleChange]
+    [activeStopId, locked, stops, op.inputs.stops, commitInputDebounced]
   )
 
   const handleValChange = useCallback(
@@ -683,18 +725,31 @@ function RampOpComponent({
       if (!activeStopId || locked) return
       const val = Math.max(0, Math.min(1, Number.parseFloat(e.target.value)))
       if (Number.isNaN(val)) return
-      handleChange(stops.map(s => (s.id === activeStopId ? { ...s, val } : s)))
+      if (inputBeforeRef.current === null) inputBeforeRef.current = captureOperatorInputs()
+      op.inputs.stops.setValue(stops.map(s => (s.id === activeStopId ? { ...s, val } : s)))
+      commitInputDebounced('Update ramp stop value')
     },
-    [activeStopId, locked, stops, handleChange]
+    [activeStopId, locked, stops, op.inputs.stops, commitInputDebounced]
   )
 
   const handleInterpChange = useCallback(
     (interp: RampInterpType) => {
       if (!activeStopId || locked) return
-      handleChange(stops.map(s => (s.id === activeStopId ? { ...s, interp } : s)))
+      const before = captureOperatorInputs()
+      op.inputs.stops.setValue(stops.map(s => (s.id === activeStopId ? { ...s, interp } : s)))
+      firePropertyMutation('Change ramp interpolation', before)
     },
-    [activeStopId, locked, stops, handleChange]
+    [activeStopId, locked, stops, op.inputs.stops]
   )
+
+  const handleDeleteActiveStop = useCallback(() => {
+    if (!activeStopId || locked || stops.length <= 2) return
+    const before = captureOperatorInputs()
+    op.inputs.stops.setValue(stops.filter(s => s.id !== activeStopId))
+    firePropertyMutation('Delete ramp stop', before)
+  }, [activeStopId, locked, stops, op.inputs.stops])
+
+  const canDelete = !!activeStop && stops.length > 2
 
   return (
     <div
@@ -712,14 +767,44 @@ function RampOpComponent({
           disabled={locked}
           handle={PAR_HANDLE_OPTIONS}
         />
-        <div style={{ padding: '4px 0' }}>
+        <div style={{ position: 'relative', padding: '4px 0' }}>
           <RampEditor
             stops={stops}
             onChange={handleChange}
+            onStructuralChange={handleStructuralChange}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
             disabled={locked}
             activeStopId={activeStopId}
             onActivate={handleActivate}
           />
+          {canDelete && !locked && (
+            <button
+              type="button"
+              title="Delete stop"
+              onClick={handleDeleteActiveStop}
+              style={{
+                position: 'absolute',
+                top: 8,
+                right: 4,
+                width: 16,
+                height: 16,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: 0,
+                background: 'rgba(30,38,52,0.85)',
+                border: '1px solid rgba(255,255,255,0.2)',
+                borderRadius: 3,
+                color: '#e2dede',
+                cursor: 'pointer',
+                fontSize: 14,
+                lineHeight: 1,
+              }}
+            >
+              −
+            </button>
+          )}
         </div>
         <div className={s.fieldWrapper}>
           <label className={s.fieldLabel} style={{ whiteSpace: 'nowrap' }}>

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -600,10 +600,12 @@ function NodeComponent({
   )
 }
 
-const DEFAULT_RAMP_STOPS: RampStop[] = [
-  { id: 'default-start', pos: 0, val: 0 },
-  { id: 'default-end', pos: 1, val: 1 },
-]
+function makeDefaultStops(): RampStop[] {
+  return [
+    { id: crypto.randomUUID(), pos: 0, val: 0 },
+    { id: crypto.randomUUID(), pos: 1, val: 1 },
+  ]
+}
 
 function RampOpComponent({
   id,
@@ -619,14 +621,14 @@ function RampOpComponent({
 
   const [stops, setStops] = useState<RampStop[]>(() => {
     const v = op.inputs.stops.value as RampStop[] | null
-    return v && v.length > 0 ? v : DEFAULT_RAMP_STOPS
+    return v && v.length > 0 ? v : makeDefaultStops()
   })
 
   // Subscribe to stops changes to handle undo/redo and project load
   useEffect(() => {
     const sub = op.inputs.stops.subscribe(newVal => {
       const v = newVal as RampStop[] | null
-      setStops(v && v.length > 0 ? v : DEFAULT_RAMP_STOPS)
+      setStops(v && v.length > 0 ? v : makeDefaultStops())
     })
     return () => sub.unsubscribe()
   }, [op.inputs.stops])
@@ -634,7 +636,7 @@ function RampOpComponent({
   // Seed default stops into the field on first render if empty
   useEffect(() => {
     const v = op.inputs.stops.value as RampStop[] | null
-    if (!v || v.length === 0) op.inputs.stops.setValue(DEFAULT_RAMP_STOPS)
+    if (!v || v.length === 0) op.inputs.stops.setValue(makeDefaultStops())
   }, [op.inputs.stops])
 
   const handleChange = useCallback(

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -727,7 +727,7 @@ function RampOpComponent({
           </label>
           <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 2, minWidth: 0 }}>
             <label
-              className={cx(s.fieldLabel, s.fieldLabelVector)}
+              className={s.fieldLabelVector}
               title="position"
               style={{ cursor: 'default', flexShrink: 0 }}
             >
@@ -745,7 +745,7 @@ function RampOpComponent({
               style={{ flex: 1, minWidth: 0 }}
             />
             <label
-              className={cx(s.fieldLabel, s.fieldLabelVector)}
+              className={s.fieldLabelVector}
               title="value"
               style={{ cursor: 'default', flexShrink: 0 }}
             >

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -49,7 +49,7 @@ import {
   Operator,
   type OutOp,
   opTypes,
-  type RampCurveType,
+  type RampInterpType,
   type RampOp,
   type RerouteOp,
   type TableEditorOp,
@@ -624,26 +624,25 @@ function RampOpComponent({
     const v = op.inputs.stops.value as RampStop[] | null
     return v && v.length > 0 ? v : makeDefaultStops()
   })
-  const [activeStopId, setActiveStopId] = useState<string | null>(null)
-  const [curveType, setCurveType] = useState<RampCurveType>(
-    (op.inputs.curveType.value as RampCurveType) ?? 'linear'
-  )
+  const [activeStopId, setActiveStopId] = useState<string | null>(() => {
+    const v = op.inputs.stops.value as RampStop[] | null
+    const s = v && v.length > 0 ? v : makeDefaultStops()
+    return s[0]?.id ?? null
+  })
 
-  // Subscribe to stops and curveType to handle undo/redo and project load
+  // Subscribe to stops to handle undo/redo and project load
   useEffect(() => {
     const stopsSub = op.inputs.stops.subscribe(newVal => {
       const v = newVal as RampStop[] | null
       const nextStops = v && v.length > 0 ? v : makeDefaultStops()
       setStops(nextStops)
-      // Clear active stop if it no longer exists
-      setActiveStopId(prev => (nextStops.find(s => s.id === prev) ? prev : null))
+      // Keep active stop if still present, otherwise fall back to first
+      setActiveStopId(prev =>
+        nextStops.find(s => s.id === prev) ? prev : (nextStops[0]?.id ?? null)
+      )
     })
-    const curveSub = op.inputs.curveType.subscribe(v => setCurveType(v as RampCurveType))
-    return () => {
-      stopsSub.unsubscribe()
-      curveSub.unsubscribe()
-    }
-  }, [op.inputs.stops, op.inputs.curveType])
+    return () => stopsSub.unsubscribe()
+  }, [op.inputs.stops])
 
   // Seed default stops on first render if empty
   useEffect(() => {
@@ -685,6 +684,14 @@ function RampOpComponent({
     [activeStopId, locked, stops, handleChange]
   )
 
+  const handleInterpChange = useCallback(
+    (interp: RampInterpType) => {
+      if (!activeStopId || locked) return
+      handleChange(stops.map(s => (s.id === activeStopId ? { ...s, interp } : s)))
+    },
+    [activeStopId, locked, stops, handleChange]
+  )
+
   return (
     <div
       className={cx(s.wrapper, {
@@ -701,28 +708,24 @@ function RampOpComponent({
           disabled={locked}
           handle={PAR_HANDLE_OPTIONS}
         />
-        <FieldComponent
-          id="curveType"
-          field={op.inputs.curveType}
-          disabled={locked}
-          handle={PAR_HANDLE_OPTIONS}
-        />
         <div style={{ padding: '4px 0' }}>
           <RampEditor
             stops={stops}
             onChange={handleChange}
             disabled={locked}
-            curveType={curveType}
             activeStopId={activeStopId}
             onActivate={handleActivate}
           />
         </div>
         <div className={s.fieldWrapper}>
-          <label className={s.fieldLabel}>pos</label>
-          <div className={s.fieldInputWrapper}>
+          <label className={s.fieldLabel} style={{ whiteSpace: 'nowrap' }}>
+            {activeStop ? `stop ${stops.indexOf(activeStop) + 1}` : 'stop'}
+          </label>
+          <div className={cx(s.fieldInputWrapper, s.fieldInputWrapperVector)}>
+            <label className={cx(s.fieldLabel, s.fieldLabelVector)}>p</label>
             <input
               type="number"
-              className={s.fieldInput}
+              className={cx(s.fieldInput, s.fieldInputVector)}
               value={activeStop?.pos.toFixed(3) ?? ''}
               min={0}
               max={1}
@@ -730,19 +733,36 @@ function RampOpComponent({
               disabled={locked || !activeStop}
               onChange={handlePosChange}
             />
-          </div>
-        </div>
-        <div className={s.fieldWrapper}>
-          <label className={s.fieldLabel}>val</label>
-          <div className={s.fieldInputWrapper}>
+            <label className={cx(s.fieldLabel, s.fieldLabelVector)}>v</label>
             <input
               type="number"
-              className={s.fieldInput}
+              className={cx(s.fieldInput, s.fieldInputVector)}
               value={activeStop?.val.toFixed(3) ?? ''}
               step={0.001}
               disabled={locked || !activeStop}
               onChange={handleValChange}
             />
+          </div>
+        </div>
+        <div className={s.fieldWrapper}>
+          <label className={s.fieldLabel}>interp</label>
+          <div style={{ display: 'flex', gap: 2 }}>
+            {(['linear', 'smooth', 'hold'] as RampInterpType[]).map(type => (
+              <button
+                key={type}
+                type="button"
+                className={s.fieldInputButton}
+                style={{
+                  padding: '2px 6px',
+                  opacity: !activeStop ? 0.4 : (activeStop.interp ?? 'linear') === type ? 1 : 0.5,
+                  fontWeight: (activeStop?.interp ?? 'linear') === type ? 600 : 400,
+                }}
+                disabled={locked || !activeStop}
+                onClick={() => handleInterpChange(type)}
+              >
+                {type}
+              </button>
+            ))}
           </div>
         </div>
         <div className={s.outputHandleContainer}>

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -49,6 +49,7 @@ import {
   Operator,
   type OutOp,
   opTypes,
+  type RampCurveType,
   type RampOp,
   type RerouteOp,
   type TableEditorOp,
@@ -623,17 +624,28 @@ function RampOpComponent({
     const v = op.inputs.stops.value as RampStop[] | null
     return v && v.length > 0 ? v : makeDefaultStops()
   })
+  const [activeStopId, setActiveStopId] = useState<string | null>(null)
+  const [curveType, setCurveType] = useState<RampCurveType>(
+    (op.inputs.curveType.value as RampCurveType) ?? 'linear'
+  )
 
-  // Subscribe to stops changes to handle undo/redo and project load
+  // Subscribe to stops and curveType to handle undo/redo and project load
   useEffect(() => {
-    const sub = op.inputs.stops.subscribe(newVal => {
+    const stopsSub = op.inputs.stops.subscribe(newVal => {
       const v = newVal as RampStop[] | null
-      setStops(v && v.length > 0 ? v : makeDefaultStops())
+      const nextStops = v && v.length > 0 ? v : makeDefaultStops()
+      setStops(nextStops)
+      // Clear active stop if it no longer exists
+      setActiveStopId(prev => (nextStops.find(s => s.id === prev) ? prev : null))
     })
-    return () => sub.unsubscribe()
-  }, [op.inputs.stops])
+    const curveSub = op.inputs.curveType.subscribe(v => setCurveType(v as RampCurveType))
+    return () => {
+      stopsSub.unsubscribe()
+      curveSub.unsubscribe()
+    }
+  }, [op.inputs.stops, op.inputs.curveType])
 
-  // Seed default stops into the field on first render if empty
+  // Seed default stops on first render if empty
   useEffect(() => {
     const v = op.inputs.stops.value as RampStop[] | null
     if (!v || v.length === 0) op.inputs.stops.setValue(makeDefaultStops())
@@ -645,6 +657,32 @@ function RampOpComponent({
       op.inputs.stops.setValue(newStops)
     },
     [op.inputs.stops, locked]
+  )
+
+  const activeStop = stops.find(s => s.id === activeStopId) ?? null
+
+  const handleActivate = useCallback((stopId: string) => setActiveStopId(stopId), [])
+
+  const handlePosChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!activeStopId || locked) return
+      const pos = Math.max(0, Math.min(1, Number.parseFloat(e.target.value)))
+      if (Number.isNaN(pos)) return
+      handleChange(
+        stops.map(s => (s.id === activeStopId ? { ...s, pos } : s)).sort((a, b) => a.pos - b.pos)
+      )
+    },
+    [activeStopId, locked, stops, handleChange]
+  )
+
+  const handleValChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!activeStopId || locked) return
+      const val = Number.parseFloat(e.target.value)
+      if (Number.isNaN(val)) return
+      handleChange(stops.map(s => (s.id === activeStopId ? { ...s, val } : s)))
+    },
+    [activeStopId, locked, stops, handleChange]
   )
 
   return (
@@ -663,8 +701,49 @@ function RampOpComponent({
           disabled={locked}
           handle={PAR_HANDLE_OPTIONS}
         />
+        <FieldComponent
+          id="curveType"
+          field={op.inputs.curveType}
+          disabled={locked}
+          handle={PAR_HANDLE_OPTIONS}
+        />
         <div style={{ padding: '4px 0' }}>
-          <RampEditor stops={stops} onChange={handleChange} disabled={locked} />
+          <RampEditor
+            stops={stops}
+            onChange={handleChange}
+            disabled={locked}
+            curveType={curveType}
+            activeStopId={activeStopId}
+            onActivate={handleActivate}
+          />
+        </div>
+        <div className={s.fieldWrapper}>
+          <label className={s.fieldLabel}>pos</label>
+          <div className={s.fieldInputWrapper}>
+            <input
+              type="number"
+              className={s.fieldInput}
+              value={activeStop?.pos.toFixed(3) ?? ''}
+              min={0}
+              max={1}
+              step={0.001}
+              disabled={locked || !activeStop}
+              onChange={handlePosChange}
+            />
+          </div>
+        </div>
+        <div className={s.fieldWrapper}>
+          <label className={s.fieldLabel}>val</label>
+          <div className={s.fieldInputWrapper}>
+            <input
+              type="number"
+              className={s.fieldInput}
+              value={activeStop?.val.toFixed(3) ?? ''}
+              step={0.001}
+              disabled={locked || !activeStop}
+              onChange={handleValChange}
+            />
+          </div>
         </div>
         <div className={s.outputHandleContainer}>
           <OutputHandle id="value" field={op.outputs.value} />

--- a/noodles-editor/src/noodles/components/ramp-editor.tsx
+++ b/noodles-editor/src/noodles/components/ramp-editor.tsx
@@ -1,5 +1,6 @@
 import { scaleLinear } from 'd3'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { monotoneSlopes } from '../operators'
 import type { RampInterpType } from '../operators'
 
@@ -12,7 +13,12 @@ export interface RampStop {
 
 interface RampEditorProps {
   stops: RampStop[]
+  /** Called on every drag frame — no history commit. */
   onChange: (stops: RampStop[]) => void
+  /** Called for structural changes (add/delete). Parent should wrap with history. */
+  onStructuralChange?: (stops: RampStop[], description: string) => void
+  onDragStart?: () => void
+  onDragEnd?: () => void
   disabled?: boolean
   width?: number
   height?: number
@@ -23,7 +29,6 @@ interface RampEditorProps {
 const PAD = 12
 
 // Build an SVG path string for the ramp curve, segment by segment.
-// Each segment uses the interp type of the left (earlier) stop.
 function buildRampPath(
   sortedStops: RampStop[],
   xScale: (v: number) => number,
@@ -37,18 +42,14 @@ function buildRampPath(
   for (let i = 0; i < sortedStops.length - 1; i++) {
     const s0 = sortedStops[i]
     const s1 = sortedStops[i + 1]
-    const x0 = xScale(s0.pos)
-    const y0 = yScale(s0.val)
     const x1 = xScale(s1.pos)
+    const y0 = yScale(s0.val)
     const y1 = yScale(s1.val)
-    const interp = s0.interp ?? 'linear'
+    const interp = s0.interp ?? 'smooth'
 
     if (interp === 'hold') {
-      // Step: horizontal then vertical
       parts.push(`L ${x1} ${y0} L ${x1} ${y1}`)
     } else if (interp === 'smooth') {
-      // Cubic bezier from PCHIP slopes, converted to pixel space.
-      // Data-space control points: (x0 + h/3, y0 + m0*h/3) and (x1 - h/3, y1 - m1*h/3)
       const h = s1.pos - s0.pos
       const cp1x = xScale(s0.pos + h / 3)
       const cp1y = yScale(s0.val + slopes[i] * (h / 3))
@@ -56,7 +57,6 @@ function buildRampPath(
       const cp2y = yScale(s1.val - slopes[i + 1] * (h / 3))
       parts.push(`C ${cp1x} ${cp1y} ${cp2x} ${cp2y} ${x1} ${y1}`)
     } else {
-      // linear
       parts.push(`L ${x1} ${y1}`)
     }
   }
@@ -67,6 +67,9 @@ function buildRampPath(
 export default function RampEditor({
   stops: stopsProp,
   onChange,
+  onStructuralChange,
+  onDragStart,
+  onDragEnd,
   disabled = false,
   width = 220,
   height = 100,
@@ -86,15 +89,27 @@ export default function RampEditor({
   )
 
   const svgRef = useRef<SVGSVGElement>(null)
-  // Keep ref in sync so closures inside event handlers always see latest stops
   const stopsRef = useRef(stops)
   useEffect(() => {
     stopsRef.current = stops
   })
 
   const [draggingId, setDraggingId] = useState<string | null>(null)
+  const [contextMenu, setContextMenu] = useState<{
+    stopId: string
+    x: number
+    y: number
+  } | null>(null)
   // Suppress the second click of a double-click (which would add two stops)
   const lastClickTimeRef = useRef(0)
+
+  // Close context menu on outside mousedown
+  useEffect(() => {
+    if (!contextMenu) return
+    const handle = () => setContextMenu(null)
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [contextMenu])
 
   const handleBgClick = useCallback(
     (e: React.MouseEvent<SVGRectElement>) => {
@@ -109,9 +124,9 @@ export default function RampEditor({
       const val = Math.max(0, Math.min(1, yScale.invert(y)))
       const newStop: RampStop = { id: crypto.randomUUID(), pos, val, interp: 'smooth' }
       const newStops = [...stopsRef.current, newStop].sort((a, b) => a.pos - b.pos)
-      onChange(newStops)
+      onStructuralChange?.(newStops, 'Add ramp stop')
     },
-    [disabled, xScale, yScale, onChange]
+    [disabled, xScale, yScale, onStructuralChange]
   )
 
   const handleStopMouseDown = useCallback(
@@ -119,21 +134,27 @@ export default function RampEditor({
       if (disabled) return
       e.stopPropagation()
       onActivate?.(stopId)
-      // Capture scales at drag start — avoids jank when y-axis auto-rescales during drag
-      const capturedXScale = xScale.copy()
-      const capturedYScale = yScale.copy()
-      setDraggingId(stopId)
+      onDragStart?.()
 
       const sorted = [...stopsRef.current].sort((a, b) => a.pos - b.pos)
       const isFirst = sorted[0]?.id === stopId
       const isLast = sorted[sorted.length - 1]?.id === stopId
+
+      // Capture scales at drag start — avoids jank when y-axis auto-rescales during drag
+      const capturedXScale = xScale.copy()
+      const capturedYScale = yScale.copy()
+      setDraggingId(stopId)
 
       const onMouseMove = (moveEvent: MouseEvent) => {
         if (!svgRef.current) return
         const rect = svgRef.current.getBoundingClientRect()
         const x = moveEvent.clientX - rect.left
         const y = moveEvent.clientY - rect.top
-        const newPos = isFirst ? 0 : isLast ? 1 : Math.max(0, Math.min(1, capturedXScale.invert(x)))
+        const newPos = isFirst
+          ? 0
+          : isLast
+            ? 1
+            : Math.max(0, Math.min(1, capturedXScale.invert(x)))
         const newVal = Math.max(0, Math.min(1, capturedYScale.invert(y)))
         const updated = stopsRef.current
           .map(s => (s.id === stopId ? { ...s, pos: newPos, val: newVal } : s))
@@ -143,6 +164,7 @@ export default function RampEditor({
 
       const onMouseUp = () => {
         setDraggingId(null)
+        onDragEnd?.()
         document.removeEventListener('mousemove', onMouseMove)
         document.removeEventListener('mouseup', onMouseUp)
       }
@@ -150,17 +172,42 @@ export default function RampEditor({
       document.addEventListener('mousemove', onMouseMove)
       document.addEventListener('mouseup', onMouseUp)
     },
-    [disabled, xScale, yScale, onChange]
+    [disabled, xScale, yScale, onChange, onActivate, onDragStart, onDragEnd]
   )
 
-  const handleStopDoubleClick = useCallback(
+  const handleStopContextMenu = useCallback(
     (e: React.MouseEvent, stopId: string) => {
-      if (disabled) return
+      e.preventDefault()
       e.stopPropagation()
-      if (stopsRef.current.length <= 2) return
-      onChange(stopsRef.current.filter(s => s.id !== stopId))
+      setContextMenu({ stopId, x: e.clientX, y: e.clientY })
     },
-    [disabled, onChange]
+    []
+  )
+
+  const handleContextMenuDelete = useCallback(() => {
+    if (!contextMenu) return
+    const current = stopsRef.current
+    if (current.length <= 2) return
+    onStructuralChange?.(
+      current.filter(s => s.id !== contextMenu.stopId),
+      'Delete ramp stop'
+    )
+    setContextMenu(null)
+  }, [contextMenu, onStructuralChange])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== 'Delete' && e.key !== 'Backspace') return
+      if (!activeStopId) return
+      const current = stopsRef.current
+      if (current.length <= 2) return
+      e.preventDefault()
+      onStructuralChange?.(
+        current.filter(s => s.id !== activeStopId),
+        'Delete ramp stop'
+      )
+    },
+    [activeStopId, onStructuralChange]
   )
 
   const sortedStops = useMemo(() => [...stops].sort((a, b) => a.pos - b.pos), [stops])
@@ -170,47 +217,108 @@ export default function RampEditor({
   )
 
   return (
-    <svg
-      ref={svgRef}
-      width={width}
-      height={height}
-      style={{
-        display: 'block',
-        background: '#1a1d22',
-        borderRadius: 3,
-        cursor: disabled ? 'default' : 'crosshair',
-        userSelect: 'none',
-      }}
-    >
-      {/* Clickable background to add stops */}
-      <rect x={0} y={0} width={width} height={height} fill="transparent" onClick={handleBgClick} />
-      {sortedStops.length >= 2 && (
-        <path d={pathD} fill="none" stroke="#3b82f6" strokeWidth={1.5} />
-      )}
-      {sortedStops.map(stop => (
-        <g key={stop.id}>
-          {/* Large transparent hit area for easier grabbing */}
-          <circle
-            cx={xScale(stop.pos)}
-            cy={yScale(stop.val)}
-            r={8}
-            fill="transparent"
-            style={{ cursor: disabled ? 'default' : draggingId === stop.id ? 'grabbing' : 'grab' }}
-            onMouseDown={e => handleStopMouseDown(e, stop.id)}
-            onDoubleClick={e => handleStopDoubleClick(e, stop.id)}
-          />
-          {/* Visible control point — white when active, blue otherwise */}
-          <circle
-            cx={xScale(stop.pos)}
-            cy={yScale(stop.val)}
-            r={activeStopId === stop.id ? 5 : 4}
-            fill={activeStopId === stop.id ? '#ffffff' : draggingId === stop.id ? '#60a5fa' : '#3b82f6'}
-            stroke={activeStopId === stop.id ? '#3b82f6' : '#1e3a8a'}
-            strokeWidth={1.5}
-            pointerEvents="none"
-          />
-        </g>
-      ))}
-    </svg>
+    <>
+      {/* biome-ignore lint/a11y/noSvgWithoutTitle: interactive SVG editor */}
+      <svg
+        ref={svgRef}
+        width={width}
+        height={height}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        style={{
+          display: 'block',
+          background: '#1a1d22',
+          borderRadius: 3,
+          cursor: disabled ? 'default' : 'crosshair',
+          userSelect: 'none',
+          outline: 'none',
+        }}
+      >
+        {/* Clickable background to add stops */}
+        <rect
+          x={0}
+          y={0}
+          width={width}
+          height={height}
+          fill="transparent"
+          onClick={handleBgClick}
+        />
+        {sortedStops.length >= 2 && (
+          <path d={pathD} fill="none" stroke="#3b82f6" strokeWidth={1.5} />
+        )}
+        {sortedStops.map(stop => (
+          <g key={stop.id}>
+            {/* Large transparent hit area */}
+            <circle
+              cx={xScale(stop.pos)}
+              cy={yScale(stop.val)}
+              r={8}
+              fill="transparent"
+              style={{
+                cursor: disabled ? 'default' : draggingId === stop.id ? 'grabbing' : 'grab',
+              }}
+              onMouseDown={e => handleStopMouseDown(e, stop.id)}
+              onContextMenu={e => handleStopContextMenu(e, stop.id)}
+            />
+            {/* Visible control point */}
+            <circle
+              cx={xScale(stop.pos)}
+              cy={yScale(stop.val)}
+              r={activeStopId === stop.id ? 5 : 4}
+              fill={
+                activeStopId === stop.id
+                  ? '#ffffff'
+                  : draggingId === stop.id
+                    ? '#60a5fa'
+                    : '#3b82f6'
+              }
+              stroke={activeStopId === stop.id ? '#3b82f6' : '#1e3a8a'}
+              strokeWidth={1.5}
+              pointerEvents="none"
+            />
+          </g>
+        ))}
+      </svg>
+      {contextMenu &&
+        createPortal(
+          // biome-ignore lint/a11y/noStaticElementInteractions: context menu
+          <div
+            style={{
+              position: 'fixed',
+              left: contextMenu.x,
+              top: contextMenu.y,
+              zIndex: 9999,
+              background: 'linear-gradient(180deg, #1e2634 0%, #171d27 100%)',
+              border: '1px solid #2f3b4c',
+              borderRadius: 4,
+              padding: 4,
+              minWidth: 120,
+              boxShadow: '0 2px 8px rgba(0,0,0,0.4)',
+            }}
+            onMouseDown={e => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              style={{
+                display: 'block',
+                width: '100%',
+                padding: '6px 10px',
+                textAlign: 'left',
+                background: 'none',
+                border: 'none',
+                borderRadius: 2,
+                color: stopsRef.current.length <= 2 ? 'rgba(226,222,222,0.3)' : '#e2dede',
+                cursor: stopsRef.current.length <= 2 ? 'not-allowed' : 'pointer',
+                fontSize: '0.875em',
+              }}
+              disabled={stopsRef.current.length <= 2}
+              onClick={handleContextMenuDelete}
+            >
+              Delete stop
+            </button>
+          </div>,
+          document.body
+        )}
+    </>
   )
 }

--- a/noodles-editor/src/noodles/components/ramp-editor.tsx
+++ b/noodles-editor/src/noodles/components/ramp-editor.tsx
@@ -1,11 +1,13 @@
-import { curveLinear, curveMonotoneX, line, scaleLinear } from 'd3'
+import { scaleLinear } from 'd3'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { RampCurveType } from '../operators'
+import { monotoneSlopes } from '../operators'
+import type { RampInterpType } from '../operators'
 
 export interface RampStop {
   id: string
   pos: number
   val: number
+  interp?: RampInterpType
 }
 
 interface RampEditorProps {
@@ -14,17 +16,53 @@ interface RampEditorProps {
   disabled?: boolean
   width?: number
   height?: number
-  curveType?: RampCurveType
   activeStopId?: string | null
   onActivate?: (id: string) => void
 }
 
-const curveMap = {
-  linear: curveLinear,
-  smooth: curveMonotoneX,
-}
-
 const PAD = 12
+
+// Build an SVG path string for the ramp curve, segment by segment.
+// Each segment uses the interp type of the left (earlier) stop.
+function buildRampPath(
+  sortedStops: RampStop[],
+  xScale: (v: number) => number,
+  yScale: (v: number) => number
+): string {
+  if (sortedStops.length < 2) return ''
+
+  const slopes = monotoneSlopes(sortedStops)
+  const parts: string[] = [`M ${xScale(sortedStops[0].pos)} ${yScale(sortedStops[0].val)}`]
+
+  for (let i = 0; i < sortedStops.length - 1; i++) {
+    const s0 = sortedStops[i]
+    const s1 = sortedStops[i + 1]
+    const x0 = xScale(s0.pos)
+    const y0 = yScale(s0.val)
+    const x1 = xScale(s1.pos)
+    const y1 = yScale(s1.val)
+    const interp = s0.interp ?? 'linear'
+
+    if (interp === 'hold') {
+      // Step: horizontal then vertical
+      parts.push(`L ${x1} ${y0} L ${x1} ${y1}`)
+    } else if (interp === 'smooth') {
+      // Cubic bezier from PCHIP slopes, converted to pixel space.
+      // Data-space control points: (x0 + h/3, y0 + m0*h/3) and (x1 - h/3, y1 - m1*h/3)
+      const h = s1.pos - s0.pos
+      const cp1x = xScale(s0.pos + h / 3)
+      const cp1y = yScale(s0.val + slopes[i] * (h / 3))
+      const cp2x = xScale(s1.pos - h / 3)
+      const cp2y = yScale(s1.val - slopes[i + 1] * (h / 3))
+      parts.push(`C ${cp1x} ${cp1y} ${cp2x} ${cp2y} ${x1} ${y1}`)
+    } else {
+      // linear
+      parts.push(`L ${x1} ${y1}`)
+    }
+  }
+
+  return parts.join(' ')
+}
 
 export default function RampEditor({
   stops: stopsProp,
@@ -32,7 +70,6 @@ export default function RampEditor({
   disabled = false,
   width = 220,
   height = 100,
-  curveType = 'linear',
   activeStopId,
   onActivate,
 }: RampEditorProps) {
@@ -55,15 +92,6 @@ export default function RampEditor({
   const yScale = useMemo(
     () => scaleLinear().domain([yMin, yMax]).range([height - PAD, PAD]),
     [yMin, yMax, height]
-  )
-
-  const lineGen = useMemo(
-    () =>
-      line<RampStop>()
-        .x(d => xScale(d.pos))
-        .y(d => yScale(d.val))
-        .curve(curveMap[curveType]),
-    [xScale, yScale, curveType]
   )
 
   const svgRef = useRef<SVGSVGElement>(null)
@@ -141,6 +169,10 @@ export default function RampEditor({
   )
 
   const sortedStops = useMemo(() => [...stops].sort((a, b) => a.pos - b.pos), [stops])
+  const pathD = useMemo(
+    () => buildRampPath(sortedStops, xScale, yScale),
+    [sortedStops, xScale, yScale]
+  )
 
   return (
     <svg
@@ -158,7 +190,7 @@ export default function RampEditor({
       {/* Clickable background to add stops */}
       <rect x={0} y={0} width={width} height={height} fill="transparent" onClick={handleBgClick} />
       {sortedStops.length >= 2 && (
-        <path d={lineGen(sortedStops) ?? undefined} fill="none" stroke="#3b82f6" strokeWidth={1.5} />
+        <path d={pathD} fill="none" stroke="#3b82f6" strokeWidth={1.5} />
       )}
       {sortedStops.map(stop => (
         <g key={stop.id}>

--- a/noodles-editor/src/noodles/components/ramp-editor.tsx
+++ b/noodles-editor/src/noodles/components/ramp-editor.tsx
@@ -1,0 +1,171 @@
+import { curveMonotoneX, line, scaleLinear } from 'd3'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+export interface RampStop {
+  id: string
+  pos: number
+  val: number
+}
+
+interface RampEditorProps {
+  stops: RampStop[]
+  onChange: (stops: RampStop[]) => void
+  disabled?: boolean
+  width?: number
+  height?: number
+}
+
+const PAD = 12
+
+export default function RampEditor({
+  stops: stopsProp,
+  onChange,
+  disabled = false,
+  width = 220,
+  height = 100,
+}: RampEditorProps) {
+  const stops = stopsProp.length > 0 ? stopsProp : []
+
+  const [yMin, yMax] = useMemo(() => {
+    if (stops.length === 0) return [0, 1]
+    const vals = stops.map(s => s.val)
+    const min = Math.min(...vals)
+    const max = Math.max(...vals)
+    const range = max - min || 1
+    return [min - range * 0.15, max + range * 0.15]
+  }, [stops])
+
+  const xScale = useMemo(
+    () => scaleLinear().domain([0, 1]).range([PAD, width - PAD]),
+    [width]
+  )
+
+  const yScale = useMemo(
+    () => scaleLinear().domain([yMin, yMax]).range([height - PAD, PAD]),
+    [yMin, yMax, height]
+  )
+
+  const lineGen = useMemo(
+    () =>
+      line<RampStop>()
+        .x(d => xScale(d.pos))
+        .y(d => yScale(d.val))
+        .curve(curveMonotoneX),
+    [xScale, yScale]
+  )
+
+  const svgRef = useRef<SVGSVGElement>(null)
+  // Keep ref in sync so closures inside event handlers always see latest stops
+  const stopsRef = useRef(stops)
+  useEffect(() => {
+    stopsRef.current = stops
+  })
+
+  const [draggingId, setDraggingId] = useState<string | null>(null)
+
+  const handleBgClick = useCallback(
+    (e: React.MouseEvent<SVGRectElement>) => {
+      if (disabled) return
+      const rect = svgRef.current!.getBoundingClientRect()
+      const x = e.clientX - rect.left
+      const y = e.clientY - rect.top
+      const pos = Math.max(0, Math.min(1, xScale.invert(x)))
+      const val = yScale.invert(y)
+      const newStop: RampStop = { id: crypto.randomUUID(), pos, val }
+      const newStops = [...stopsRef.current, newStop].sort((a, b) => a.pos - b.pos)
+      onChange(newStops)
+    },
+    [disabled, xScale, yScale, onChange]
+  )
+
+  const handleStopMouseDown = useCallback(
+    (e: React.MouseEvent<SVGCircleElement>, stopId: string) => {
+      if (disabled) return
+      e.stopPropagation()
+      // Capture scales at drag start — avoids jank when y-axis auto-rescales during drag
+      const capturedXScale = xScale.copy()
+      const capturedYScale = yScale.copy()
+      setDraggingId(stopId)
+
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        if (!svgRef.current) return
+        const rect = svgRef.current.getBoundingClientRect()
+        const x = moveEvent.clientX - rect.left
+        const y = moveEvent.clientY - rect.top
+        const newPos = Math.max(0, Math.min(1, capturedXScale.invert(x)))
+        const newVal = capturedYScale.invert(y)
+        const updated = stopsRef.current
+          .map(s => (s.id === stopId ? { ...s, pos: newPos, val: newVal } : s))
+          .sort((a, b) => a.pos - b.pos)
+        onChange(updated)
+      }
+
+      const onMouseUp = () => {
+        setDraggingId(null)
+        document.removeEventListener('mousemove', onMouseMove)
+        document.removeEventListener('mouseup', onMouseUp)
+      }
+
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+    },
+    [disabled, xScale, yScale, onChange]
+  )
+
+  const handleStopDoubleClick = useCallback(
+    (e: React.MouseEvent, stopId: string) => {
+      if (disabled) return
+      e.stopPropagation()
+      if (stopsRef.current.length <= 2) return
+      onChange(stopsRef.current.filter(s => s.id !== stopId))
+    },
+    [disabled, onChange]
+  )
+
+  const sortedStops = useMemo(() => [...stops].sort((a, b) => a.pos - b.pos), [stops])
+
+  return (
+    <svg
+      ref={svgRef}
+      width={width}
+      height={height}
+      style={{
+        display: 'block',
+        background: '#1a1d22',
+        borderRadius: 3,
+        cursor: disabled ? 'default' : 'crosshair',
+        userSelect: 'none',
+      }}
+    >
+      {/* Clickable background to add stops */}
+      <rect x={0} y={0} width={width} height={height} fill="transparent" onClick={handleBgClick} />
+      {sortedStops.length >= 2 && (
+        <path d={lineGen(sortedStops) ?? undefined} fill="none" stroke="#3b82f6" strokeWidth={1.5} />
+      )}
+      {sortedStops.map(stop => (
+        <g key={stop.id}>
+          {/* Large transparent hit area for easier grabbing */}
+          <circle
+            cx={xScale(stop.pos)}
+            cy={yScale(stop.val)}
+            r={8}
+            fill="transparent"
+            style={{ cursor: disabled ? 'default' : draggingId === stop.id ? 'grabbing' : 'grab' }}
+            onMouseDown={e => handleStopMouseDown(e, stop.id)}
+            onDoubleClick={e => handleStopDoubleClick(e, stop.id)}
+          />
+          {/* Visible control point */}
+          <circle
+            cx={xScale(stop.pos)}
+            cy={yScale(stop.val)}
+            r={4}
+            fill={draggingId === stop.id ? '#60a5fa' : '#3b82f6'}
+            stroke="#1e3a8a"
+            strokeWidth={1.5}
+            pointerEvents="none"
+          />
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/noodles-editor/src/noodles/components/ramp-editor.tsx
+++ b/noodles-editor/src/noodles/components/ramp-editor.tsx
@@ -115,8 +115,8 @@ export default function RampEditor({
       const x = e.clientX - rect.left
       const y = e.clientY - rect.top
       const pos = Math.max(0, Math.min(1, xScale.invert(x)))
-      const val = yScale.invert(y)
-      const newStop: RampStop = { id: crypto.randomUUID(), pos, val }
+      const val = Math.max(0, Math.min(1, yScale.invert(y)))
+      const newStop: RampStop = { id: crypto.randomUUID(), pos, val, interp: 'smooth' }
       const newStops = [...stopsRef.current, newStop].sort((a, b) => a.pos - b.pos)
       onChange(newStops)
     },
@@ -133,13 +133,17 @@ export default function RampEditor({
       const capturedYScale = yScale.copy()
       setDraggingId(stopId)
 
+      const sorted = [...stopsRef.current].sort((a, b) => a.pos - b.pos)
+      const isFirst = sorted[0]?.id === stopId
+      const isLast = sorted[sorted.length - 1]?.id === stopId
+
       const onMouseMove = (moveEvent: MouseEvent) => {
         if (!svgRef.current) return
         const rect = svgRef.current.getBoundingClientRect()
         const x = moveEvent.clientX - rect.left
         const y = moveEvent.clientY - rect.top
-        const newPos = Math.max(0, Math.min(1, capturedXScale.invert(x)))
-        const newVal = capturedYScale.invert(y)
+        const newPos = isFirst ? 0 : isLast ? 1 : Math.max(0, Math.min(1, capturedXScale.invert(x)))
+        const newVal = Math.max(0, Math.min(1, capturedYScale.invert(y)))
         const updated = stopsRef.current
           .map(s => (s.id === stopId ? { ...s, pos: newPos, val: newVal } : s))
           .sort((a, b) => a.pos - b.pos)

--- a/noodles-editor/src/noodles/components/ramp-editor.tsx
+++ b/noodles-editor/src/noodles/components/ramp-editor.tsx
@@ -1,4 +1,4 @@
-import { curveMonotoneX, line, scaleLinear } from 'd3'
+import { curveLinear, line, scaleLinear } from 'd3'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 export interface RampStop {
@@ -50,7 +50,7 @@ export default function RampEditor({
       line<RampStop>()
         .x(d => xScale(d.pos))
         .y(d => yScale(d.val))
-        .curve(curveMonotoneX),
+        .curve(curveLinear),
     [xScale, yScale]
   )
 
@@ -62,10 +62,15 @@ export default function RampEditor({
   })
 
   const [draggingId, setDraggingId] = useState<string | null>(null)
+  // Suppress the second click of a double-click (which would add two stops)
+  const lastClickTimeRef = useRef(0)
 
   const handleBgClick = useCallback(
     (e: React.MouseEvent<SVGRectElement>) => {
       if (disabled) return
+      const now = Date.now()
+      if (now - lastClickTimeRef.current < 300) return
+      lastClickTimeRef.current = now
       const rect = svgRef.current!.getBoundingClientRect()
       const x = e.clientX - rect.left
       const y = e.clientY - rect.top

--- a/noodles-editor/src/noodles/components/ramp-editor.tsx
+++ b/noodles-editor/src/noodles/components/ramp-editor.tsx
@@ -75,23 +75,14 @@ export default function RampEditor({
 }: RampEditorProps) {
   const stops = stopsProp.length > 0 ? stopsProp : []
 
-  const [yMin, yMax] = useMemo(() => {
-    if (stops.length === 0) return [0, 1]
-    const vals = stops.map(s => s.val)
-    const min = Math.min(...vals)
-    const max = Math.max(...vals)
-    const range = max - min || 1
-    return [min - range * 0.15, max + range * 0.15]
-  }, [stops])
-
   const xScale = useMemo(
     () => scaleLinear().domain([0, 1]).range([PAD, width - PAD]),
     [width]
   )
 
   const yScale = useMemo(
-    () => scaleLinear().domain([yMin, yMax]).range([height - PAD, PAD]),
-    [yMin, yMax, height]
+    () => scaleLinear().domain([0, 1]).range([height - PAD, PAD]),
+    [height]
   )
 
   const svgRef = useRef<SVGSVGElement>(null)

--- a/noodles-editor/src/noodles/components/ramp-editor.tsx
+++ b/noodles-editor/src/noodles/components/ramp-editor.tsx
@@ -1,5 +1,6 @@
-import { curveLinear, line, scaleLinear } from 'd3'
+import { curveLinear, curveMonotoneX, line, scaleLinear } from 'd3'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { RampCurveType } from '../operators'
 
 export interface RampStop {
   id: string
@@ -13,6 +14,14 @@ interface RampEditorProps {
   disabled?: boolean
   width?: number
   height?: number
+  curveType?: RampCurveType
+  activeStopId?: string | null
+  onActivate?: (id: string) => void
+}
+
+const curveMap = {
+  linear: curveLinear,
+  smooth: curveMonotoneX,
 }
 
 const PAD = 12
@@ -23,6 +32,9 @@ export default function RampEditor({
   disabled = false,
   width = 220,
   height = 100,
+  curveType = 'linear',
+  activeStopId,
+  onActivate,
 }: RampEditorProps) {
   const stops = stopsProp.length > 0 ? stopsProp : []
 
@@ -50,8 +62,8 @@ export default function RampEditor({
       line<RampStop>()
         .x(d => xScale(d.pos))
         .y(d => yScale(d.val))
-        .curve(curveLinear),
-    [xScale, yScale]
+        .curve(curveMap[curveType]),
+    [xScale, yScale, curveType]
   )
 
   const svgRef = useRef<SVGSVGElement>(null)
@@ -87,6 +99,7 @@ export default function RampEditor({
     (e: React.MouseEvent<SVGCircleElement>, stopId: string) => {
       if (disabled) return
       e.stopPropagation()
+      onActivate?.(stopId)
       // Capture scales at drag start — avoids jank when y-axis auto-rescales during drag
       const capturedXScale = xScale.copy()
       const capturedYScale = yScale.copy()
@@ -159,13 +172,13 @@ export default function RampEditor({
             onMouseDown={e => handleStopMouseDown(e, stop.id)}
             onDoubleClick={e => handleStopDoubleClick(e, stop.id)}
           />
-          {/* Visible control point */}
+          {/* Visible control point — white when active, blue otherwise */}
           <circle
             cx={xScale(stop.pos)}
             cy={yScale(stop.val)}
-            r={4}
-            fill={draggingId === stop.id ? '#60a5fa' : '#3b82f6'}
-            stroke="#1e3a8a"
+            r={activeStopId === stop.id ? 5 : 4}
+            fill={activeStopId === stop.id ? '#ffffff' : draggingId === stop.id ? '#60a5fa' : '#3b82f6'}
+            stroke={activeStopId === stop.id ? '#3b82f6' : '#1e3a8a'}
             strokeWidth={1.5}
             pointerEvents="none"
           />

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -24,6 +24,7 @@ import {
   NumberOp,
   Operator,
   ProjectOp,
+  RampOp,
   RectangleOp,
   RerouteOp,
   ScatterplotLayerOp,
@@ -2459,5 +2460,75 @@ describe('RerouteOp', () => {
     const op = new RerouteOp('/reroute-0')
     expect(Object.keys(op.inputs)).toEqual(['value'])
     expect(Object.keys(op.outputs)).toEqual(['value'])
+  })
+})
+
+describe('RampOp', () => {
+  const stops2 = [
+    { id: 'a', pos: 0, val: 0 },
+    { id: 'b', pos: 1, val: 1 },
+  ]
+
+  it('uses default linear ramp when stops are empty', () => {
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 0, stops: [] }).value).toBe(0)
+    expect(op.execute({ position: 0.5, stops: [] }).value).toBe(0.5)
+    expect(op.execute({ position: 1, stops: [] }).value).toBe(1)
+  })
+
+  it('interpolates linearly between two stops', () => {
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 0, stops: stops2 }).value).toBe(0)
+    expect(op.execute({ position: 0.25, stops: stops2 }).value).toBe(0.25)
+    expect(op.execute({ position: 0.5, stops: stops2 }).value).toBe(0.5)
+    expect(op.execute({ position: 1, stops: stops2 }).value).toBe(1)
+  })
+
+  it('clamps below the first stop position', () => {
+    const stops = [
+      { id: 'a', pos: 0.2, val: 5 },
+      { id: 'b', pos: 0.8, val: 10 },
+    ]
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 0, stops }).value).toBe(5)
+    expect(op.execute({ position: 0.1, stops }).value).toBe(5)
+  })
+
+  it('clamps above the last stop position', () => {
+    const stops = [
+      { id: 'a', pos: 0.2, val: 5 },
+      { id: 'b', pos: 0.8, val: 10 },
+    ]
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 1, stops }).value).toBe(10)
+    expect(op.execute({ position: 0.9, stops }).value).toBe(10)
+  })
+
+  it('interpolates across multiple stops', () => {
+    const stops = [
+      { id: 'a', pos: 0, val: 0 },
+      { id: 'b', pos: 0.5, val: 10 },
+      { id: 'c', pos: 1, val: 0 },
+    ]
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 0.25, stops }).value).toBe(5)
+    expect(op.execute({ position: 0.75, stops }).value).toBe(5)
+  })
+
+  it('returns the only stop val for a single stop at any position', () => {
+    const stops = [{ id: 'a', pos: 0.5, val: 42 }]
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 0, stops }).value).toBe(42)
+    expect(op.execute({ position: 0.5, stops }).value).toBe(42)
+    expect(op.execute({ position: 1, stops }).value).toBe(42)
+  })
+
+  it('sorts unsorted stops before interpolating', () => {
+    const stops = [
+      { id: 'b', pos: 1, val: 10 },
+      { id: 'a', pos: 0, val: 0 },
+    ]
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 0.5, stops }).value).toBe(5)
   })
 })

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -2464,30 +2464,34 @@ describe('RerouteOp', () => {
 })
 
 describe('RampOp', () => {
-  const stops2 = [
-    { id: 'a', pos: 0, val: 0 },
-    { id: 'b', pos: 1, val: 1 },
+  const linear = 'linear' as const
+  const smooth = 'smooth' as const
+
+  const linearStops2 = [
+    { id: 'a', pos: 0, val: 0, interp: linear },
+    { id: 'b', pos: 1, val: 1, interp: linear },
   ]
 
-  it('uses default linear ramp when stops are empty', () => {
+  it('uses default smooth ramp when stops are empty', () => {
     const op = new RampOp('/ramp-0')
     expect(op.execute({ position: 0, stops: [] }).value).toBe(0)
-    expect(op.execute({ position: 0.5, stops: [] }).value).toBe(0.5)
     expect(op.execute({ position: 1, stops: [] }).value).toBe(1)
+    // smooth symmetric ramp: midpoint equals 0.5
+    expect(op.execute({ position: 0.5, stops: [] }).value).toBeCloseTo(0.5, 5)
   })
 
-  it('interpolates linearly between two stops', () => {
+  it('interpolates linearly between two stops with interp=linear', () => {
     const op = new RampOp('/ramp-0')
-    expect(op.execute({ position: 0, stops: stops2 }).value).toBe(0)
-    expect(op.execute({ position: 0.25, stops: stops2 }).value).toBe(0.25)
-    expect(op.execute({ position: 0.5, stops: stops2 }).value).toBe(0.5)
-    expect(op.execute({ position: 1, stops: stops2 }).value).toBe(1)
+    expect(op.execute({ position: 0, stops: linearStops2 }).value).toBe(0)
+    expect(op.execute({ position: 0.25, stops: linearStops2 }).value).toBe(0.25)
+    expect(op.execute({ position: 0.5, stops: linearStops2 }).value).toBe(0.5)
+    expect(op.execute({ position: 1, stops: linearStops2 }).value).toBe(1)
   })
 
   it('clamps below the first stop position', () => {
     const stops = [
-      { id: 'a', pos: 0.2, val: 5 },
-      { id: 'b', pos: 0.8, val: 10 },
+      { id: 'a', pos: 0.2, val: 5, interp: linear },
+      { id: 'b', pos: 0.8, val: 10, interp: linear },
     ]
     const op = new RampOp('/ramp-0')
     expect(op.execute({ position: 0, stops }).value).toBe(5)
@@ -2496,23 +2500,46 @@ describe('RampOp', () => {
 
   it('clamps above the last stop position', () => {
     const stops = [
-      { id: 'a', pos: 0.2, val: 5 },
-      { id: 'b', pos: 0.8, val: 10 },
+      { id: 'a', pos: 0.2, val: 5, interp: linear },
+      { id: 'b', pos: 0.8, val: 10, interp: linear },
     ]
     const op = new RampOp('/ramp-0')
     expect(op.execute({ position: 1, stops }).value).toBe(10)
     expect(op.execute({ position: 0.9, stops }).value).toBe(10)
   })
 
-  it('interpolates across multiple stops', () => {
+  it('interpolates linearly across multiple stops', () => {
     const stops = [
-      { id: 'a', pos: 0, val: 0 },
-      { id: 'b', pos: 0.5, val: 10 },
-      { id: 'c', pos: 1, val: 0 },
+      { id: 'a', pos: 0, val: 0, interp: linear },
+      { id: 'b', pos: 0.5, val: 10, interp: linear },
+      { id: 'c', pos: 1, val: 0, interp: linear },
     ]
     const op = new RampOp('/ramp-0')
     expect(op.execute({ position: 0.25, stops }).value).toBe(5)
     expect(op.execute({ position: 0.75, stops }).value).toBe(5)
+  })
+
+  it('hold interp returns left stop value until next stop', () => {
+    const stops = [
+      { id: 'a', pos: 0, val: 0, interp: 'hold' as const },
+      { id: 'b', pos: 0.5, val: 10, interp: 'hold' as const },
+      { id: 'c', pos: 1, val: 20, interp: 'hold' as const },
+    ]
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 0.25, stops }).value).toBe(0)
+    expect(op.execute({ position: 0.75, stops }).value).toBe(10)
+    expect(op.execute({ position: 1, stops }).value).toBe(20)
+  })
+
+  it('smooth interp passes through endpoints and is symmetric', () => {
+    const stops = [
+      { id: 'a', pos: 0, val: 0, interp: smooth },
+      { id: 'b', pos: 1, val: 1, interp: smooth },
+    ]
+    const op = new RampOp('/ramp-0')
+    expect(op.execute({ position: 0, stops }).value).toBeCloseTo(0, 5)
+    expect(op.execute({ position: 1, stops }).value).toBeCloseTo(1, 5)
+    expect(op.execute({ position: 0.5, stops }).value).toBeCloseTo(0.5, 5)
   })
 
   it('returns the only stop val for a single stop at any position', () => {
@@ -2525,8 +2552,8 @@ describe('RampOp', () => {
 
   it('sorts unsorted stops before interpolating', () => {
     const stops = [
-      { id: 'b', pos: 1, val: 10 },
-      { id: 'a', pos: 0, val: 0 },
+      { id: 'b', pos: 1, val: 10, interp: linear },
+      { id: 'a', pos: 0, val: 0, interp: linear },
     ]
     const op = new RampOp('/ramp-0')
     expect(op.execute({ position: 0.5, stops }).value).toBe(5)

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -5768,6 +5768,60 @@ export class ExpressionOp extends Operator<ExpressionOp> {
   }
 }
 
+function linearInterpolateRamp(
+  position: number,
+  sortedStops: Array<{ pos: number; val: number }>
+): number {
+  if (sortedStops.length === 1) return sortedStops[0].val
+  if (position <= sortedStops[0].pos) return sortedStops[0].val
+  if (position >= sortedStops[sortedStops.length - 1].pos)
+    return sortedStops[sortedStops.length - 1].val
+  for (let i = 0; i < sortedStops.length - 1; i++) {
+    const lo = sortedStops[i]
+    const hi = sortedStops[i + 1]
+    if (position >= lo.pos && position <= hi.pos) {
+      const range = hi.pos - lo.pos
+      if (range === 0) return lo.val
+      return lo.val + ((position - lo.pos) / range) * (hi.val - lo.val)
+    }
+  }
+  return 0
+}
+
+export class RampOp extends Operator<RampOp> {
+  static displayName = 'Ramp'
+  static description = 'Map a position (0–1) to a value using a user-defined curve'
+
+  createInputs() {
+    return {
+      position: new NumberField(0, { min: 0, max: 1, step: 0.01, accessor: true }),
+      stops: new DataField(),
+    }
+  }
+
+  createOutputs() {
+    return {
+      value: new NumberField(),
+    }
+  }
+
+  execute({
+    position,
+    stops,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    const rampStops: Array<{ pos: number; val: number }> =
+      !stops || (stops as unknown[]).length === 0
+        ? [
+            { pos: 0, val: 0 },
+            { pos: 1, val: 1 },
+          ]
+        : [...(stops as Array<{ pos: number; val: number }>)].sort((a, b) => a.pos - b.pos)
+
+    const value = composeAccessor(position, (p: number) => linearInterpolateRamp(p, rampStops))
+    return { value }
+  }
+}
+
 export class RectangleOp extends Operator<RectangleOp> {
   static displayName = 'Rectangle'
   static description =
@@ -7098,6 +7152,7 @@ export const opTypes = {
   PolygonLayerOp,
   ProjectOp,
   QuadkeyLayerOp,
+  RampOp,
   RandomizeAttributeOp,
   RasterTileLayerOp,
   RectangleOp,

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -5768,29 +5768,11 @@ export class ExpressionOp extends Operator<ExpressionOp> {
   }
 }
 
-function linearInterpolateRamp(
-  position: number,
-  sortedStops: Array<{ pos: number; val: number }>
-): number {
-  if (sortedStops.length === 1) return sortedStops[0].val
-  if (position <= sortedStops[0].pos) return sortedStops[0].val
-  if (position >= sortedStops[sortedStops.length - 1].pos)
-    return sortedStops[sortedStops.length - 1].val
-  for (let i = 0; i < sortedStops.length - 1; i++) {
-    const lo = sortedStops[i]
-    const hi = sortedStops[i + 1]
-    if (position >= lo.pos && position <= hi.pos) {
-      const range = hi.pos - lo.pos
-      if (range === 0) return lo.val
-      return lo.val + ((position - lo.pos) / range) * (hi.val - lo.val)
-    }
-  }
-  return 0
-}
+export type RampInterpType = 'linear' | 'smooth' | 'hold'
 
 // Tangent slopes matching D3's curveMonotoneX (Fritsch-Carlson algorithm)
 // so the smooth computation result matches the visual curve exactly
-function monotoneSlopes(stops: Array<{ pos: number; val: number }>): number[] {
+export function monotoneSlopes(stops: Array<{ pos: number; val: number }>): number[] {
   const n = stops.length
   const m = new Array<number>(n).fill(0)
   if (n < 2) return m
@@ -5815,9 +5797,10 @@ function monotoneSlopes(stops: Array<{ pos: number; val: number }>): number[] {
   return m
 }
 
-function smoothInterpolateRamp(
+// Per-segment interpolation: uses each stop's interp type for the segment that follows it
+function interpolateRamp(
   position: number,
-  sortedStops: Array<{ pos: number; val: number }>
+  sortedStops: Array<{ pos: number; val: number; interp?: RampInterpType }>
 ): number {
   const n = sortedStops.length
   if (n === 1) return sortedStops[0].val
@@ -5827,27 +5810,30 @@ function smoothInterpolateRamp(
   let i = 0
   while (i < n - 2 && position >= sortedStops[i + 1].pos) i++
 
-  const x0 = sortedStops[i].pos
-  const x1 = sortedStops[i + 1].pos
-  const y0 = sortedStops[i].val
-  const y1 = sortedStops[i + 1].val
-  const h = x1 - x0
-  if (h === 0) return y0
+  const s0 = sortedStops[i]
+  const s1 = sortedStops[i + 1]
+  const h = s1.pos - s0.pos
+  if (h === 0) return s0.val
 
+  const interp = s0.interp ?? 'linear'
+
+  if (interp === 'hold') return s0.val
+
+  const t = (position - s0.pos) / h
+
+  if (interp === 'linear') return s0.val + t * (s1.val - s0.val)
+
+  // smooth: cubic Hermite with PCHIP slopes
   const slopes = monotoneSlopes(sortedStops)
-  const t = (position - x0) / h
   const t2 = t * t
   const t3 = t2 * t
-  // Cubic Hermite basis functions
   return (
-    (2 * t3 - 3 * t2 + 1) * y0 +
+    (2 * t3 - 3 * t2 + 1) * s0.val +
     (t3 - 2 * t2 + t) * h * slopes[i] +
-    (-2 * t3 + 3 * t2) * y1 +
+    (-2 * t3 + 3 * t2) * s1.val +
     (t3 - t2) * h * slopes[i + 1]
   )
 }
-
-export type RampCurveType = 'linear' | 'smooth'
 
 export class RampOp extends Operator<RampOp> {
   static displayName = 'Ramp'
@@ -5857,9 +5843,6 @@ export class RampOp extends Operator<RampOp> {
     return {
       // softMin/softMax suggests 0-1 in the UI without hard-clamping accessor functions
       position: new NumberField(0, { softMin: 0, softMax: 1, step: 0.01, accessor: true }),
-      curveType: new StringLiteralField('linear' as RampCurveType, {
-        values: ['linear', 'smooth'] as const,
-      }),
       stops: new DataField(),
     }
   }
@@ -5873,18 +5856,18 @@ export class RampOp extends Operator<RampOp> {
   execute({
     position,
     stops,
-    curveType,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    const rampStops: Array<{ pos: number; val: number }> =
+    const rampStops: Array<{ pos: number; val: number; interp?: RampInterpType }> =
       !stops || (stops as unknown[]).length === 0
         ? [
             { pos: 0, val: 0 },
             { pos: 1, val: 1 },
           ]
-        : [...(stops as Array<{ pos: number; val: number }>)].sort((a, b) => a.pos - b.pos)
+        : [...(stops as Array<{ pos: number; val: number; interp?: RampInterpType }>)].sort(
+            (a, b) => a.pos - b.pos
+          )
 
-    const interpolate = curveType === 'smooth' ? smoothInterpolateRamp : linearInterpolateRamp
-    const value = composeAccessor(position, (p: number) => interpolate(p, rampStops))
+    const value = composeAccessor(position, (p: number) => interpolateRamp(p, rampStops))
     return { value }
   }
 }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -5794,7 +5794,8 @@ export class RampOp extends Operator<RampOp> {
 
   createInputs() {
     return {
-      position: new NumberField(0, { min: 0, max: 1, step: 0.01, accessor: true }),
+      // softMin/softMax suggests 0-1 in the UI without hard-clamping accessor functions
+      position: new NumberField(0, { softMin: 0, softMax: 1, step: 0.01, accessor: true }),
       stops: new DataField(),
     }
   }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -5771,11 +5771,17 @@ export class ExpressionOp extends Operator<ExpressionOp> {
 export type RampInterpType = 'linear' | 'smooth' | 'hold'
 
 // Tangent slopes matching D3's curveMonotoneX (Fritsch-Carlson algorithm)
-// so the smooth computation result matches the visual curve exactly
+// so the smooth computation result matches the visual curve exactly.
+// For n=2, D3 draws a straight line, so we return the chord slope at both endpoints.
 export function monotoneSlopes(stops: Array<{ pos: number; val: number }>): number[] {
   const n = stops.length
   const m = new Array<number>(n).fill(0)
   if (n < 2) return m
+  if (n === 2) {
+    const h = stops[1].pos - stops[0].pos
+    const s = h !== 0 ? (stops[1].val - stops[0].val) / h : 0
+    return [s, s]
+  }
 
   // Interior slopes — D3 slope3 formula
   for (let i = 1; i < n - 1; i++) {
@@ -5815,7 +5821,7 @@ function interpolateRamp(
   const h = s1.pos - s0.pos
   if (h === 0) return s0.val
 
-  const interp = s0.interp ?? 'linear'
+  const interp = s0.interp ?? 'smooth'
 
   if (interp === 'hold') return s0.val
 
@@ -5860,8 +5866,8 @@ export class RampOp extends Operator<RampOp> {
     const rampStops: Array<{ pos: number; val: number; interp?: RampInterpType }> =
       !stops || (stops as unknown[]).length === 0
         ? [
-            { pos: 0, val: 0 },
-            { pos: 1, val: 1 },
+            { pos: 0, val: 0, interp: 'smooth' as RampInterpType },
+            { pos: 1, val: 1, interp: 'smooth' as RampInterpType },
           ]
         : [...(stops as Array<{ pos: number; val: number; interp?: RampInterpType }>)].sort(
             (a, b) => a.pos - b.pos

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -5788,6 +5788,67 @@ function linearInterpolateRamp(
   return 0
 }
 
+// Tangent slopes matching D3's curveMonotoneX (Fritsch-Carlson algorithm)
+// so the smooth computation result matches the visual curve exactly
+function monotoneSlopes(stops: Array<{ pos: number; val: number }>): number[] {
+  const n = stops.length
+  const m = new Array<number>(n).fill(0)
+  if (n < 2) return m
+
+  // Interior slopes — D3 slope3 formula
+  for (let i = 1; i < n - 1; i++) {
+    const h0 = stops[i].pos - stops[i - 1].pos
+    const h1 = stops[i + 1].pos - stops[i].pos
+    const s0 = h0 !== 0 ? (stops[i].val - stops[i - 1].val) / h0 : 0
+    const s1 = h1 !== 0 ? (stops[i + 1].val - stops[i].val) / h1 : 0
+    const p = (s0 * h1 + s1 * h0) / (h0 + h1)
+    const sign = (v: number) => (v < 0 ? -1 : v > 0 ? 1 : 0)
+    m[i] = (sign(s0) + sign(s1)) * Math.min(Math.abs(s0), Math.abs(s1), 0.5 * Math.abs(p)) || 0
+  }
+
+  // Endpoint slopes — D3 slope2 formula
+  const h0 = stops[1].pos - stops[0].pos
+  const hN = stops[n - 1].pos - stops[n - 2].pos
+  m[0] = h0 !== 0 ? ((3 * (stops[1].val - stops[0].val)) / h0 - m[1]) / 2 : m[1]
+  m[n - 1] = hN !== 0 ? ((3 * (stops[n - 1].val - stops[n - 2].val)) / hN - m[n - 2]) / 2 : m[n - 2]
+
+  return m
+}
+
+function smoothInterpolateRamp(
+  position: number,
+  sortedStops: Array<{ pos: number; val: number }>
+): number {
+  const n = sortedStops.length
+  if (n === 1) return sortedStops[0].val
+  if (position <= sortedStops[0].pos) return sortedStops[0].val
+  if (position >= sortedStops[n - 1].pos) return sortedStops[n - 1].val
+
+  let i = 0
+  while (i < n - 2 && position >= sortedStops[i + 1].pos) i++
+
+  const x0 = sortedStops[i].pos
+  const x1 = sortedStops[i + 1].pos
+  const y0 = sortedStops[i].val
+  const y1 = sortedStops[i + 1].val
+  const h = x1 - x0
+  if (h === 0) return y0
+
+  const slopes = monotoneSlopes(sortedStops)
+  const t = (position - x0) / h
+  const t2 = t * t
+  const t3 = t2 * t
+  // Cubic Hermite basis functions
+  return (
+    (2 * t3 - 3 * t2 + 1) * y0 +
+    (t3 - 2 * t2 + t) * h * slopes[i] +
+    (-2 * t3 + 3 * t2) * y1 +
+    (t3 - t2) * h * slopes[i + 1]
+  )
+}
+
+export type RampCurveType = 'linear' | 'smooth'
+
 export class RampOp extends Operator<RampOp> {
   static displayName = 'Ramp'
   static description = 'Map a position (0–1) to a value using a user-defined curve'
@@ -5796,6 +5857,9 @@ export class RampOp extends Operator<RampOp> {
     return {
       // softMin/softMax suggests 0-1 in the UI without hard-clamping accessor functions
       position: new NumberField(0, { softMin: 0, softMax: 1, step: 0.01, accessor: true }),
+      curveType: new StringLiteralField('linear' as RampCurveType, {
+        values: ['linear', 'smooth'] as const,
+      }),
       stops: new DataField(),
     }
   }
@@ -5809,6 +5873,7 @@ export class RampOp extends Operator<RampOp> {
   execute({
     position,
     stops,
+    curveType,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     const rampStops: Array<{ pos: number; val: number }> =
       !stops || (stops as unknown[]).length === 0
@@ -5818,7 +5883,8 @@ export class RampOp extends Operator<RampOp> {
           ]
         : [...(stops as Array<{ pos: number; val: number }>)].sort((a, b) => a.pos - b.pos)
 
-    const value = composeAccessor(position, (p: number) => linearInterpolateRamp(p, rampStops))
+    const interpolate = curveType === 'smooth' ? smoothInterpolateRamp : linearInterpolateRamp
+    const value = composeAccessor(position, (p: number) => interpolate(p, rampStops))
     return { value }
   }
 }


### PR DESCRIPTION
#### Background

Adds a `RampOp` operator that maps a position (0–1) to a value via a user-defined curve, inspired by Blender's Float Curve node. The implementation prioritizes ease of use over the reference implementation.

#### Change List
- `RampOp` operator with `position` (0–1, accessor-capable) and `stops` inputs, `value` output; computation uses linear interpolation between sorted stops
- `RampEditor` SVG component with document-level drag listeners (no missed events on fast mouse moves), large transparent hit targets (r=8) around visible control points (r=4), auto-scaling y-axis, click-to-add, and double-click-to-remove stops
- Registered in `nodeComponents`, `opTypes`, and the `number` category
- 7 unit tests covering default ramp, linear interpolation, clamping, multi-stop, single stop, and unsorted stop handling