### PR TITLE
feat: add viral accessor support to SwitchOp index input

### DIFF
--- a/noodles-editor/src/noodles/accessor-integration.test.ts
+++ b/noodles-editor/src/noodles/accessor-integration.test.ts
@@ -1,5 +1,6 @@
+import { Temporal } from 'temporal-polyfill'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { ColorRampOp, MapRangeOp, ScatterplotLayerOp } from './operators'
+import { ColorRampOp, MapRangeOp, ScatterplotLayerOp, SwitchOp } from './operators'
 
 describe('Accessor Integration Tests', () => {
   describe('ColorRampOp with accessors', () => {
@@ -342,6 +343,183 @@ describe('Accessor Integration Tests', () => {
       expect(positionFn(low)).toEqual([1, 1, 0])
       expect(positionFn(mid)).toEqual([2, 2, 0])
       expect(positionFn(high)).toEqual([3, 3, 0])
+    })
+  })
+
+  describe('SwitchOp with accessors', () => {
+    let op: SwitchOp
+
+    beforeEach(() => {
+      op = new SwitchOp('/test/switch')
+      op.createListeners()
+    })
+
+    it('should handle static index without blend', () => {
+      op.inputs.values.setValue(['red', 'green', 'blue'])
+      op.inputs.index.setValue(1)
+      op.inputs.blend.setValue(false)
+
+      const result = op.execute(op.data)
+      expect(result.value).toBe('green')
+    })
+
+    it('should handle static index with blend', () => {
+      op.inputs.values.setValue([0, 100, 200])
+      op.inputs.index.setValue(1.5)
+      op.inputs.blend.setValue(true)
+
+      const result = op.execute(op.data)
+      expect(result.value).toBe(150)
+    })
+
+    it('should handle accessor index without blend', () => {
+      const indexAccessor = (d: { category: number }) => d.category
+      op.inputs.values.setValue(['red', 'green', 'blue'])
+      op.inputs.index.setValue(indexAccessor)
+      op.inputs.blend.setValue(false)
+
+      const result = op.execute(op.data)
+      expect(typeof result.value).toBe('function')
+
+      const valueFn = result.value as (d: { category: number }) => string
+      expect(valueFn({ category: 0 })).toBe('red')
+      expect(valueFn({ category: 1 })).toBe('green')
+      expect(valueFn({ category: 2 })).toBe('blue')
+    })
+
+    it('should handle accessor index with blend', () => {
+      const indexAccessor = (d: { progress: number }) => d.progress
+      op.inputs.values.setValue([0, 100, 200])
+      op.inputs.index.setValue(indexAccessor)
+      op.inputs.blend.setValue(true)
+
+      const result = op.execute(op.data)
+      expect(typeof result.value).toBe('function')
+
+      const valueFn = result.value as (d: { progress: number }) => number
+      expect(valueFn({ progress: 0 })).toBe(0)
+      expect(valueFn({ progress: 1 })).toBe(100)
+      expect(valueFn({ progress: 1.5 })).toBe(150)
+      expect(valueFn({ progress: 2 })).toBe(200)
+    })
+
+    it('should handle empty values array', () => {
+      const indexAccessor = (d: { idx: number }) => d.idx
+      op.inputs.values.setValue([])
+      op.inputs.index.setValue(indexAccessor)
+      op.inputs.blend.setValue(false)
+
+      const result = op.execute(op.data)
+      const valueFn = result.value as (d: { idx: number }) => unknown
+      expect(valueFn({ idx: 0 })).toBeUndefined()
+    })
+
+    it('should clamp negative indices to 0', () => {
+      const indexAccessor = (d: { idx: number }) => d.idx
+      op.inputs.values.setValue(['first', 'second', 'third'])
+      op.inputs.index.setValue(indexAccessor)
+      op.inputs.blend.setValue(false)
+
+      const result = op.execute(op.data)
+      const valueFn = result.value as (d: { idx: number }) => string
+      expect(valueFn({ idx: -1 })).toBe('first')
+      expect(valueFn({ idx: -10 })).toBe('first')
+    })
+
+    it('should clamp indices beyond bounds', () => {
+      const indexAccessor = (d: { idx: number }) => d.idx
+      op.inputs.values.setValue(['first', 'second', 'third'])
+      op.inputs.index.setValue(indexAccessor)
+      op.inputs.blend.setValue(false)
+
+      const result = op.execute(op.data)
+      const valueFn = result.value as (d: { idx: number }) => string
+      expect(valueFn({ idx: 5 })).toBe('third')
+      expect(valueFn({ idx: 100 })).toBe('third')
+    })
+
+    it('should handle single value array', () => {
+      const indexAccessor = (d: { idx: number }) => d.idx
+      op.inputs.values.setValue(['only'])
+      op.inputs.index.setValue(indexAccessor)
+      op.inputs.blend.setValue(true)
+
+      const result = op.execute(op.data)
+      const valueFn = result.value as (d: { idx: number }) => string
+      expect(valueFn({ idx: 0 })).toBe('only')
+      expect(valueFn({ idx: 5 })).toBe('only')
+    })
+
+    it('should interpolate Temporal objects with accessor', () => {
+      const indexAccessor = (d: { progress: number }) => d.progress
+      const start = Temporal.Instant.from('2024-01-01T00:00:00Z')
+      const end = Temporal.Instant.from('2024-01-02T00:00:00Z')
+
+      op.inputs.values.setValue([start, end])
+      op.inputs.index.setValue(indexAccessor)
+      op.inputs.blend.setValue(true)
+
+      const result = op.execute(op.data)
+      const valueFn = result.value as (d: { progress: number }) => typeof start
+      const midpoint = valueFn({ progress: 0.5 })
+
+      expect(midpoint).toBeInstanceOf(Temporal.Instant)
+      expect(midpoint.toString()).toBe('2024-01-01T12:00:00Z')
+    })
+
+    it('should chain with MapRangeOp', () => {
+      // MapRange: normalize 0-100 to 0-2 (for selecting from 3 values)
+      const mapRange = new MapRangeOp('/test/map-range')
+      mapRange.createListeners()
+      const countAccessor = (d: { count: number }) => d.count
+      mapRange.inputs.val.setValue(countAccessor)
+      mapRange.inputs.inMin.setValue(0)
+      mapRange.inputs.inMax.setValue(100)
+      mapRange.inputs.outMin.setValue(0)
+      mapRange.inputs.outMax.setValue(2)
+
+      const { scaled } = mapRange.execute(mapRange.data)
+
+      // Switch: select color based on normalized value
+      op.inputs.values.setValue(['red', 'yellow', 'green'])
+      op.inputs.index.setValue(scaled)
+      op.inputs.blend.setValue(false)
+
+      const result = op.execute(op.data)
+      const colorFn = result.value as (d: { count: number }) => string
+
+      expect(colorFn({ count: 0 })).toBe('red')
+      expect(colorFn({ count: 50 })).toBe('yellow')
+      expect(colorFn({ count: 100 })).toBe('green')
+    })
+
+    it('should work with deck.gl ScatterplotLayer', () => {
+      const categoryAccessor = (d: { category: number }) => d.category
+      op.inputs.values.setValue(['#ff0000', '#00ff00', '#0000ff'])
+      op.inputs.index.setValue(categoryAccessor)
+      op.inputs.blend.setValue(false)
+
+      const { value: colorAccessor } = op.execute(op.data)
+
+      const scatterplot = new ScatterplotLayerOp('/test/scatterplot')
+      scatterplot.createListeners()
+      scatterplot.inputs.data.setValue([
+        { category: 0, pos: [0, 0] },
+        { category: 1, pos: [1, 1] },
+        { category: 2, pos: [2, 2] },
+      ])
+      scatterplot.inputs.getFillColor.setValue(colorAccessor)
+      scatterplot.inputs.getPosition.setValue((d: { pos: number[] }) => d.pos)
+
+      const { layer } = scatterplot.execute(scatterplot.data)
+
+      expect(typeof layer.getFillColor).toBe('function')
+
+      // Test that the accessor works correctly with actual data
+      const fillColorFn = layer.getFillColor as (d: { category: number; pos: number[] }) => number[]
+      expect(fillColorFn({ category: 0, pos: [0, 0] })).toEqual([255, 0, 0, 255])
+      expect(fillColorFn({ category: 1, pos: [1, 1] })).toEqual([0, 255, 0, 255])
+      expect(fillColorFn({ category: 2, pos: [2, 2] })).toEqual([0, 0, 255, 255])
     })
   })
 })

