### PR TITLE
feat(GlobeViewOp): add pitch, bearing, resolution, and touch rotation

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3699,9 +3699,13 @@ export class GlobeViewOp extends Operator<GlobeViewOp> {
     return {
       ...createBaseViewFields(),
       ...createGeoViewFields(),
+      resolution: new NumberField(10, { min: 1, max: 90, step: 1 }),
+      controller: new BooleanField(true),
       viewState: new CompoundPropsField({
         ...createGeoViewStateFields(),
         zoom: new NumberField(12, { min: 0, max: 24, step: 0.1 }),
+        bearing: new NumberField(0, { optional: true }),
+        pitch: new NumberField(0, { min: 0, max: 60, optional: true }),
       }),
     }
   }
@@ -3714,7 +3718,14 @@ export class GlobeViewOp extends Operator<GlobeViewOp> {
 
   execute(props: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     validateViewState(props.viewState)
-    return { view: new GlobeView({ id: this.id, ...props }) }
+    const { controller, ...viewProps } = props
+    return {
+      view: new GlobeView({
+        id: this.id,
+        ...viewProps,
+        controller: controller ? { touchRotate: true } : false,
+      }),
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `resolution`, `controller`, `bearing`, and `pitch` fields to `GlobeViewOp` — supported by deck.gl's GlobeView but missing from the operator, so values were silently dropped
- When `controller` is true, pass `{ touchRotate: true }` to GlobeView, enabling two-finger rotation for pitch/bearing on mobile

## Dependencies
> **Blocked on visgl/deck.gl#10207** — this PR relies on GlobeView pitch/bearing support landing in deck.gl first. The `pitch` and `bearing` viewState fields added here have no effect until that deck.gl PR is merged and released.

## Context
deck.gl's GlobeView supports pitch and bearing (via visgl/deck.gl#10207), but the noodles GlobeViewOp only exposed latitude, longitude, and zoom in its viewState. This meant there was no gesture path to change pitch or bearing on touch devices — `touchRotate` defaults to `false` in deck.gl's base Controller.

## Changes
- `resolution` NumberField (default 10, controls mesh detail for flat-to-3D conversion)
- `controller` BooleanField (default true, enables/disables interaction)
- `bearing` NumberField in viewState (optional)
- `pitch` NumberField in viewState (0-60, optional, matching GlobeView maxPitch)
- `execute()` converts `controller: true` to `{ touchRotate: true }` so mobile two-finger rotation works out of the box

## Test plan
- [ ] GlobeView renders with pitch/bearing values from nib definition
- [ ] Two-finger rotate gesture changes pitch/bearing on mobile
- [ ] Single-finger drag still pans the globe
- [ ] Pinch-zoom still works
- [ ] `controller: false` disables all interaction