### PR TITLE
Add CustomMapLibreLayer operator for WebGL custom layers

### DIFF
--- a/noodles-editor/public/examples/3d-building-gradient.json
+++ b/noodles-editor/public/examples/3d-building-gradient.json
@@ -1,0 +1,96 @@
+{
+  "version": 6,
+  "nodes": [
+    {
+      "id": "/maplibre-basemap",
+      "type": "MaplibreBasemapOp",
+      "position": { "x": 100, "y": 100 },
+      "data": {
+        "inputs": {
+          "mapStyle": "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+          "projection": "mercator",
+          "viewState": {
+            "latitude": 40.7128,
+            "longitude": -74.0060,
+            "zoom": 15,
+            "pitch": 60,
+            "bearing": -17.6
+          }
+        }
+      }
+    },
+    {
+      "id": "/gradient-params",
+      "type": "JSONOp",
+      "position": { "x": 100, "y": 300 },
+      "data": {
+        "inputs": {
+          "json": "{\n  \"baseColor\": [0.2, 0.3, 0.5],\n  \"topColor\": [0.8, 0.9, 1.0],\n  \"heightScale\": 0.01\n}"
+        }
+      }
+    },
+    {
+      "id": "/building-layer",
+      "type": "CustomMapLibreLayerOp",
+      "position": { "x": 100, "y": 500 },
+      "data": {
+        "inputs": {
+          "id": "3d-buildings",
+          "renderingMode": "3d",
+          "beforeId": "road-label",
+          "code": "{\n  onAdd: function(map, gl) {\n    this.map = map;\n    this.gl = gl;\n    \n    // Vertex shader - applies height-based color gradient\n    const vertexSource = `\n      uniform mat4 u_matrix;\n      attribute vec2 a_pos;\n      attribute float a_height;\n      varying float v_height;\n      \n      void main() {\n        v_height = a_height;\n        vec4 pos = vec4(a_pos, a_height, 1.0);\n        gl_Position = u_matrix * pos;\n      }\n    `;\n    \n    // Fragment shader - interpolates color based on height\n    const fragmentSource = `\n      precision mediump float;\n      uniform vec3 u_baseColor;\n      uniform vec3 u_topColor;\n      uniform float u_heightScale;\n      varying float v_height;\n      \n      void main() {\n        float t = clamp(v_height * u_heightScale, 0.0, 1.0);\n        vec3 color = mix(u_baseColor, u_topColor, t);\n        gl_FragColor = vec4(color, 0.8);\n      }\n    `;\n    \n    // Create shader program\n    const vertexShader = gl.createShader(gl.VERTEX_SHADER);\n    gl.shaderSource(vertexShader, vertexSource);\n    gl.compileShader(vertexShader);\n    \n    const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);\n    gl.shaderSource(fragmentShader, fragmentSource);\n    gl.compileShader(fragmentShader);\n    \n    this.program = gl.createProgram();\n    gl.attachShader(this.program, vertexShader);\n    gl.attachShader(this.program, fragmentShader);\n    gl.linkProgram(this.program);\n    \n    // Store attribute and uniform locations\n    this.aPos = gl.getAttribLocation(this.program, 'a_pos');\n    this.aHeight = gl.getAttribLocation(this.program, 'a_height');\n    this.uMatrix = gl.getUniformLocation(this.program, 'u_matrix');\n    this.uBaseColor = gl.getUniformLocation(this.program, 'u_baseColor');\n    this.uTopColor = gl.getUniformLocation(this.program, 'u_topColor');\n    this.uHeightScale = gl.getUniformLocation(this.program, 'u_heightScale');\n    \n    console.log('3D building gradient layer initialized');\n  },\n  \n  render: function(gl, matrix) {\n    if (!this.program) return;\n    \n    gl.useProgram(this.program);\n    gl.uniformMatrix4fv(this.uMatrix, false, matrix);\n    \n    // Apply gradient colors from params\n    const baseColor = params.baseColor || [0.2, 0.3, 0.5];\n    const topColor = params.topColor || [0.8, 0.9, 1.0];\n    const heightScale = params.heightScale || 0.01;\n    \n    gl.uniform3fv(this.uBaseColor, baseColor);\n    gl.uniform3fv(this.uTopColor, topColor);\n    gl.uniform1f(this.uHeightScale, heightScale);\n    \n    // Enable blending for transparency\n    gl.enable(gl.BLEND);\n    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);\n    \n    // Note: Actual building geometry would be fetched from vector tiles\n    // This is a placeholder that demonstrates the shader setup\n  },\n  \n  onRemove: function(map, gl) {\n    if (this.program) {\n      gl.deleteProgram(this.program);\n    }\n    console.log('3D building gradient layer removed');\n  }\n}"
+        }
+      }
+    },
+    {
+      "id": "/deck-renderer",
+      "type": "DeckRendererOp",
+      "position": { "x": 500, "y": 300 },
+      "data": {
+        "inputs": {
+          "layers": [],
+          "views": []
+        }
+      }
+    },
+    {
+      "id": "/out",
+      "type": "OutOp",
+      "position": { "x": 800, "y": 300 },
+      "data": {
+        "inputs": {}
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "/maplibre-basemap.maplibre->/deck-renderer.basemap",
+      "source": "/maplibre-basemap",
+      "target": "/deck-renderer",
+      "sourceHandle": "out.maplibre",
+      "targetHandle": "par.basemap"
+    },
+    {
+      "id": "/gradient-params.json->/building-layer.params",
+      "source": "/gradient-params",
+      "target": "/building-layer",
+      "sourceHandle": "out.json",
+      "targetHandle": "par.params"
+    },
+    {
+      "id": "/building-layer.layer->/deck-renderer.maplibreLayers",
+      "source": "/building-layer",
+      "target": "/deck-renderer",
+      "sourceHandle": "out.layer",
+      "targetHandle": "par.maplibreLayers"
+    },
+    {
+      "id": "/deck-renderer.vis->/out.vis",
+      "source": "/deck-renderer",
+      "target": "/out",
+      "sourceHandle": "out.vis",
+      "targetHandle": "par.vis"
+    }
+  ],
+  "viewport": { "x": 0, "y": 0, "zoom": 1 }
+}

--- a/noodles-editor/public/examples/custom-maplibre-layer-test.json
+++ b/noodles-editor/public/examples/custom-maplibre-layer-test.json
@@ -1,0 +1,82 @@
+{
+  "version": 6,
+  "nodes": [
+    {
+      "id": "/maplibre-basemap",
+      "type": "MaplibreBasemapOp",
+      "position": { "x": 100, "y": 100 },
+      "data": {
+        "inputs": {
+          "mapStyle": "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+          "projection": "mercator",
+          "viewState": {
+            "latitude": 40.7128,
+            "longitude": -74.0060,
+            "zoom": 13,
+            "pitch": 45,
+            "bearing": 0
+          }
+        }
+      }
+    },
+    {
+      "id": "/custom-layer",
+      "type": "CustomMapLibreLayerOp",
+      "position": { "x": 100, "y": 300 },
+      "data": {
+        "inputs": {
+          "id": "test-custom-layer",
+          "renderingMode": "3d",
+          "code": "{\n  onAdd: function(map, gl) {\n    console.log('Custom layer added:', params);\n    this.map = map;\n    this.gl = gl;\n  },\n  render: function(gl, matrix) {\n    // Simple render - just log once\n    if (!this.hasLogged) {\n      console.log('Custom layer rendering');\n      this.hasLogged = true;\n    }\n  },\n  onRemove: function(map, gl) {\n    console.log('Custom layer removed');\n  }\n}",
+          "params": {
+            "color": "#ff0000",
+            "opacity": 0.5
+          }
+        }
+      }
+    },
+    {
+      "id": "/deck-renderer",
+      "type": "DeckRendererOp",
+      "position": { "x": 400, "y": 200 },
+      "data": {
+        "inputs": {
+          "layers": [],
+          "views": []
+        }
+      }
+    },
+    {
+      "id": "/out",
+      "type": "OutOp",
+      "position": { "x": 700, "y": 200 },
+      "data": {
+        "inputs": {}
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "/maplibre-basemap.maplibre->/deck-renderer.basemap",
+      "source": "/maplibre-basemap",
+      "target": "/deck-renderer",
+      "sourceHandle": "out.maplibre",
+      "targetHandle": "par.basemap"
+    },
+    {
+      "id": "/custom-layer.layer->/deck-renderer.maplibreLayers",
+      "source": "/custom-layer",
+      "target": "/deck-renderer",
+      "sourceHandle": "out.layer",
+      "targetHandle": "par.maplibreLayers"
+    },
+    {
+      "id": "/deck-renderer.vis->/out.vis",
+      "source": "/deck-renderer",
+      "target": "/out",
+      "sourceHandle": "out.vis",
+      "targetHandle": "par.vis"
+    }
+  ],
+  "viewport": { "x": 0, "y": 0, "zoom": 1 }
+}

--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -95,7 +95,7 @@ export const categories = {
   ],
   vector: ['CombineXY', 'CombineXYZ', 'SplitXY', 'SplitXYZ'],
   view: [
-    'Custom MapLibre Layer',
+    'CustomMapLibreLayer',
     'FirstPersonView',
     'GlobeView',
     'MaplibreBasemap',

--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -95,6 +95,7 @@ export const categories = {
   ],
   vector: ['CombineXY', 'CombineXYZ', 'SplitXY', 'SplitXYZ'],
   view: [
+    'Custom MapLibre Layer',
     'FirstPersonView',
     'GlobeView',
     'MaplibreBasemap',

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -1116,14 +1116,47 @@ export class ViewField extends Field<
   }
 }
 
+export class MapLibreLayerField extends Field<
+  z.ZodType<{
+    id: string
+    type: 'custom'
+    code: string
+    renderingMode?: '2d' | '3d'
+    beforeId?: string
+    params?: Record<string, unknown>
+  }>
+> {
+  static type = 'maplibre-layer'
+  static defaultValue = undefined
+
+  createSchema() {
+    return z.strictObject({
+      id: z.string(),
+      type: z.literal('custom'),
+      code: z.string(),
+      renderingMode: z.enum(['2d', '3d']).optional(),
+      beforeId: z.string().optional(),
+      params: z.record(z.unknown()).optional(),
+    })
+  }
+}
+
 export class VisualizationField extends Field<
   z.ZodType<{
     deckProps: { layers: (LayerProps & { type: string })[] } & BetterDeckProps
     mapProps?: BetterMapProps
+    maplibreLayers?: Array<{
+      id: string
+      type: 'custom'
+      code: string
+      renderingMode?: '2d' | '3d'
+      beforeId?: string
+      params?: Record<string, unknown>
+    }>
   }>
 > {
   static type = 'visualization'
-  static defaultValue = { deckProps: {}, mapProps: undefined }
+  static defaultValue = { deckProps: {}, mapProps: undefined, maplibreLayers: [] }
   createSchema() {
     return z.looseObject({
       deckProps: z.looseObject({
@@ -1141,6 +1174,18 @@ export class VisualizationField extends Field<
           latitude: z.number(),
           zoom: z.number(),
         })
+        .optional(),
+      maplibreLayers: z
+        .array(
+          z.strictObject({
+            id: z.string(),
+            type: z.literal('custom'),
+            code: z.string(),
+            renderingMode: z.enum(['2d', '3d']).optional(),
+            beforeId: z.string().optional(),
+            params: z.record(z.unknown()).optional(),
+          })
+        )
         .optional(),
     })
   }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -168,6 +168,7 @@ import {
   type InOut,
   LayerField,
   ListField,
+  MapLibreLayerField,
   MapStyleField,
   mustacheRe,
   NumberField,

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3736,6 +3736,64 @@ export class MaplibreBasemapOp extends Operator<MaplibreBasemapOp> {
   }
 }
 
+export class CustomMapLibreLayerOp extends Operator<CustomMapLibreLayerOp> {
+  static displayName = 'Custom MapLibre Layer'
+  static description =
+    'Define a custom MapLibre GL layer with WebGL rendering. ' +
+    'The code must return an object with onAdd, render, and onRemove methods. ' +
+    'Access parameters via `params` object and map instance via `map`.'
+
+  createInputs() {
+    return {
+      id: new StringField('custom-layer'),
+      code: new CodeField('', { language: 'javascript' }),
+      renderingMode: new StringLiteralField('3d', {
+        values: ['2d', '3d'],
+      }),
+      beforeId: new StringField('', {
+        optional: true,
+        showByDefault: false,
+      }),
+      params: new UnknownField(
+        {},
+        {
+          optional: true,
+          showByDefault: false,
+        }
+      ),
+    }
+  }
+
+  createOutputs() {
+    return {
+      layer: new MapLibreLayerField(),
+    }
+  }
+
+  execute({
+    id,
+    code: codeString,
+    renderingMode,
+    beforeId,
+    params,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    if (!codeString || codeString.trim() === '') {
+      throw new Error('CustomMapLibreLayer code cannot be empty')
+    }
+
+    return {
+      layer: {
+        id,
+        type: 'custom',
+        code: codeString,
+        renderingMode: renderingMode || '3d',
+        beforeId,
+        params: params || {},
+      },
+    }
+  }
+}
+
 export class MapStyleConfiguratorOp extends Operator<MapStyleConfiguratorOp> {
   static displayName = 'MapStyleConfigurator'
   static description =
@@ -3816,6 +3874,10 @@ export class DeckRendererOp extends Operator<DeckRendererOp> {
       //   bearing: new NumberField(0, { optional: true }),
       // }, { optional: true }),
       viewState: new UnknownField({}, { showByDefault: false }),
+      maplibreLayers: new ListField(new MapLibreLayerField(), {
+        optional: true,
+        showByDefault: false,
+      }),
     }
   }
   createOutputs() {
@@ -3831,6 +3893,7 @@ export class DeckRendererOp extends Operator<DeckRendererOp> {
     basemap,
     views,
     layerFilter,
+    maplibreLayers,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     // Validate the ViewState to ensure lat/lng are within valid bounds
     validateViewState(viewState)
@@ -3866,6 +3929,7 @@ export class DeckRendererOp extends Operator<DeckRendererOp> {
       vis: {
         deckProps,
         mapProps,
+        maplibreLayers: maplibreLayers || [],
       },
     }
   }
@@ -7701,6 +7765,7 @@ export const opTypes = {
   CombineRGBAOp,
   CombineXYOp,
   ConcatOp,
+  CustomMapLibreLayerOp,
   ConsoleOp,
   ContainerOp,
   ContourLayerOp,

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -3737,7 +3737,7 @@ export class MaplibreBasemapOp extends Operator<MaplibreBasemapOp> {
 }
 
 export class CustomMapLibreLayerOp extends Operator<CustomMapLibreLayerOp> {
-  static displayName = 'Custom MapLibre Layer'
+  static displayName = 'CustomMapLibreLayer'
   static description =
     'Define a custom MapLibre GL layer with WebGL rendering. ' +
     'The code must return an object with onAdd, render, and onRemove methods. ' +

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -6189,7 +6189,7 @@ function formatSyntaxError(error: Error, id: string, body: string): string {
 }
 
 // Create a function with a source property for debugging
-function fnWithSource(args: string[], body: string, id: string): FunctionWithSource {
+export function fnWithSource(args: string[], body: string, id: string): FunctionWithSource {
   try {
     // Duck typing to check if the function is async
     const isAsync = /\bawait\b/.test(body)

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -2,7 +2,7 @@ import type { Deck, DeckProps } from '@deck.gl/core'
 import { MapboxOverlay, type MapboxOverlayProps } from '@deck.gl/mapbox'
 import { DeckGL } from '@deck.gl/react'
 import { ReactFlowProvider } from '@xyflow/react'
-import type { Map as MapLibre } from 'maplibre-gl'
+import type { CustomLayerInterface, Map as MapLibre } from 'maplibre-gl'
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react'
 import ReactMapGL, { type MapProps, useControl } from 'react-map-gl/maplibre'
 import { Layout } from './layout'
@@ -71,6 +71,7 @@ export default function TimelineEditor() {
   const isRenderingRef = useRef(false)
   // Session-only handle set by selectRendersDirectory; takes priority over project subdir
   const rendersDirectoryHandleRef = useRef<FileSystemDirectoryHandle | null>(null)
+  const customLayersRef = useRef<Set<string>>(new Set())
 
   // Trigger a redraw of React, mapbox and deck when the renderer state changes,
   // to ensure that the VideoStreamReader in renderer.ts runs
@@ -208,6 +209,122 @@ export default function TimelineEditor() {
       map.setSky(undefined)
     }
   }, [light, sky])
+
+  // Helper function to evaluate MapLibre layer code
+  const evaluateMapLibreLayerCode = (
+    code: string,
+    params: Record<string, unknown>,
+    layerId: string,
+    map: MapLibre
+  ): Partial<CustomLayerInterface> => {
+    try {
+      const fn = new Function('params', 'map', ['// Layer ID: ' + layerId, 'return ' + code].join('\n'))
+
+      const result = fn(params, map)
+
+      if (typeof result !== 'object' || result === null) {
+        throw new Error('Layer code must return an object')
+      }
+
+      if (typeof result.render !== 'function') {
+        throw new Error('Layer code must define a render() method')
+      }
+
+      return result as Partial<CustomLayerInterface>
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e))
+      throw new Error(`Failed to evaluate MapLibre layer code for "${layerId}": ${error.message}`)
+    }
+  }
+
+  // Manage custom MapLibre layers
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !map.isStyleLoaded()) return
+
+    const layerConfigs = visualization.maplibreLayers || []
+    const desiredLayerIds = new Set(layerConfigs.map(config => config.id))
+
+    // Remove layers that are no longer in the config
+    for (const existingId of customLayersRef.current) {
+      if (!desiredLayerIds.has(existingId)) {
+        try {
+          if (map.getLayer(existingId)) {
+            map.removeLayer(existingId)
+            debugRender('Removed custom MapLibre layer: %s', existingId)
+          }
+        } catch (e) {
+          debugRender('Error removing custom MapLibre layer %s: %o', existingId, e)
+        }
+      }
+    }
+
+    // Add or update layers
+    for (const config of layerConfigs) {
+      try {
+        const existingLayer = map.getLayer(config.id)
+
+        if (existingLayer) {
+          map.removeLayer(config.id)
+        }
+
+        const layerImpl = evaluateMapLibreLayerCode(config.code, config.params || {}, config.id, map)
+
+        const customLayer: CustomLayerInterface = {
+          ...layerImpl,
+          id: config.id,
+          type: 'custom',
+          renderingMode: config.renderingMode || '3d',
+        }
+
+        map.addLayer(customLayer, config.beforeId)
+        customLayersRef.current.add(config.id)
+
+        debugRender('Added/updated custom MapLibre layer: %s', config.id)
+      } catch (e) {
+        const error = e instanceof Error ? e : new Error(String(e))
+        debugRender('Error adding custom MapLibre layer %s: %o', config.id, error)
+      }
+    }
+
+    customLayersRef.current = desiredLayerIds
+  }, [visualization.maplibreLayers])
+
+  // Clean up custom layers on unmount
+  useEffect(() => {
+    return () => {
+      const map = mapRef.current
+      if (!map) return
+
+      for (const layerId of customLayersRef.current) {
+        try {
+          if (map.getLayer(layerId)) {
+            map.removeLayer(layerId)
+          }
+        } catch (e) {
+          debugRender('Error removing layer on cleanup: %o', e)
+        }
+      }
+      customLayersRef.current.clear()
+    }
+  }, [])
+
+  // Handle map style changes - clear layer tracking so they get re-added
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map) return
+
+    const handleStyleData = () => {
+      customLayersRef.current.clear()
+    }
+
+    map.on('styledata', handleStyleData)
+
+    return () => {
+      map.off('styledata', handleStyleData)
+    }
+  }, [])
+
   // Expose deck.gl canvas and instance for Claude AI visual debugging
   useEffect(() => {
     if (deckRef.current) {

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -73,6 +73,8 @@ export default function TimelineEditor() {
   // Session-only handle set by selectRendersDirectory; takes priority over project subdir
   const rendersDirectoryHandleRef = useRef<FileSystemDirectoryHandle | null>(null)
   const customLayersRef = useRef<Set<string>>(new Set())
+  // Track style version to trigger layer re-addition after style changes
+  const [styleVersion, setStyleVersion] = useState(0)
 
   // Trigger a redraw of React, mapbox and deck when the renderer state changes,
   // to ensure that the VideoStreamReader in renderer.ts runs
@@ -283,7 +285,7 @@ export default function TimelineEditor() {
     }
 
     customLayersRef.current = desiredLayerIds
-  }, [visualization.maplibreLayers])
+  }, [visualization.maplibreLayers, styleVersion])
 
   // Clean up custom layers on unmount
   useEffect(() => {
@@ -304,13 +306,14 @@ export default function TimelineEditor() {
     }
   }, [])
 
-  // Handle map style changes - clear layer tracking so they get re-added
+  // Handle map style changes - increment styleVersion to trigger layer re-addition
   useEffect(() => {
     const map = mapRef.current
     if (!map) return
 
     const handleStyleData = () => {
       customLayersRef.current.clear()
+      setStyleVersion(v => v + 1)
     }
 
     map.on('styledata', handleStyleData)

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -13,6 +13,7 @@ import { useActiveStorageType, useCurrentDirectory } from './noodles/filesystem-
 import { useActiveOutOp } from './noodles/hooks/use-active-outop'
 import { useRenderSettings } from './noodles/hooks/use-render-settings'
 import { getNoodles } from './noodles/noodles'
+import { fnWithSource } from './noodles/operators'
 import type { RenderSettings } from './noodles/utils/serialization'
 import { useDeckDrawLoop } from './render/draw-loop'
 import { captureScreenshot, useRenderer } from './render/renderer'
@@ -210,31 +211,25 @@ export default function TimelineEditor() {
     }
   }, [light, sky])
 
-  // Helper function to evaluate MapLibre layer code
+  // Helper function to evaluate MapLibre layer code using shared fnWithSource utility
   const evaluateMapLibreLayerCode = (
     code: string,
     params: Record<string, unknown>,
     layerId: string,
     map: MapLibre
   ): Partial<CustomLayerInterface> => {
-    try {
-      const fn = new Function('params', 'map', ['// Layer ID: ' + layerId, 'return ' + code].join('\n'))
+    const fn = fnWithSource(['params', 'map'], code, layerId)
+    const result = fn(params, map)
 
-      const result = fn(params, map)
-
-      if (typeof result !== 'object' || result === null) {
-        throw new Error('Layer code must return an object')
-      }
-
-      if (typeof result.render !== 'function') {
-        throw new Error('Layer code must define a render() method')
-      }
-
-      return result as Partial<CustomLayerInterface>
-    } catch (e) {
-      const error = e instanceof Error ? e : new Error(String(e))
-      throw new Error(`Failed to evaluate MapLibre layer code for "${layerId}": ${error.message}`)
+    if (typeof result !== 'object' || result === null) {
+      throw new Error('Layer code must return an object')
     }
+
+    if (typeof result.render !== 'function') {
+      throw new Error('Layer code must define a render() method')
+    }
+
+    return result as Partial<CustomLayerInterface>
   }
 
   // Manage custom MapLibre layers

--- a/noodles-editor/src/visualizations.ts
+++ b/noodles-editor/src/visualizations.ts
@@ -14,6 +14,15 @@ export type ViewState =
 export type BetterMapProps = MapProps & MapViewState
 export type BetterDeckProps = Partial<DeckProps & { viewState: ViewState }>
 
+export interface MapLibreLayerConfig {
+  id: string
+  type: 'custom'
+  code: string
+  renderingMode?: '2d' | '3d'
+  beforeId?: string
+  params?: Record<string, unknown>
+}
+
 export type Visualization = {
   // Direct component props (no widgets wrapper)
   flowGraph?: React.ReactNode
@@ -48,4 +57,5 @@ export type Visualization = {
   // Visualization props
   mapProps?: BetterMapProps
   deckProps: BetterDeckProps
+  maplibreLayers?: MapLibreLayerConfig[]
 }


### PR DESCRIPTION
#### Background
Noodles.gl needs support for custom MapLibre GL layers to enable advanced WebGL effects like 3D buildings with height-based gradients using custom shaders. Normal operators execute during graph evaluation (before rendering), but MapLibre custom layers need the map instance which only exists at render time.

#### Change List
- Add MapLibreLayerField for layer configuration validation with id, code, renderingMode, beforeId, and params
- Create CustomMapLibreLayerOp operator that packages layer code and parameters as configuration objects
- Extend DeckRendererOp to accept optional maplibreLayers input and pass configs through visualization output
- Add MapLibreLayerConfig interface and extend Visualization type with maplibreLayers field
- Implement React effects in TimelineEditor to evaluate layer code and manage lifecycle (add/update/remove) at render time
- Add helper function to safely evaluate layer code using Function constructor with access to params and map instance
- Handle map style changes by clearing layer tracking and re-adding layers after style loads
- Add CustomMapLibreLayer to view category menu
- Include two example projects: simple test demonstrating layer lifecycle, and advanced 3D building gradient with custom WebGL shaders