### PR TITLE
feat: download SVG from ViewerOp when input is a chart

### DIFF
--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -847,8 +847,23 @@ function NodeHeader({
   const downloadable = Boolean(op.asDownload)
   const createDownload = useCallback(() => {
     if (!op.asDownload) return
-    // TODO: make this more generic, or have the op handle it
     const data = op.asDownload()
+
+    if (data instanceof Element) {
+      const svgEl = data instanceof SVGElement ? data : data.querySelector('svg')
+      if (svgEl) {
+        const svgStr = new XMLSerializer().serializeToString(svgEl)
+        const blob = new Blob([svgStr], { type: 'image/svg+xml' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `${baseName}.svg`
+        a.click()
+        URL.revokeObjectURL(url)
+        return
+      }
+    }
+
     const blob = new Blob([JSON.stringify(data)], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')


### PR DESCRIPTION
#### Background

When a ViewerOp receives data from a ChartOp, the input is a \`<figure>\` DOM element (from Observable Plot) containing an \`<svg>\`. The download button was previously JSON-stringifying it, producing unusable output.

#### Change List
- In the \`createDownload\` callback, detect when the data is a DOM \`Element\` containing an SVG
- Serialize the SVG via \`XMLSerializer\` and download as \`.svg\`
- Non-SVG data continues to download as \`.json\`