### PR TITLE
fix: skip upload dialog when selecting existing project asset

### DIFF
--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -51,7 +51,7 @@ import type { Edge as GraphEdge } from '../graph-executor'
 import type { Edge } from '../noodles'
 import s from '../noodles.module.css'
 import { getFriendlyErrorMessage, type IOperator, type Operator } from '../operators'
-import { checkAssetExists, writeAsset } from '../storage'
+import { checkAssetExists, getAssetFileHandle, writeAsset } from '../storage'
 import { useEdgeConnectionStore } from '../store'
 import { getExpressionContext } from '../utils/expression-context'
 import { projectScheme } from '../utils/filesystem'
@@ -815,6 +815,15 @@ export function FileUrlFieldComponent({
 
     const exists = await checkAssetExists(activeStorageType, currentProjectName, file.name)
     if (exists) {
+      // If the user picked the exact same file already in the data directory, just use it
+      const existingHandle = await getAssetFileHandle(activeStorageType, currentProjectName, file.name)
+      if (existingHandle && await fileHandle.isSameEntry(existingHandle)) {
+        captureStart()
+        field.setValue(projectScheme + file.name)
+        setValue(projectScheme + file.name)
+        commitChange('Change file')
+        return
+      }
       captureStart()
       setPendingFile({ name: file.name, contents })
       setReplaceDialogOpen(true)

--- a/noodles-editor/src/noodles/storage.ts
+++ b/noodles-editor/src/noodles/storage.ts
@@ -527,6 +527,25 @@ export async function checkAssetExists(
   }
 }
 
+// Returns the FileSystemFileHandle for an existing asset, or null if unavailable
+export async function getAssetFileHandle(
+  type: StorageType,
+  projectName: string,
+  fileName: string
+): Promise<FileSystemFileHandle | null> {
+  if (type !== 'fileSystemAccess') return null
+  const projectDirectory = await getProjectDirectoryHandle(type, projectName, false)
+  if (!projectDirectory.success) return null
+  try {
+    const hasDataDir = await directoryExists(projectDirectory.data, DATA_DIRECTORY_NAME)
+    if (!hasDataDir) return null
+    const dataDirectory = await projectDirectory.data.getDirectoryHandle(DATA_DIRECTORY_NAME)
+    return await dataDirectory.getFileHandle(fileName)
+  } catch {
+    return null
+  }
+}
+
 // Write an asset file to a project's data directory
 export async function writeAsset(
   type: StorageType,


### PR DESCRIPTION
#### Background

When a user clicks the upload button on a FileUrlField and selects a file that already exists in the project's \`@/\` data directory (i.e. they navigated to the project's \`.data\` folder and picked the same file), the app was treating it as an overwrite and showing a "Replace file" dialog unnecessarily.

#### Change List
- Added \`getAssetFileHandle()\` to \`storage.ts\` to retrieve the \`FileSystemFileHandle\` for an existing project asset
- In \`doUpload()\`, when a file with the same name already exists, use \`FileSystemHandle.isSameEntry()\` to detect if the user picked the identical file — if so, set the \`@/filename\` reference directly without prompting to replace