### PR TITLE
fix: allow MaplibreBasemapOp mapStyle to accept both URLs and style objects

### DIFF
--- a/noodles-editor/src/noodles/__tests__/mapstyle-integration.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/mapstyle-integration.test.tsx
@@ -1,0 +1,168 @@
+// Integration test for MapStyleField accepting both URL strings and style objects
+// Tests the exact user scenario: JSONOp -> MaplibreBasemapOp (simplified from FileOp -> CodeOp -> MaplibreBasemapOp)
+import type { Node as ReactFlowNode } from '@xyflow/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { JSONOp, MaplibreBasemapOp } from '../operators'
+import { clearOps, getOp } from '../store'
+import { transformGraph } from '../transform-graph'
+
+describe('MapStyle Integration Tests', () => {
+  afterEach(() => {
+    clearOps()
+  })
+
+  it('accepts style objects from JSONOp -> MaplibreBasemapOp connection', () => {
+    // Create a minimal valid map style object
+    const styleObject = {
+      version: 8,
+      sources: {
+        'test-source': {
+          type: 'raster',
+          tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+          tileSize: 256,
+        }
+      },
+      layers: [
+        {
+          id: 'test-layer',
+          type: 'raster',
+          source: 'test-source'
+        }
+      ]
+    }
+
+    // Setup nodes - JSONOp parses JSON string to object
+    const nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[] = [
+      {
+        id: '/json-op',
+        type: 'JSONOp',
+        position: { x: 0, y: 0 },
+        data: {
+          inputs: {
+            text: JSON.stringify(styleObject)
+          }
+        },
+      },
+      {
+        id: '/maplibre',
+        type: 'MaplibreBasemapOp',
+        position: { x: 200, y: 0 },
+        data: {
+          inputs: {
+            viewState: { latitude: 0, longitude: 0, zoom: 1, pitch: 0, bearing: 0 }
+          }
+        },
+      },
+    ]
+
+    // Setup connection: JSONOp -> MaplibreBasemapOp.mapStyle
+    const edges = [
+      {
+        id: '/json-op.out.data->/maplibre.par.mapStyle',
+        source: '/json-op',
+        target: '/maplibre',
+        sourceHandle: 'out.data',
+        targetHandle: 'par.mapStyle',
+      },
+    ]
+
+    // Transform graph to establish connections
+    transformGraph({ nodes, edges })
+
+    const jsonOp = getOp('/json-op') as JSONOp
+    const maplibreOp = getOp('/maplibre') as MaplibreBasemapOp
+
+    // Verify connection is established
+    expect(maplibreOp.inputs.mapStyle.subscriptions.size).toBe(1)
+
+    // Execute JSONOp to produce the style object
+    const jsonResult = jsonOp.execute({ text: JSON.stringify(styleObject) })
+    expect(typeof jsonResult.data).toBe('object')
+    expect(jsonResult.data).toEqual(styleObject)
+
+    // Set JSONOp output which should propagate to MaplibreBasemapOp.mapStyle
+    jsonOp.outputs.data.next(jsonResult.data)
+
+    // Verify MaplibreBasemapOp's mapStyle field received the object
+    const mapStyleValue = maplibreOp.inputs.mapStyle.value
+    expect(typeof mapStyleValue).toBe('object')
+    expect(mapStyleValue).toHaveProperty('version', 8)
+    expect(mapStyleValue).toHaveProperty('sources')
+    expect(mapStyleValue).toHaveProperty('layers')
+
+    // Execute MaplibreBasemapOp and verify output passes through the object
+    const result = maplibreOp.execute({
+      mapStyle: mapStyleValue as unknown as string,
+      projection: 'mercator',
+      viewState: { latitude: 0, longitude: 0, zoom: 1, pitch: 0, bearing: 0 },
+      sky: { enabled: false, skyColor: '#88C6FC', horizonColor: '#ffffff', skyHorizonBlend: 0.8, atmosphereBlend: 0.5 },
+      light: { anchor: 'viewport', azimuthal: 210, polar: 30 },
+    })
+
+    expect(typeof result.maplibre.mapStyle).toBe('object')
+    expect(result.maplibre.mapStyle).toEqual(styleObject)
+  })
+
+  it('still accepts URL strings in mapStyle field', () => {
+    // Verify backward compatibility - string URLs still work
+    const nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[] = [
+      {
+        id: '/maplibre',
+        type: 'MaplibreBasemapOp',
+        position: { x: 0, y: 0 },
+        data: {
+          inputs: {
+            mapStyle: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+            viewState: { latitude: 37, longitude: -122, zoom: 10, pitch: 0, bearing: 0 }
+          }
+        },
+      },
+    ]
+
+    transformGraph({ nodes, edges: [] })
+
+    const maplibreOp = getOp('/maplibre') as MaplibreBasemapOp
+
+    expect(typeof maplibreOp.inputs.mapStyle.value).toBe('string')
+    expect(maplibreOp.inputs.mapStyle.value).toBe('https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json')
+
+    const result = maplibreOp.execute({
+      mapStyle: maplibreOp.inputs.mapStyle.value,
+      projection: 'mercator',
+      viewState: { latitude: 37, longitude: -122, zoom: 10, pitch: 0, bearing: 0 },
+      sky: { enabled: false, skyColor: '#88C6FC', horizonColor: '#ffffff', skyHorizonBlend: 0.8, atmosphereBlend: 0.5 },
+      light: { anchor: 'viewport', azimuthal: 210, polar: 30 },
+    })
+
+    expect(typeof result.maplibre.mapStyle).toBe('string')
+    expect(result.maplibre.mapStyle).toBe('https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json')
+  })
+
+  it('rejects invalid types (prevents validation errors)', () => {
+    // Verify that invalid types are rejected by the schema
+    const nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[] = [
+      {
+        id: '/maplibre',
+        type: 'MaplibreBasemapOp',
+        position: { x: 0, y: 0 },
+        data: {
+          inputs: {
+            mapStyle: '',
+            viewState: { latitude: 0, longitude: 0, zoom: 1, pitch: 0, bearing: 0 }
+          }
+        },
+      },
+    ]
+
+    transformGraph({ nodes, edges: [] })
+
+    const maplibreOp = getOp('/maplibre') as MaplibreBasemapOp
+
+    // Try to set an invalid type (number)
+    const initialValue = maplibreOp.inputs.mapStyle.value
+    maplibreOp.inputs.mapStyle.setValue(123 as unknown as string)
+
+    // Value should remain unchanged (validation failure)
+    expect(maplibreOp.inputs.mapStyle.value).toBe(initialValue)
+  })
+})

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -39,6 +39,7 @@ import {
   type FileUrlField,
   getFieldReferences,
   type IField,
+  type MapStyleField,
   type NumberField,
   Point2DField,
   Point3DField,
@@ -94,6 +95,7 @@ export const inputComponents = {
   'geopoint-3d': VectorFieldComponent,
   layer: EmptyFieldComponent,
   list: EmptyFieldComponent,
+  'map-style': MapStyleFieldComponent,
   number: NumberFieldComponent,
   string: TextFieldComponent,
   'string-literal': TextFieldComponent,
@@ -892,6 +894,192 @@ export function FileUrlFieldComponent({
             onClick={onUpload}
             title="Upload File"
             size="small"
+          />
+        </div>
+      </div>
+
+      <Dialog.Root open={replaceDialogOpen} onOpenChange={setReplaceDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className={menuStyles.dialogOverlay} />
+          <Dialog.Content className={menuStyles.dialogContent}>
+            <Dialog.Title className={menuStyles.dialogTitle}>Replace file</Dialog.Title>
+            <Dialog.Description className={menuStyles.dialogDescription}>
+              A file named "{pendingFile?.name}" already exists. Do you want to replace it?
+            </Dialog.Description>
+            <div className={menuStyles.dialogRightSlot}>
+              <Dialog.Close asChild>
+                <button type="button" className={menuStyles.dialogButton} onClick={onCancelReplace}>
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="button"
+                className={cx(menuStyles.dialogButton, menuStyles.red)}
+                onClick={onConfirmReplace}
+              >
+                Replace
+              </button>
+            </div>
+            <Dialog.Close asChild onClick={onCancelReplace}>
+              <button type="button" className={menuStyles.dialogIconButton} aria-label="Close">
+                <Cross2Icon />
+              </button>
+            </Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  )
+}
+
+export function MapStyleFieldComponent({
+  id,
+  field,
+  disabled,
+}: {
+  id: OpId
+  field: MapStyleField
+  disabled: boolean
+}) {
+  const [value, setValue] = useState(guardAccessorFallback(field.value))
+  const { captureStart, commitChange } = usePropertyHistory()
+
+  useEffect(() => {
+    const sub = field.subscribe(newVal => {
+      if (typeof newVal === 'function') return
+      setValue(newVal)
+    })
+    return () => sub.unsubscribe()
+  }, [field])
+
+  const isObject = typeof value === 'object' && value !== null
+  const displayValue = isObject ? '[Style Object]' : value
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.currentTarget.value
+    if (val !== field.value) {
+      setValue(val)
+    }
+  }
+
+  const onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const val = e.currentTarget.value
+    if (val !== field.value) {
+      field.setValue(val)
+    }
+    commitChange('Change map style')
+  }
+
+  const [replaceDialogOpen, setReplaceDialogOpen] = useState(false)
+  const [pendingFile, setPendingFile] = useState<{ name: string; contents: Blob } | null>(null)
+
+  const onUpload = async () => {
+    try {
+      await doUpload()
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      throw err
+    }
+  }
+
+  const doUpload = async () => {
+    const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
+    if (!currentProjectName) {
+      throw new Error('No project loaded. Please save or load a project first.')
+    }
+
+    const pickerOpts: OpenFilePickerOptions = field.accept
+      ? {
+          types: [{ description: 'Files', accept: extToMimeTypes(field.accept) }],
+          excludeAcceptAllOption: true,
+          multiple: false,
+        }
+      : { multiple: false }
+
+    const [fileHandle] = await window.showOpenFilePicker(pickerOpts)
+    const file = await fileHandle.getFile()
+    const buffer = await file.arrayBuffer()
+    const contents = new Blob([buffer], { type: file.type })
+
+    const exists = await checkAssetExists(activeStorageType, currentProjectName, file.name)
+    if (exists) {
+      const existingHandle = await getAssetFileHandle(activeStorageType, currentProjectName, file.name)
+      if (existingHandle && await fileHandle.isSameEntry(existingHandle)) {
+        captureStart()
+        field.setValue(projectScheme + file.name)
+        setValue(projectScheme + file.name)
+        commitChange('Change map style')
+        return
+      }
+      captureStart()
+      setPendingFile({ name: file.name, contents })
+      setReplaceDialogOpen(true)
+      return
+    }
+
+    const result = await writeAsset(activeStorageType, currentProjectName, file.name, contents)
+    if (!result.success) {
+      throw new Error(result.error?.message || `Failed to write file: ${file.name}`)
+    }
+
+    captureStart()
+    field.setValue(projectScheme + file.name)
+    setValue(projectScheme + file.name)
+    commitChange('Change map style')
+  }
+
+  const onConfirmReplace = async () => {
+    if (!pendingFile) return
+
+    const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
+    if (!currentProjectName) return
+
+    const result = await writeAsset(
+      activeStorageType,
+      currentProjectName,
+      pendingFile.name,
+      pendingFile.contents
+    )
+    if (!result.success) {
+      throw new Error(result.error?.message || `Failed to write file: ${pendingFile.name}`)
+    }
+
+    field.setValue(projectScheme + pendingFile.name)
+    setValue(projectScheme + pendingFile.name)
+    commitChange('Change map style')
+    setReplaceDialogOpen(false)
+    setPendingFile(null)
+  }
+
+  const onCancelReplace = () => {
+    setReplaceDialogOpen(false)
+    setPendingFile(null)
+  }
+
+  return (
+    <>
+      <div className={s.nodeFieldWrapper}>
+        <label className={s.nodeFieldLabel} htmlFor={id}>
+          {id}
+        </label>
+        <div className={cx('p-inputgroup', s.fieldFileInputGroup)}>
+          <InputText
+            id={id}
+            placeholder={isObject ? '' : 'https://'}
+            className={cx(s.fieldInput, s.fieldInputFileUrl)}
+            value={displayValue}
+            onFocus={captureStart}
+            onBlur={onBlur}
+            onChange={onChange}
+            disabled={disabled || isObject}
+          />
+          <Button
+            icon="pi pi-upload"
+            className={s.fieldInputUploadButton}
+            onClick={onUpload}
+            title="Upload File"
+            size="small"
+            disabled={isObject}
           />
         </div>
       </div>

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -957,14 +957,14 @@ export function MapStyleFieldComponent({
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.currentTarget.value
-    if (val !== field.value) {
+    if (typeof field.value !== 'object' && val !== field.value) {
       setValue(val)
     }
   }
 
   const onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const val = e.currentTarget.value
-    if (val !== field.value) {
+    if (typeof field.value !== 'object' && val !== field.value) {
       field.setValue(val)
     }
     commitChange('Change map style')

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -352,6 +352,7 @@ const handleClasses = {
   'geopoint-3d': s.handleVector,
   layer: s.handleLayer,
   list: s.handleList,
+  'map-style': s.handleString,
   number: s.handleNumber,
   string: s.handleString,
   'string-literal': s.handleString,

--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -15,12 +15,14 @@ import {
   getFieldReferences,
   LayerField,
   ListField,
+  MapStyleField,
   NumberField,
   Point2DField,
   Point3DField,
   parseChoices,
   StringField,
   StringLiteralField,
+  UnknownField,
 } from './fields'
 import { NumberOp } from './operators'
 import { clearOps, setOp } from './store'
@@ -244,6 +246,117 @@ describe('FileUrlField', () => {
 
     const noAccept = new FileUrlField()
     expect(noAccept.accept).toBeUndefined()
+  })
+})
+
+describe('MapStyleField', () => {
+  it('accepts string values (URLs)', () => {
+    const field = new MapStyleField('https://example.com/style.json')
+    expect(field.value).toEqual('https://example.com/style.json')
+
+    field.setValue('@/style.json')
+    expect(field.value).toEqual('@/style.json')
+
+    field.setValue('mapbox://styles/mapbox/streets-v11')
+    expect(field.value).toEqual('mapbox://styles/mapbox/streets-v11')
+  })
+
+  it('accepts style objects', () => {
+    const styleObject = {
+      version: 8,
+      sources: {},
+      layers: [],
+    }
+    const field = new MapStyleField()
+
+    field.setValue(styleObject)
+    expect(field.value).toEqual(styleObject)
+  })
+
+  it('accepts string values from connected fields', () => {
+    const stringField = new StringField('https://example.com/style.json')
+    const mapStyleField = new MapStyleField()
+
+    expect(canConnect(stringField, mapStyleField)).toBe(true)
+    mapStyleField.addConnection('field', stringField, 'value')
+
+    expect(mapStyleField.value).toEqual('https://example.com/style.json')
+  })
+
+  it('accepts object values from connected fields', () => {
+    const unknownField = new UnknownField({ version: 8, sources: {}, layers: [] })
+    const mapStyleField = new MapStyleField()
+
+    expect(canConnect(unknownField, mapStyleField)).toBe(true)
+    mapStyleField.addConnection('field', unknownField, 'value')
+
+    expect(mapStyleField.value).toEqual({ version: 8, sources: {}, layers: [] })
+  })
+
+  it('rejects invalid types (numbers)', () => {
+    const field = new MapStyleField()
+
+    field.setValue(123 as unknown as string)
+    // Should not update value on validation failure
+    expect(field.value).toEqual('')
+  })
+
+  it('rejects invalid types (arrays)', () => {
+    const field = new MapStyleField()
+
+    field.setValue([1, 2, 3] as unknown as string)
+    // Should not update value on validation failure
+    expect(field.value).toEqual('')
+  })
+
+  it('stores options on the instance', () => {
+    const field = new MapStyleField('', {
+      accept: '.json',
+      suggestions: [
+        { value: 'https://example.com/style1.json', label: 'Style 1' },
+        { value: 'https://example.com/style2.json', label: 'Style 2' },
+      ],
+    })
+
+    expect(field.accept).toEqual('.json')
+    expect(field.suggestions).toHaveLength(2)
+    expect(field.suggestions[0]).toEqual({
+      value: 'https://example.com/style1.json',
+      label: 'Style 1',
+    })
+  })
+
+  it('defaults to empty array for suggestions', () => {
+    const field = new MapStyleField()
+    expect(field.suggestions).toEqual([])
+  })
+
+  it('serializes and deserializes string values correctly', () => {
+    const field = new MapStyleField('https://example.com/style.json')
+    const serialized = JSON.parse(JSON.stringify(field.value))
+
+    expect(serialized).toEqual('https://example.com/style.json')
+
+    const newField = new MapStyleField()
+    newField.setValue(serialized)
+    expect(newField.value).toEqual('https://example.com/style.json')
+  })
+
+  it('serializes and deserializes object values correctly', () => {
+    const styleObject = {
+      version: 8,
+      sources: { osm: { type: 'vector', url: 'mapbox://mapbox.mapbox-streets-v8' } },
+      layers: [{ id: 'background', type: 'background', paint: { 'background-color': '#000' } }],
+    }
+    const field = new MapStyleField()
+    field.setValue(styleObject)
+
+    const serialized = JSON.parse(JSON.stringify(field.value))
+    expect(serialized).toEqual(styleObject)
+
+    const newField = new MapStyleField()
+    newField.setValue(serialized)
+    expect(newField.value).toEqual(styleObject)
   })
 })
 

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -280,7 +280,7 @@ export class FileUrlField extends Field<z.ZodString, FileUrlFieldOptions> {
 
 export interface MapStyleFieldOptions extends BaseFieldOptions {
   accept?: string
-  suggestions?: { value: string; label: string }[]
+  suggestions?: { value: string | Record<string, unknown>; label: string }[]
 }
 
 export class MapStyleField extends Field<

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -278,6 +278,31 @@ export class FileUrlField extends Field<z.ZodString, FileUrlFieldOptions> {
   }
 }
 
+export interface MapStyleFieldOptions extends BaseFieldOptions {
+  accept?: string
+  suggestions?: { value: string; label: string }[]
+}
+
+export class MapStyleField extends Field<
+  z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodUnknown>]>,
+  MapStyleFieldOptions
+> {
+  static type = 'map-style'
+  static defaultValue = ''
+  accept?: string
+  suggestions: { value: string; label: string }[]
+
+  constructor(defaultValue = '', options?: Partial<MapStyleFieldOptions>) {
+    super(defaultValue, options)
+    this.accept = options?.accept
+    this.suggestions = options?.suggestions ?? []
+  }
+
+  createSchema(_options?: Partial<MapStyleFieldOptions>) {
+    return z.union([z.string(), z.record(z.string(), z.unknown())])
+  }
+}
+
 export const IN_NS = 'par'
 export const OUT_NS = 'out'
 export type InOut = typeof IN_NS | typeof OUT_NS

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -869,6 +869,82 @@ describe('MaplibreBasemapOp', () => {
     })
     expect(result.maplibre.mapStyle).toBe('')
   })
+
+  it('accepts and passes through style objects', () => {
+    const op = new MaplibreBasemapOp('/maplibre-0')
+    const styleObject = {
+      version: 8,
+      sources: {
+        osm: {
+          type: 'raster',
+          tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+          tileSize: 256,
+        },
+      },
+      layers: [
+        {
+          id: 'osm',
+          type: 'raster',
+          source: 'osm',
+        },
+      ],
+    }
+
+    const result = op.execute({
+      mapStyle: styleObject as unknown as string,
+      projection: 'mercator',
+      viewState: { latitude: 37, longitude: -122, zoom: 10, pitch: 0, bearing: 0 },
+      sky: {
+        enabled: false,
+        skyColor: '#88C6FC',
+        horizonColor: '#ffffff',
+        skyHorizonBlend: 0.8,
+        atmosphereBlend: 0.5,
+      },
+      light: { anchor: 'viewport', azimuthal: 210, polar: 30 },
+    })
+
+    expect(result.maplibre.mapStyle).toEqual(styleObject)
+    expect(typeof result.maplibre.mapStyle).toBe('object')
+  })
+
+  it('output field accepts both strings and objects', () => {
+    const op = new MaplibreBasemapOp('/maplibre-0')
+
+    // Test with string
+    const resultString = op.execute({
+      mapStyle: 'https://example.com/style.json',
+      projection: 'mercator',
+      viewState: { latitude: 0, longitude: 0, zoom: 0, pitch: 0, bearing: 0 },
+      sky: {
+        enabled: false,
+        skyColor: '#88C6FC',
+        horizonColor: '#ffffff',
+        skyHorizonBlend: 0.8,
+        atmosphereBlend: 0.5,
+      },
+      light: { anchor: 'viewport', azimuthal: 210, polar: 30 },
+    })
+    expect(typeof resultString.maplibre.mapStyle).toBe('string')
+
+    // Test with object
+    const styleObj = { version: 8, sources: {}, layers: [] }
+    const resultObject = op.execute({
+      mapStyle: styleObj as unknown as string,
+      projection: 'mercator',
+      viewState: { latitude: 0, longitude: 0, zoom: 0, pitch: 0, bearing: 0 },
+      sky: {
+        enabled: false,
+        skyColor: '#88C6FC',
+        horizonColor: '#ffffff',
+        skyHorizonBlend: 0.8,
+        atmosphereBlend: 0.5,
+      },
+      light: { anchor: 'viewport', azimuthal: 210, polar: 30 },
+    })
+    expect(typeof resultObject.maplibre.mapStyle).toBe('object')
+    expect(resultObject.maplibre.mapStyle).toEqual(styleObj)
+  })
 })
 
 describe('MapViewOp', () => {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -162,6 +162,7 @@ import {
   type InOut,
   LayerField,
   ListField,
+  MapStyleField,
   mustacheRe,
   NumberField,
   OUT_NS,
@@ -3415,7 +3416,14 @@ export class MaplibreBasemapOp extends Operator<MaplibreBasemapOp> {
 
   createInputs() {
     return {
-      mapStyle: new FileUrlField(CARTO_DARK, { accept: '.json' }),
+      mapStyle: new MapStyleField(CARTO_DARK, {
+        accept: '.json',
+        suggestions: [
+          { value: CARTO_DARK, label: 'Carto Dark' },
+          { value: MAP_STYLES.CARTO_LIGHT, label: 'Carto Light' },
+          { value: MAP_STYLES.CARTO_VOYAGER, label: 'Carto Voyager' },
+        ],
+      }),
       projection: new StringLiteralField('mercator', {
         values: ['mercator', 'globe'],
         showByDefault: false,
@@ -3451,7 +3459,7 @@ export class MaplibreBasemapOp extends Operator<MaplibreBasemapOp> {
   createOutputs() {
     return {
       maplibre: new CompoundPropsField({
-        mapStyle: new FileUrlField(),
+        mapStyle: new MapStyleField(),
         projection: new StringField(),
         longitude: new NumberField(),
         latitude: new NumberField(),


### PR DESCRIPTION
#### Background

MaplibreBasemapOp's mapStyle field used FileUrlField with z.string() schema, which rejected style objects from operators like CodeOp. This caused silent validation failures where the field retained its default CARTO_DARK value instead of accepting programmatically modified map styles.

#### Change List
- Create MapStyleField with union schema (z.string() | z.record()) accepting both URL strings and style specification objects
- Add MapStyleFieldComponent displaying "[Style Object]" for objects while preserving file upload UI for strings
- Update MaplibreBasemapOp to use MapStyleField instead of FileUrlField for both input and output
- Register MapStyleField in inputComponents and handleClasses for proper rendering and handle styling
- Add comprehensive test coverage: 9 unit tests (fields.test.ts), 3 operator tests (operators.test.ts), 3 integration tests (mapstyle-integration.test.tsx)

Backward compatible - existing projects with URL strings work unchanged. Enables users to connect FileOp → CodeOp → MaplibreBasemapOp for programmatic map style modifications.