### PR TITLE
feat: add debug breakpoint toggle to operator nodes

### DIFF
--- a/noodles-editor/package.json
+++ b/noodles-editor/package.json
@@ -18,6 +18,7 @@
     "@microlink/react-json-view": "^1.31.15",
     "@observablehq/plot": "^0.6.17",
     "@radix-ui/colors": "^3.0.0",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-icons": "^1.3.2",

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -591,29 +591,29 @@ function NodeComponent({
             [s.wrapperDimmed]: isDimmed,
           })}
         >
-      <NodeHeader id={id} type={type} op={op} connectionErrors={connectionErrors} />
-      {resizeableNodes.includes(type) && (
-        <NodeResizer isVisible={selected} minWidth={200} minHeight={100} />
-      )}
-      <div className={s.content}>
-        {Object.entries(op.inputs)
-          .filter(([key]) => op.isFieldVisible(key))
-          .map(([key, field]) => (
-            <FieldComponent
-              key={key}
-              id={key}
-              field={field}
-              disabled={locked}
-              handle={PAR_HANDLE_OPTIONS}
-            />
-          ))}
-        <div className={s.outputHandleContainer}>
-          {Object.entries(op.outputs).map(([key, field]) => (
-            <OutputHandle key={key} id={key} field={field} />
-          ))}
+          <NodeHeader id={id} type={type} op={op} connectionErrors={connectionErrors} />
+          {resizeableNodes.includes(type) && (
+            <NodeResizer isVisible={selected} minWidth={200} minHeight={100} />
+          )}
+          <div className={s.content}>
+            {Object.entries(op.inputs)
+              .filter(([key]) => op.isFieldVisible(key))
+              .map(([key, field]) => (
+                <FieldComponent
+                  key={key}
+                  id={key}
+                  field={field}
+                  disabled={locked}
+                  handle={PAR_HANDLE_OPTIONS}
+                />
+              ))}
+            <div className={s.outputHandleContainer}>
+              {Object.entries(op.outputs).map(([key, field]) => (
+                <OutputHandle key={key} id={key} field={field} />
+              ))}
+            </div>
+          </div>
         </div>
-      </div>
-      </div>
       </ContextMenu.Trigger>
 
       <ContextMenu.Portal>

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -1,5 +1,6 @@
 import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder'
 import ReactJson from '@microlink/react-json-view'