--- a/noodles-editor/src/noodles/accessor-integration.test.ts
+++ b/noodles-editor/src/noodles/accessor-integration.test.ts
@@ -372,6 +372,15 @@ describe('Accessor Integration Tests', () => {
       expect(result.value).toBe(150)
     })
 
+    it('should clamp static negative index to 0', () => {
+      op.inputs.values.setValue(['first', 'second', 'third'])
+      op.inputs.index.setValue(-1)
+      op.inputs.blend.setValue(false)
+
+      const result = op.execute(op.data)
+      expect(result.value).toBe('first')
+    })
+
     it('should handle accessor index without blend', () => {
       const indexAccessor = (d: { category: number }) => d.category
       op.inputs.values.setValue(['red', 'green', 'blue'])

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -2485,7 +2485,7 @@ export class SwitchOp extends Operator<SwitchOp> {
   createInputs() {
     return {
       values: new ListField(new DataField()),
-      index: new NumberField(0, { min: 0, step: 1 }),
+      index: new NumberField(0, { min: 0, step: 1, accessor: true }),
       blend: new BooleanField(false),
     }
   }
@@ -2499,44 +2499,48 @@ export class SwitchOp extends Operator<SwitchOp> {
     index,
     blend,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    if (!blend) {
-      const value = values[Math.floor(Math.min(index, values.length - 1))]
+    // Define helper functions
+    const selectValue = (values: unknown[], index: number): unknown => {
+      if (values.length === 0) return undefined
+      const clampedIndex = Math.max(0, Math.min(index, values.length - 1))
+      return values[Math.floor(clampedIndex)]
+    }
+
+    const blendValues = (values: unknown[], index: number): unknown => {
+      if (values.length === 0) return undefined
+      if (values.length === 1) return values[0]
+
+      const clampedIndex = Math.max(0, Math.min(index, values.length - 1))
+      const lowerIndex = Math.floor(clampedIndex)
+      const upperIndex = Math.ceil(clampedIndex)
+
+      if (lowerIndex === upperIndex) return values[lowerIndex]
+
+      const t = clampedIndex - lowerIndex
+      const lowerValue = values[lowerIndex]
+      const upperValue = values[upperIndex]
+
+      if (isTemporal(lowerValue) && isTemporal(upperValue)) {
+        return interpolateTemporal(lowerValue, upperValue, t)
+      }
+
+      return interpolate(lowerValue, upperValue)(t)
+    }
+
+    // Choose function based on blend mode
+    const selectFn = blend ? blendValues : selectValue
+
+    // Handle accessor input
+    if (isAccessor(index)) {
+      const value = (...args: unknown[]) => {
+        const idx = (index as (...args: unknown[]) => number)(...args)
+        return selectFn(values, idx)
+      }
       return { value }
     }
 
-    if (values.length === 0) {
-      return { value: undefined }
-    }
-
-    if (values.length === 1) {
-      return { value: values[0] }
-    }
-
-    // For multiple values, we need to find which two values to interpolate between
-    // and calculate the interpolation factor
-    const clampedIndex = Math.min(index, values.length - 1)
-    const lowerIndex = Math.floor(clampedIndex)
-    const upperIndex = Math.ceil(clampedIndex)
-
-    // If we're exactly on an index, return that value
-    if (lowerIndex === upperIndex) {
-      return { value: values[lowerIndex] }
-    }
-
-    // Calculate the interpolation factor between the two values
-    const t = clampedIndex - lowerIndex
-
-    // Check if we're dealing with Temporal objects
-    const lowerValue = values[lowerIndex]
-    const upperValue = values[upperIndex]
-
-    if (isTemporal(lowerValue) && isTemporal(upperValue)) {
-      const value = interpolateTemporal(lowerValue, upperValue, t)
-      return { value }
-    }
-
-    // Fall back to d3's interpolate for other types
-    const value = interpolate(lowerValue, upperValue)(t)
+    // Handle static input (unchanged behavior)
+    const value = selectFn(values, index as number)
     return { value }
   }
 }


### PR DESCRIPTION
#### Background

SwitchOp previously only accepted a static number for its `index` input. This adds support for the viral accessor pattern used by MathOp, MapRangeOp, and others, enabling data-driven selection per datum (e.g. category-based layer styling in deck.gl).

#### Change List
- Add `accessor: true` to SwitchOp's `index` NumberField
- Refactor `execute()` to handle both static and accessor index inputs, with support for both blend and non-blend modes
- Fix subtle bug: negative indices now correctly clamp to 0 via `Math.max(0, ...)`
- Add 11 tests covering static regression, accessor paths, edge cases, Temporal interpolation, MapRangeOp chaining, and deck.gl integration