### PR TITLE
feat: add LegendWidget operator

### DIFF
--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -103,7 +103,7 @@ export const categories = {
     'OrthographicView',
     'SplitMapViewState',
   ],
-  widget: ['CompassWidget', 'FpsWidget', 'FullscreenWidget', 'ScreenshotWidget', 'ZoomWidget'],
+  widget: ['CompassWidget', 'FpsWidget', 'FullscreenWidget', 'LegendWidget', 'ScreenshotWidget', 'ZoomWidget'],
 } as const
 
 // TODO: Remove this function when we fully migrate to operator displayNames

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -1,5 +1,6 @@
 import type { AnyNodeJSON } from 'SKIP-@xyflow/react'
 import * as deckWidgets from '@deck.gl/widgets'
+import { LegendWidget, type LegendWidgetProps } from './widgets/legend-widget'
 import type {
   Connection,
   DefaultEdgeOptions,
@@ -1566,8 +1567,11 @@ export function getNoodles(): Visualization {
             deckProps: {
               ...deckProps,
               layers: instantiatedLayers,
-              // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl widget types dynamically
-              widgets: widgets?.map(({ type, ...widget }) => new deckWidgets[type](widget)),
+              widgets: widgets?.map(({ type, ...widget }) => {
+                if (type === 'LegendWidget') return new LegendWidget(widget as unknown as LegendWidgetProps)
+                // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl widget types dynamically
+                return new deckWidgets[type](widget)
+              }),
             },
             mapProps,
           })

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -1,6 +1,5 @@
 import type { AnyNodeJSON } from 'SKIP-@xyflow/react'
 import * as deckWidgets from '@deck.gl/widgets'
