### PR TITLE
fix(operators): preserve extension props in parseLayerProps output

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4193,10 +4193,12 @@ function parseLayerProps<P extends LayerProps>({
   const result = { ...props }
 
   if (validExtensions.length > 0) {
-    // Keep extensions as POJOs for now - they'll be instantiated later in noodles.tsx
-    result.extensions = validExtensions.map(e => e.extension)
+    // Keep full { extension, props } structure so downstream instantiation
+    // can pass constructor args (e.g. terrainDrawMode) to Extension classes.
+    result.extensions = validExtensions
 
-    // Merge extension props into the layer props
+    // Also merge extension props into the layer props — deck.gl reads
+    // extension-defined props (like terrainDrawMode) from the layer.
     for (const ext of validExtensions) {
       Object.assign(result, ext.props)
     }


### PR DESCRIPTION
## Summary
- `parseLayerProps` was stripping extension constructor args by mapping `validExtensions.map(e => e.extension)`, discarding the `props` object (e.g. `{ terrainDrawMode: 'offset' }`)
- Downstream instantiation received `{ type: 'TerrainExtension' }` with no constructor args, causing extensions like `_TerrainExtension` to fall back to defaults instead of using the nib-declared mode
- Keep the full `{ extension, props }` structure so consumers can pass both the extension type and its constructor args

## Test plan
- [x] Verify layers with `TerrainExtension` declared in nib `data.inputs.extensions` correctly drape on terrain
- [ ] Verify extension props (e.g. `terrainDrawMode: 'offset'`) are passed to extension constructors
- [ ] Verify backward compatibility with existing projects using extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)