### PR TITLE
feat: add SimplifyOp operator for GeoJSON simplification

### DIFF
--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -68,7 +68,6 @@ import { useActiveStorageType, useFileSystemStore } from './filesystem-store'
 import { findEdgeAtPosition, useConnectionDropOnEdge } from './hooks/use-connection-drop-on-edge'
 import { useKeyboardShortcut } from './hooks/use-keyboard-shortcut'
 import { useNodeDropOnEdge } from './hooks/use-node-drop-on-edge'
-import { EdgeSpatialIndex } from './utils/spatial-index'
 import { useProjectModifications } from './hooks/use-project-modifications'
 import type { IOperator, Operator, OutOp } from './operators'
 import { extensionMap } from './operators'
@@ -103,6 +102,7 @@ import {
   serializeEdges,
   serializeNodes,
 } from './utils/serialization'
+import { EdgeSpatialIndex } from './utils/spatial-index'
 import { calculateViewerPosition } from './utils/viewer-position'
 
 const ChatPanel = lazy(() => import('../ai-chat/chat-panel').then(m => ({ default: m.ChatPanel })))

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -6499,6 +6499,41 @@ export class GeoJsonTransformOp extends Operator<GeoJsonTransformOp> {
   }
 }
 
+export class SimplifyOp extends Operator<SimplifyOp> {
+  static displayName = 'Simplify'
+  static description = 'Simplify GeoJSON geometries using Ramer-Douglas-Peucker algorithm'
+  asDownload = () => this.outputData
+
+  createInputs() {
+    return {
+      feature: new GeoJsonField(),
+      tolerance: new NumberField(0.01, { min: 0.0001, softMax: 1, step: 0.01 }),
+      highQuality: new BooleanField(false),
+    }
+  }
+
+  createOutputs() {
+    return {
+      feature: new GeoJsonField(),
+    }
+  }
+
+  execute({
+    feature,
+    tolerance,
+    highQuality,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    // Apply Ramer-Douglas-Peucker simplification
+    const simplified = turf.simplify(feature, {
+      tolerance,
+      highQuality,
+      mutate: false, // Never mutate input to avoid side effects
+    })
+
+    return { feature: simplified }
+  }
+}
+
 // ==================== Core Layers (@deck.gl/layers) ====================
 
 export class BitmapLayerOp extends Operator<BitmapLayerOp> {
@@ -7639,6 +7674,7 @@ export const opTypes = {
   ScreenGridLayerOp,
   ScreenshotWidgetOp,
   SimpleMeshLayerOp,
+  SimplifyOp,
   SelectOp,
   SliceOp,
   SolidPolygonLayerOp,


### PR DESCRIPTION
#### Background
Adds a new operator to simplify GeoJSON geometries using the Ramer-Douglas-Peucker algorithm. This enables users to reduce complexity of LineStrings, Polygons, and other geometries while preserving overall shape, improving rendering performance and reducing file sizes.

#### Change List
- Add SimplifyOp operator class in operators.ts that wraps @turf/simplify
- Accept any GeoJSON input (Feature, FeatureCollection, or raw geometry)
- Provide tolerance parameter (default 0.01) to control simplification aggressiveness
- Provide highQuality boolean option for better quality results
- Export SimplifyOp in opTypes registry
- Support data export via asDownload method
- Formatter auto-fixed import ordering in noodles.tsx