### PR TITLE
feat: add scale input to LegendWidgetOp

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3897,6 +3897,7 @@ export class LegendWidgetOp extends Operator<LegendWidgetOp> {
         values: ['top-left', 'top-right', 'bottom-left', 'bottom-right'],
       }),
       steps: new NumberField(12, { min: 2, max: 32, step: 1, showByDefault: false }),
+      scale: new NumberField(1, { min: 0.25, max: 4, step: 0.25 }),
     }
   }
 
@@ -3913,6 +3914,7 @@ export class LegendWidgetOp extends Operator<LegendWidgetOp> {
     maxValue,
     placement,
     steps,
+    scale,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     const colorStops: string[] = []
     for (let i = 0; i < steps; i++) {
@@ -3926,6 +3928,7 @@ export class LegendWidgetOp extends Operator<LegendWidgetOp> {
       minValue,
       maxValue,
       placement,
+      scale,
     }
     return { widget }
   }

--- a/noodles-editor/src/noodles/widgets/legend-widget.ts
+++ b/noodles-editor/src/noodles/widgets/legend-widget.ts
@@ -8,6 +8,7 @@ export type LegendWidgetProps = WidgetProps & {
   label?: string
   minValue?: number
   maxValue?: number
+  scale?: number
 }
 
 export class LegendWidget extends Widget<LegendWidgetProps> {
@@ -20,6 +21,7 @@ export class LegendWidget extends Widget<LegendWidgetProps> {
     label: '',
     minValue: 0,
     maxValue: 1,
+    scale: 1,
   }
 
   className = 'deck-widget-legend'
@@ -37,7 +39,16 @@ export class LegendWidget extends Widget<LegendWidgetProps> {
   }
 
   onRenderHTML(rootElement: HTMLElement): void {
-    const {colorStops = [], label = '', minValue = 0, maxValue = 1} = this.props
+    const {colorStops = [], label = '', minValue = 0, maxValue = 1, scale = 1, placement = 'bottom-right'} = this.props
+
+    const originMap: Record<string, string> = {
+      'top-left': 'top left',
+      'top-right': 'top right',
+      'bottom-left': 'bottom left',
+      'bottom-right': 'bottom right',
+    }
+    rootElement.style.transform = `scale(${scale})`
+    rootElement.style.transformOrigin = originMap[placement] ?? 'bottom right'
 
     // Outer container styles
     rootElement.style.background = 'rgba(20, 20, 20, 0.82)'


### PR DESCRIPTION
#### Background

`LegendWidgetOp` renders as an HTML overlay with hardcoded pixel dimensions, making it tiny on high-resolution canvases with no way to resize it independently.

#### Change List
- Add `scale` input (NumberField, 0.25–4, default 1) to `LegendWidgetOp`
- Apply `transform: scale()` in `LegendWidget.onRenderHTML()` with `transform-origin` anchored to the placement corner so the widget grows/shrinks toward its edge

<img width="1222" height="733" alt="Screenshot 2026-04-03 at 11 13 49 AM" src="https://github.com/user-attachments/assets/2a429c74-33ab-48ca-8d80-360f5735d492" />
