### PR TITLE
feat: add BitmapOverlayWidget for screen-space image overlays

### DIFF
--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -104,7 +104,7 @@ export const categories = {
     'SplitMapViewState',
   ],
   widget: [
-    'Bitmap Overlay',
+    'BitmapOverlayWidget',
     'CompassWidget',
     'FpsWidget',
     'FullscreenWidget',

--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -103,7 +103,15 @@ export const categories = {
     'OrthographicView',
     'SplitMapViewState',
   ],
-  widget: ['CompassWidget', 'FpsWidget', 'FullscreenWidget', 'LegendWidget', 'ScreenshotWidget', 'ZoomWidget'],
+  widget: [
+    'Bitmap Overlay',
+    'CompassWidget',
+    'FpsWidget',
+    'FullscreenWidget',
+    'LegendWidget',
+    'ScreenshotWidget',
+    'ZoomWidget',
+  ],
 } as const
 
 // TODO: Remove this function when we fully migrate to operator displayNames

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -32,6 +32,7 @@ import { getPendingQuickStartAction } from '../components/quick-start-modal'
 import { analytics } from '../utils/analytics'
 import { getKeysForProject, getKeysStore } from './keys-store'
 import newProjectJSON from './new.json'
+import { BitmapOverlayWidget, type BitmapOverlayWidgetProps } from './widgets/bitmap-overlay-widget'
 import { LegendWidget, type LegendWidgetProps } from './widgets/legend-widget'
 
 // Get URLs for all example noodles.json files (lazy-loaded)
@@ -1658,6 +1659,8 @@ export function getNoodles(): Visualization {
               widgets: widgets?.map(({ type, ...widget }) => {
                 if (type === 'LegendWidget')
                   return new LegendWidget(widget as unknown as LegendWidgetProps)
+                if (type === 'BitmapOverlay')
+                  return new BitmapOverlayWidget(widget as unknown as BitmapOverlayWidgetProps)
                 // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl widget types dynamically
                 return new deckWidgets[type](widget)
               }),

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NumberField } from './fields'
 import {
   AccessorOp,
+  BitmapOverlayWidgetOp,
   BoundingBoxOp,
   ChartOp,
   CodeOp,
@@ -2961,5 +2962,103 @@ describe('Operator debugging', () => {
     op.breakpointEnabled.next(false)
 
     expect(states).toEqual([false, true, false])
+  })
+})
+
+describe('BitmapOverlayWidgetOp', () => {
+  it('creates a widget with default values', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    await op.pull()
+    expect(op.outputData.widget).toBeDefined()
+    expect(op.outputData.widget.id).toBe('/bitmap-overlay-0')
+    expect(op.outputData.widget.type).toBe('BitmapOverlay')
+    expect(op.outputData.widget.placement).toBe('top-right')
+    expect(op.outputData.widget.width).toBe(200)
+    expect(op.outputData.widget.height).toBe(200)
+    expect(op.outputData.widget.opacity).toBe(1)
+    expect(op.outputData.widget.scale).toBe(1)
+  })
+
+  it('accepts custom image URL', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.image.setValue('https://example.com/image.png')
+    await op.pull()
+    expect(op.outputData.widget.image).toBe('https://example.com/image.png')
+  })
+
+  it('accepts placement values', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.placement.setValue('bottom-left')
+    await op.pull()
+    expect(op.outputData.widget.placement).toBe('bottom-left')
+  })
+
+  it('accepts custom dimensions', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.width.setValue(300)
+    op.inputs.height.setValue(400)
+    await op.pull()
+    expect(op.outputData.widget.width).toBe(300)
+    expect(op.outputData.widget.height).toBe(400)
+  })
+
+  it('accepts opacity values', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.opacity.setValue(0.5)
+    await op.pull()
+    expect(op.outputData.widget.opacity).toBe(0.5)
+  })
+
+  it('accepts scale values', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.scale.setValue(2)
+    await op.pull()
+    expect(op.outputData.widget.scale).toBe(2)
+  })
+
+  it('includes viewId when provided', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.viewId.setValue('map-view')
+    await op.pull()
+    expect(op.outputData.widget.viewId).toBe('map-view')
+  })
+
+  it('excludes viewId when empty', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.viewId.setValue('')
+    await op.pull()
+    expect(op.outputData.widget.viewId).toBeUndefined()
+  })
+
+  it('supports fill placement for center positioning', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.placement.setValue('fill')
+    await op.pull()
+    expect(op.outputData.widget.placement).toBe('fill')
+  })
+
+  it('accepts offsetX values', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.offsetX.setValue(100)
+    await op.pull()
+    expect(op.outputData.widget.offsetX).toBe(100)
+  })
+
+  it('accepts offsetY values', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.offsetY.setValue(-50)
+    await op.pull()
+    expect(op.outputData.widget.offsetY).toBe(-50)
+  })
+
+  it('combines fill placement with offsets', async () => {
+    const op = new BitmapOverlayWidgetOp('/bitmap-overlay-0')
+    op.inputs.placement.setValue('fill')
+    op.inputs.offsetX.setValue(100)
+    op.inputs.offsetY.setValue(50)
+    await op.pull()
+    expect(op.outputData.widget.placement).toBe('fill')
+    expect(op.outputData.widget.offsetX).toBe(100)
+    expect(op.outputData.widget.offsetY).toBe(50)
   })
 })

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4326,6 +4326,62 @@ export class LegendWidgetOp extends Operator<LegendWidgetOp> {
   }
 }
 