+import * as ContextMenu from '@radix-ui/react-context-menu'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import {
   BaseEdge,
@@ -573,6 +574,7 @@ function NodeComponent({
     throw new Error(`Operator with id ${id} not found`)
   }
   const locked = useLocked(op)
+  const [breakpointEnabled, toggleBreakpoint] = useBreakpoint(op)
   const executionState = useExecutionState(op)
   const connectionErrors = useConnectionErrors(op)
   const hasConnectionErrors = connectionErrors.size > 0
@@ -580,13 +582,15 @@ function NodeComponent({
   useFieldVisibility(op)
 
   return (
-    <div
-      className={cx(s.wrapper, {
-        [s.wrapperError]: executionState.status === 'error' || hasConnectionErrors,
-        [s.wrapperExecuting]: executionState.status === 'executing',
-        [s.wrapperDimmed]: isDimmed,
-      })}
-    >
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>
+        <div
+          className={cx(s.wrapper, {
+            [s.wrapperError]: executionState.status === 'error' || hasConnectionErrors,
+            [s.wrapperExecuting]: executionState.status === 'executing',
+            [s.wrapperDimmed]: isDimmed,
+          })}
+        >
       <NodeHeader id={id} type={type} op={op} connectionErrors={connectionErrors} />
       {resizeableNodes.includes(type) && (
         <NodeResizer isVisible={selected} minWidth={200} minHeight={100} />
@@ -609,7 +613,24 @@ function NodeComponent({
           ))}
         </div>
       </div>
-    </div>
+      </div>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Portal>
+        <ContextMenu.Content className={s.contextMenu} sideOffset={5}>
+          <ContextMenu.CheckboxItem
+            className={s.contextMenuItem}
+            checked={breakpointEnabled}
+            onCheckedChange={toggleBreakpoint}
+          >
+            <ContextMenu.ItemIndicator className={s.contextMenuIndicator}>
+              <i className="pi pi-check" style={{ fontSize: '12px' }} />
+            </ContextMenu.ItemIndicator>
+            Debug Breakpoint
+          </ContextMenu.CheckboxItem>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
   )
 }
 
@@ -685,7 +706,6 @@ function NodeHeader({
   connectionErrors?: Map<string, string>
 }) {
   const [locked, setLocked] = useState(op.locked.value)
-  const [breakpointEnabled, toggleBreakpoint] = useBreakpoint(op)
   const executionState = useExecutionState(op)
   const hasConnectionErrors = connectionErrors && connectionErrors.size > 0
 
@@ -939,14 +959,6 @@ function NodeHeader({
           className={cx(s.headerLock, locked && s.headerLockLocked)}
           onClick={toggleLock}
           title="Toggle lock"
-          rounded
-          text
-        />
-        <Button
-          icon={`pi ${breakpointEnabled ? 'pi-stop-circle' : 'pi-circle'}`}
-          className={cx(s.headerDebug, breakpointEnabled && s.headerDebugEnabled)}
-          onClick={toggleBreakpoint}
-          title={breakpointEnabled ? 'Disable breakpoint' : 'Enable breakpoint'}
           rounded
           text
         />

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -391,7 +391,7 @@ function useLocked(op: Operator<IOperator>) {
   return locked
 }
 
-function useBreakpoint(op: Operator<IOperator>): [boolean, () => void] {
+function useBreakpoint(op: Operator<IOperator>): [boolean, (checked: boolean) => void] {
   const [enabled, setEnabled] = useState(op.breakpointEnabled.value)
 
   useEffect(() => {
@@ -399,8 +399,8 @@ function useBreakpoint(op: Operator<IOperator>): [boolean, () => void] {
     return () => subscription.unsubscribe()
   }, [op])
 
-  const toggle = useCallback(() => {
-    op.breakpointEnabled.next(!op.breakpointEnabled.value)
+  const toggle = useCallback((checked: boolean) => {
+    op.breakpointEnabled.next(checked)
   }, [op])
 
   return [enabled, toggle]

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -390,6 +390,21 @@ function useLocked(op: Operator<IOperator>) {
   return locked
 }
 
+function useBreakpoint(op: Operator<IOperator>): [boolean, () => void] {
+  const [enabled, setEnabled] = useState(op.breakpointEnabled.value)
+
+  useEffect(() => {
+    const subscription = op.breakpointEnabled.subscribe(setEnabled)
+    return () => subscription.unsubscribe()
+  }, [op])
+
+  const toggle = useCallback(() => {
+    op.breakpointEnabled.next(!op.breakpointEnabled.value)
+  }, [op])
+
+  return [enabled, toggle]
+}
+
 // Hook to subscribe to field visibility changes and trigger re-render
 function useFieldVisibility(op: Operator<IOperator>) {
   const [, setVisibility] = useState(op.visibleFields.value)
@@ -670,6 +685,7 @@ function NodeHeader({
   connectionErrors?: Map<string, string>
 }) {
   const [locked, setLocked] = useState(op.locked.value)
+  const [breakpointEnabled, toggleBreakpoint] = useBreakpoint(op)
   const executionState = useExecutionState(op)
   const hasConnectionErrors = connectionErrors && connectionErrors.size > 0
 
@@ -923,6 +939,14 @@ function NodeHeader({
           className={cx(s.headerLock, locked && s.headerLockLocked)}
           onClick={toggleLock}
           title="Toggle lock"
+          rounded
+          text
+        />
+        <Button
+          icon={`pi ${breakpointEnabled ? 'pi-stop-circle' : 'pi-circle'}`}
+          className={cx(s.headerDebug, breakpointEnabled && s.headerDebugEnabled)}
+          onClick={toggleBreakpoint}
+          title={breakpointEnabled ? 'Disable breakpoint' : 'Enable breakpoint'}
           rounded
           text
         />

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -232,15 +232,50 @@
   filter: brightness(0.5);
 }
 
-.headerDebug {
-  font-size: 10px;
-  padding: 0;
-  width: 22px;
-  height: 22px;
+/* Context Menu Styles */
+.contextMenu {
+  min-width: 180px;
+  background: var(--color-bg-base);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 4px;
+  box-shadow:
+    0 10px 38px -10px rgba(0, 0, 0, 0.35),
+    0 10px 20px -15px rgba(0, 0, 0, 0.2);
+  z-index: var(--z-index-chrome);
 }
 
-.headerDebugEnabled {
-  color: #ef4444;
+.contextMenuItem {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  padding-left: 28px;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  border-radius: 3px;
+  cursor: pointer;
+  outline: none;
+  user-select: none;
+  transition: background-color 0.15s;
+  position: relative;
+}
+
+.contextMenuItem:hover {
+  background: var(--color-bg-hover);
+}
+
+.contextMenuItem:focus {
+  background: var(--color-bg-hover);
+}
+
+.contextMenuIndicator {
+  position: absolute;
+  left: 8px;
+  width: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-primary);
 }
 
 .headerDownload {

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -232,6 +232,17 @@
   filter: brightness(0.5);
 }
 
+.headerDebug {
+  font-size: 10px;
+  padding: 0;
+  width: 22px;
+  height: 22px;
+}
+
+.headerDebugEnabled {
+  color: #ef4444;
+}
+
 .headerDownload {
   font-size: 10px;
   padding: 0;

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -2537,3 +2537,34 @@ describe('RerouteOp', () => {
     expect(Object.keys(op.outputs)).toEqual(['value'])
   })
 })
+
+describe('Operator debugging', () => {
+  it('has a breakpointEnabled property', () => {
+    const op = new NumberOp('/num-0')
+    expect(op.breakpointEnabled).toBeDefined()
+    expect(op.breakpointEnabled.value).toBe(false)
+  })
+
+  it('can toggle breakpoint state', () => {
+    const op = new NumberOp('/num-0')
+    expect(op.breakpointEnabled.value).toBe(false)
+
+    op.breakpointEnabled.next(true)
+    expect(op.breakpointEnabled.value).toBe(true)
+
+    op.breakpointEnabled.next(false)
+    expect(op.breakpointEnabled.value).toBe(false)
+  })
+
+  it('breakpoint state is observable', async () => {
+    const op = new NumberOp('/num-0')
+    const states: boolean[] = []
+
+    op.breakpointEnabled.subscribe(state => states.push(state))
+
+    op.breakpointEnabled.next(true)
+    op.breakpointEnabled.next(false)
+
+    expect(states).toEqual([false, true, false])
+  })
+})

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -233,6 +233,9 @@ export abstract class Operator<OP extends IOperator> {
 
   locked = new BehaviorSubject<boolean>(false)
 
+  // Debug breakpoint - when enabled, execution pauses at this operator
+  breakpointEnabled = new BehaviorSubject<boolean>(false)
+
   // Execution state for visual debugging
   executionState = new BehaviorSubject<ExecutionState>({ status: 'idle' })
 
@@ -469,6 +472,15 @@ export abstract class Operator<OP extends IOperator> {
       // Get current input values
       const inputValues = this.data
 
+      // Debug breakpoint - pause execution if enabled
+      if (this.breakpointEnabled.value) {
+        console.log(`[Breakpoint] Pausing execution at operator: ${this.id}`, {
+          inputs: inputValues,
+          operator: this,
+        })
+        debugger
+      }
+
       // Execute the operator
       const result = this.execute(inputValues)
       const finalResult = result instanceof Promise ? await result : result
@@ -619,6 +631,15 @@ export abstract class Operator<OP extends IOperator> {
           this.executionState.next({ status: 'executing' })
 
           try {
+            // Debug breakpoint - pause execution if enabled
+            if (this.breakpointEnabled.value) {
+              console.log(`[Breakpoint] Pausing execution at operator: ${this.id}`, {
+                inputs: inputValues,
+                operator: this,
+              })
+              debugger
+            }
+
             const result = this.execute(inputValues)
             const finalResult = result instanceof Promise ? await result : result
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6928,6 +6928,32 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -6947,6 +6973,49 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -7043,6 +7112,46 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
@@ -7130,6 +7239,37 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -27123,6 +27263,7 @@
         "@microlink/react-json-view": "^1.31.15",
         "@observablehq/plot": "^0.6.17",
         "@radix-ui/colors": "^3.0.0",
+        "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-icons": "^1.3.2",
@@ -27419,30 +27560,6 @@
       "version": "3.0.0",
       "license": "MIT"
     },
-    "noodles-editor/node_modules/@radix-ui/react-collection": {
-      "version": "1.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "noodles-editor/node_modules/@radix-ui/react-dialog": {
       "version": "1.1.15",
       "license": "MIT",
@@ -27473,19 +27590,6 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "noodles-editor/node_modules/@radix-ui/react-direction": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
@@ -27524,44 +27628,6 @@
         "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
-    "noodles-editor/node_modules/@radix-ui/react-menu": {
-      "version": "2.1.16",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "noodles-editor/node_modules/@radix-ui/react-menubar": {
       "version": "1.1.16",
       "license": "MIT",
@@ -27575,35 +27641,6 @@
         "@radix-ui/react-menu": "2.1.16",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "noodles-editor/node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.11",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {


### PR DESCRIPTION
#### Background

Developers need to debug operator execution by inspecting state during graph execution. Previously there was no way to pause at specific operators to examine inputs, outputs, and internal state.

#### Change List
- Add `breakpointEnabled` BehaviorSubject property to Operator class for reactive state
- Inject debugger statement before execute() in both pull-based and push-based execution paths
- Add right-click context menu to operator nodes with "Debug Breakpoint" checkbox toggle
- Install @radix-ui/react-context-menu for native right-click menu support
- Console logs operator ID and inputs when breakpoint is hit
- Add unit tests verifying breakpoint state and observability

When enabled, execution pauses in Chrome DevTools before the operator runs, allowing inspection of all state. Zero performance overhead when disabled.