-import { LegendWidget, type LegendWidgetProps } from './widgets/legend-widget'
 import type {
   Connection,
   DefaultEdgeOptions,
@@ -33,6 +32,7 @@ import { getPendingQuickStartAction } from '../components/quick-start-modal'
 import { analytics } from '../utils/analytics'
 import { getKeysForProject, getKeysStore } from './keys-store'
 import newProjectJSON from './new.json'
+import { LegendWidget, type LegendWidgetProps } from './widgets/legend-widget'
 
 // Get URLs for all example noodles.json files (lazy-loaded)
 const exampleProjectUrls = import.meta.glob('../examples/**/noodles.json', {
@@ -1568,7 +1568,8 @@ export function getNoodles(): Visualization {
               ...deckProps,
               layers: instantiatedLayers,
               widgets: widgets?.map(({ type, ...widget }) => {
-                if (type === 'LegendWidget') return new LegendWidget(widget as unknown as LegendWidgetProps)
+                if (type === 'LegendWidget')
+                  return new LegendWidget(widget as unknown as LegendWidgetProps)
                 // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl widget types dynamically
                 return new deckWidgets[type](widget)
               }),

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -1360,6 +1360,7 @@ export class ColorRampOp extends Operator<ColorRampOp> {
   createOutputs() {
     return {
       color: new ColorField(),
+      colorRamp: new ColorRampField(),
     }
   }
   execute({
@@ -1367,18 +1368,17 @@ export class ColorRampOp extends Operator<ColorRampOp> {
     colorScheme: _,
     value,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    const scale = (val: number) => {
-      const color = colorRamp(val)
-
-      // Some return values are in rgb, some are in hex. Convert them all to be safe
-      // TODO: VIS-813: Make all colors d3 Colors?
-      return d3Color(color)?.formatHex()
+    // Normalize all color formats to hex for consistency
+    // TODO: VIS-813: Make all colors d3 Colors?
+    const normalizedRamp = (val: number) => {
+      const c = colorRamp(val)
+      return d3Color(c)?.formatHex() ?? c
     }
 
     // Use composeAccessor helper to handle both static values and accessor functions
-    const color = composeAccessor(value, scale)
+    const color = composeAccessor(value, normalizedRamp)
 
-    return { color }
+    return { color, colorRamp: normalizedRamp }
   }
 }
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3883,6 +3883,54 @@ export class ScreenshotWidgetOp extends Operator<ScreenshotWidgetOp> {
   }
 }
 
+export class LegendWidgetOp extends Operator<LegendWidgetOp> {
+  static displayName = 'LegendWidget'
+  static description = 'Display a color scale legend overlay on the visualization'
+
+  createInputs() {
+    return {
+      colorRamp: new ColorRampField(),
+      label: new StringField(''),
+      minValue: new NumberField(0),
+      maxValue: new NumberField(1),
+      placement: new StringLiteralField('bottom-right', {
+        values: ['top-left', 'top-right', 'bottom-left', 'bottom-right'],
+      }),
+      steps: new NumberField(12, { min: 2, max: 32, step: 1, showByDefault: false }),
+    }
+  }
+
+  createOutputs() {
+    return {
+      widget: new WidgetField(),
+    }
+  }
+
+  execute({
+    colorRamp,
+    label,
+    minValue,
+    maxValue,
+    placement,
+    steps,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    const colorStops: string[] = []
+    for (let i = 0; i < steps; i++) {
+      colorStops.push(colorRamp(i / (steps - 1)))
+    }
+    const widget = {
+      id: this.id,
+      type: 'LegendWidget',
+      colorStops,
+      label,
+      minValue,
+      maxValue,
+      placement,
+    }
+    return { widget }
+  }
+}
+
 function createFrustumViewFields() {
   return {
     near: new NumberField(0.1, { min: 0, softMax: 1_000_000, step: 0.1, showByDefault: false }),
@@ -7081,6 +7129,7 @@ export const opTypes = {
   JSONOp,
   KmlToGeoJsonOp,
   LayerPropsOp,
+  LegendWidgetOp,
   LineLayerOp,
   MaplibreBasemapOp,
   MapRangeOp,

--- a/noodles-editor/src/noodles/widgets/legend-widget.ts
+++ b/noodles-editor/src/noodles/widgets/legend-widget.ts
@@ -1,0 +1,79 @@
+import {Widget} from '@deck.gl/core'
+import type {WidgetPlacement, WidgetProps} from '@deck.gl/core'
+
+export type LegendWidgetProps = WidgetProps & {
+  placement?: WidgetPlacement
+  viewId?: string | null
+  colorStops?: string[]
+  label?: string
+  minValue?: number
+  maxValue?: number
+}
+
+export class LegendWidget extends Widget<LegendWidgetProps> {
+  static defaultProps: Required<LegendWidgetProps> = {
+    ...Widget.defaultProps,
+    id: 'legend',
+    placement: 'bottom-right',
+    viewId: null,
+    colorStops: [],
+    label: '',
+    minValue: 0,
+    maxValue: 1,
+  }
+
+  className = 'deck-widget-legend'
+  placement: WidgetPlacement = 'bottom-right'
+
+  constructor(props: LegendWidgetProps = {}) {
+    super(props)
+    this.setProps(this.props)
+  }
+
+  setProps(props: Partial<LegendWidgetProps>): void {
+    if (props.placement !== undefined) this.placement = props.placement
+    if (props.viewId !== undefined) this.viewId = props.viewId
+    super.setProps(props)
+  }
+
+  onRenderHTML(rootElement: HTMLElement): void {
+    const {colorStops = [], label = '', minValue = 0, maxValue = 1} = this.props
+
+    // Outer container styles
+    rootElement.style.background = 'rgba(20, 20, 20, 0.82)'
+    rootElement.style.border = '1px solid rgba(255,255,255,0.12)'
+    rootElement.style.borderRadius = '6px'
+    rootElement.style.padding = '8px 10px'
+    rootElement.style.minWidth = '140px'
+    rootElement.style.maxWidth = '200px'
+    rootElement.style.fontFamily = 'system-ui, sans-serif'
+    rootElement.style.fontSize = '11px'
+    rootElement.style.color = 'rgba(255,255,255,0.85)'
+    rootElement.style.pointerEvents = 'none'
+    rootElement.style.userSelect = 'none'
+    rootElement.style.margin = '8px'
+
+    const gradient = colorStops.join(', ')
+    const minLabel = formatValue(minValue)
+    const maxLabel = formatValue(maxValue)
+
+    rootElement.innerHTML = `
+      ${label ? `<div style="margin-bottom:5px;font-weight:600;letter-spacing:0.02em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escapeHtml(label)}</div>` : ''}
+      <div style="height:10px;border-radius:3px;background:linear-gradient(to right,${gradient});margin-bottom:4px;"></div>
+      <div style="display:flex;justify-content:space-between;gap:8px;opacity:0.75;">
+        <span>${escapeHtml(minLabel)}</span>
+        <span>${escapeHtml(maxLabel)}</span>
+      </div>
+    `
+  }
+}
+
+function formatValue(v: number): string {
+  if (!Number.isFinite(v)) return String(v)
+  const s = v.toPrecision(4)
+  return String(parseFloat(s))
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}


### PR DESCRIPTION
## Summary

Add LegendWidget operator to display color scale legends as overlay on the visualization. Fixes categorization by renaming LegendOp to LegendWidgetOp to follow widget naming conventions.

## Change List
- Create LegendWidgetOp class with configurable color ramp, label, min/max values, and placement
- Implement custom LegendWidget class for HTML rendering with gradient visualization
- Wire up widget instantiation in noodles.tsx renderer
- Add 'LegendWidget' to widget category in categories.ts
- Add console error logging to error-boundary for better debugging

The operator now appears in the 'Widget' category of the add node menu with full description.