+export class BitmapOverlayWidgetOp extends Operator<BitmapOverlayWidgetOp> {
+  static displayName = 'Bitmap Overlay'
+  static description = 'Display a bitmap image as a screen-space overlay'
+
+  createInputs() {
+    return {
+      image: new FileUrlField('', {
+        accept: '.png,.jpg,.jpeg,.gif,.webp,.svg',
+      }),
+      placement: new StringLiteralField('top-right', {
+        values: ['top-left', 'top-right', 'bottom-left', 'bottom-right', 'fill'],
+      }),
+      width: new NumberField(200, { min: 1, max: 2000, step: 1 }),
+      height: new NumberField(200, { min: 1, max: 2000, step: 1 }),
+      opacity: new NumberField(1, { min: 0, max: 1, step: 0.01 }),
+      scale: new NumberField(1, { min: 0.25, max: 4, step: 0.25 }),
+      offsetX: new NumberField(0, { min: -2000, max: 2000, step: 1, showByDefault: false }),
+      offsetY: new NumberField(0, { min: -2000, max: 2000, step: 1, showByDefault: false }),
+      viewId: new StringField('', { optional: true }),
+    }
+  }
+
+  createOutputs() {
+    return {
+      widget: new WidgetField(),
+    }
+  }
+
+  execute({
+    image,
+    placement,
+    width,
+    height,
+    opacity,
+    scale,
+    offsetX,
+    offsetY,
+    viewId,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    const widget = {
+      id: this.id,
+      type: 'BitmapOverlay',
+      image,
+      placement,
+      width,
+      height,
+      opacity,
+      scale,
+      offsetX,
+      offsetY,
+      ...(viewId && viewId !== '' ? { viewId } : {}),
+    }
+    return { widget }
+  }
+}
+
 function createFrustumViewFields() {
   return {
     near: new NumberField(0.1, { min: 0, softMax: 1_000_000, step: 0.1, showByDefault: false }),
@@ -7585,6 +7641,7 @@ export const opTypes = {
   ArcLayerOp,
   BezierCurveOp,
   BitmapLayerOp,
+  BitmapOverlayWidgetOp,
   BlendingOp,
   BooleanOp,
   BoundingBoxOp,

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4354,7 +4354,7 @@ export class BitmapOverlayWidgetOp extends Operator<BitmapOverlayWidgetOp> {
     }
   }
 
-  execute({
+  async execute({
     image,
     placement,
     width,
@@ -4364,11 +4364,33 @@ export class BitmapOverlayWidgetOp extends Operator<BitmapOverlayWidgetOp> {
     offsetX,
     offsetY,
     viewId,
-  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+  }: ExtractProps<typeof this.inputs>): Promise<ExtractProps<typeof this.outputs>> {
+    // Resolve project-relative paths (@/) to blob URLs
+    let resolvedImage = image
+    if (image?.startsWith(projectScheme)) {
+      const { readAssetBinary } = await import('./storage')
+      const { useFileSystemStore } = await import('./filesystem-store')
+
+      const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
+      if (!currentProjectName) {
+        throw new Error('No project loaded. Please save or load a project first.')
+      }
+
+      const fileName = image.substring(projectScheme.length)
+      const result = await readAssetBinary(activeStorageType, currentProjectName, fileName)
+      if (!result.success) {
+        throw new Error(result.error.message)
+      }
+
+      // Create blob URL from the binary data
+      const blob = new Blob([result.data])
+      resolvedImage = URL.createObjectURL(blob)
+    }
+
     const widget = {
       id: this.id,
       type: 'BitmapOverlay',
-      image,
+      image: resolvedImage,
       placement,
       width,
       height,

--- a/noodles-editor/src/noodles/widgets/bitmap-overlay-widget.ts
+++ b/noodles-editor/src/noodles/widgets/bitmap-overlay-widget.ts
@@ -1,0 +1,111 @@
+import type { WidgetPlacement, WidgetProps } from '@deck.gl/core'
+import { Widget } from '@deck.gl/core'
+
+export type BitmapOverlayWidgetProps = WidgetProps & {
+  placement?: WidgetPlacement | 'fill'
+  viewId?: string | null
+  image?: string
+  width?: number
+  height?: number
+  opacity?: number
+  scale?: number
+  offsetX?: number
+  offsetY?: number
+}
+
+export class BitmapOverlayWidget extends Widget<BitmapOverlayWidgetProps> {
+  static defaultProps: Required<BitmapOverlayWidgetProps> = {
+    ...Widget.defaultProps,
+    id: 'bitmap-overlay',
+    placement: 'top-right',
+    viewId: null,
+    image: '',
+    width: 200,
+    height: 200,
+    opacity: 1,
+    scale: 1,
+    offsetX: 0,
+    offsetY: 0,
+  }
+
+  className = 'deck-widget-bitmap-overlay'
+  placement: WidgetPlacement = 'top-right'
+
+  constructor(props: BitmapOverlayWidgetProps = {}) {
+    super(props)
+    this.setProps(this.props)
+  }
+
+  setProps(props: Partial<BitmapOverlayWidgetProps>): void {
+    if (props.placement !== undefined) this.placement = props.placement
+    if (props.viewId !== undefined) this.viewId = props.viewId
+    super.setProps(props)
+  }
+
+  onRenderHTML(rootElement: HTMLElement): void {
+    const {
+      image = '',
+      width = 200,
+      height = 200,
+      opacity = 1,
+      scale = 1,
+      placement = 'top-right',
+      offsetX = 0,
+      offsetY = 0,
+    } = this.props
+
+    const originMap: Record<string, string> = {
+      'top-left': 'top left',
+      'top-right': 'top right',
+      'bottom-left': 'bottom left',
+      'bottom-right': 'bottom right',
+      fill: 'center',
+    }
+
+    // For 'fill' placement, use absolute positioning with offsets
+    if (placement === 'fill') {
+      rootElement.style.position = 'absolute'
+      rootElement.style.left = '50%'
+      rootElement.style.top = '50%'
+      rootElement.style.transform = `translate(calc(-50% + ${offsetX}px), calc(-50% + ${offsetY}px)) scale(${scale})`
+      rootElement.style.transformOrigin = 'center'
+      rootElement.style.margin = '0'
+    } else {
+      // Corner placement with optional offsets
+      rootElement.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`
+      rootElement.style.transformOrigin = originMap[placement] ?? 'top right'
+      rootElement.style.margin = '8px'
+    }
+
+    rootElement.style.pointerEvents = 'none'
+    rootElement.style.userSelect = 'none'
+
+    if (!image) {
+      rootElement.innerHTML = ''
+      return
+    }
+
+    rootElement.innerHTML = `
+      <img
+        src="${escapeHtml(image)}"
+        style="
+          display: block;
+          width: ${width}px;
+          height: ${height}px;
+          opacity: ${opacity};
+          object-fit: contain;
+          border-radius: 4px;
+        "
+        alt="Bitmap overlay"
+      />
+    `
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/noodles-editor/src/noodles/widgets/bitmap-overlay-widget.ts
+++ b/noodles-editor/src/noodles/widgets/bitmap-overlay-widget.ts
@@ -1,5 +1,6 @@
 import type { WidgetPlacement, WidgetProps } from '@deck.gl/core'
 import { Widget } from '@deck.gl/core'
+import { escapeHtml } from './utils'
 
 export type BitmapOverlayWidgetProps = WidgetProps & {
   placement?: WidgetPlacement | 'fill'
@@ -29,7 +30,7 @@ export class BitmapOverlayWidget extends Widget<BitmapOverlayWidgetProps> {
   }
 
   className = 'deck-widget-bitmap-overlay'
-  placement: WidgetPlacement = 'top-right'
+  placement: WidgetPlacement | 'fill' = 'top-right'
 
   constructor(props: BitmapOverlayWidgetProps = {}) {
     super(props)
@@ -71,7 +72,10 @@ export class BitmapOverlayWidget extends Widget<BitmapOverlayWidgetProps> {
       rootElement.style.transformOrigin = 'center'
       rootElement.style.margin = '0'
     } else {
-      // Corner placement with optional offsets
+      // Corner placement with optional offsets - clear fill-specific styles
+      rootElement.style.position = ''
+      rootElement.style.left = ''
+      rootElement.style.top = ''
       rootElement.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`
       rootElement.style.transformOrigin = originMap[placement] ?? 'top right'
       rootElement.style.margin = '8px'
@@ -100,12 +104,4 @@ export class BitmapOverlayWidget extends Widget<BitmapOverlayWidgetProps> {
       />
     `
   }
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
 }

--- a/noodles-editor/src/noodles/widgets/bitmap-overlay-widget.ts
+++ b/noodles-editor/src/noodles/widgets/bitmap-overlay-widget.ts
@@ -31,6 +31,7 @@ export class BitmapOverlayWidget extends Widget<BitmapOverlayWidgetProps> {
 
   className = 'deck-widget-bitmap-overlay'
   placement: WidgetPlacement | 'fill' = 'top-right'
+  private imgElement: HTMLImageElement | null = null
 
   constructor(props: BitmapOverlayWidgetProps = {}) {
     super(props)
@@ -85,23 +86,33 @@ export class BitmapOverlayWidget extends Widget<BitmapOverlayWidgetProps> {
     rootElement.style.userSelect = 'none'
 
     if (!image) {
-      rootElement.innerHTML = ''
+      // Clear image if no URL provided
+      if (this.imgElement) {
+        this.imgElement.remove()
+        this.imgElement = null
+      }
       return
     }
 
-    rootElement.innerHTML = `
-      <img
-        src="${escapeHtml(image)}"
-        style="
-          display: block;
-          width: ${width}px;
-          height: ${height}px;
-          opacity: ${opacity};
-          object-fit: contain;
-          border-radius: 4px;
-        "
-        alt="Bitmap overlay"
-      />
-    `
+    // Reconciliation: reuse existing img element and only update changed props
+    if (!this.imgElement) {
+      // Create new img element
+      this.imgElement = document.createElement('img')
+      this.imgElement.alt = 'Bitmap overlay'
+      this.imgElement.style.display = 'block'
+      this.imgElement.style.objectFit = 'contain'
+      this.imgElement.style.borderRadius = '4px'
+      rootElement.appendChild(this.imgElement)
+    }
+
+    // Only update src if it changed (avoids reload flicker)
+    if (this.imgElement.src !== image) {
+      this.imgElement.src = image
+    }
+
+    // Update styles that may have changed
+    this.imgElement.style.width = `${width}px`
+    this.imgElement.style.height = `${height}px`
+    this.imgElement.style.opacity = `${opacity}`
   }
 }

--- a/noodles-editor/src/noodles/widgets/legend-widget.ts
+++ b/noodles-editor/src/noodles/widgets/legend-widget.ts
@@ -1,5 +1,6 @@
-import {Widget} from '@deck.gl/core'
-import type {WidgetPlacement, WidgetProps} from '@deck.gl/core'
+import type { WidgetPlacement, WidgetProps } from '@deck.gl/core'
+import { Widget } from '@deck.gl/core'
+import { escapeHtml } from './utils'
 
 export type LegendWidgetProps = WidgetProps & {
   placement?: WidgetPlacement
@@ -83,8 +84,4 @@ function formatValue(v: number): string {
   if (!Number.isFinite(v)) return String(v)
   const s = v.toPrecision(4)
   return String(parseFloat(s))
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }

--- a/noodles-editor/src/noodles/widgets/utils.ts
+++ b/noodles-editor/src/noodles/widgets/utils.ts
@@ -1,0 +1,9 @@
+// Shared utilities for widget implementations
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}


### PR DESCRIPTION
#### Background
Adds support for displaying bitmap images as screen-space overlays in Noodles.gl visualizations. This enables use cases like watermarks, logos, legends, or any custom UI imagery that should remain fixed in screen space rather than tied to geographic coordinates.

#### Change List
- Add `BitmapOverlayWidgetOp` operator with `FileUrlField` for image input (supports URLs and file uploads)
- Create `BitmapOverlayWidget` class extending Deck.gl Widget API with HTML-based rendering
- Support five placement modes: corner positions (`top-left`, `top-right`, `bottom-left`, `bottom-right`) and center (`fill`)
- Add `offsetX`/`offsetY` parameters for precise positioning (±2000px, hidden by default)
- Implement configurable dimensions (1-2000px), opacity (0-1), and scale (0.25-4x) with proper transform origins
- Register operator in `opTypes`, add to widget category, and wire up instantiation in `noodles.tsx`
- Add comprehensive test suite with 12 tests covering all input parameters and placement modes