### PR TITLE
feat: add timeline variables to CodeOp/ExpressionField with reactive tracking

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -6375,7 +6375,17 @@ export class AccessorOp extends Operator<AccessorOp> {
     })
 
     const fn = fnWithSource(
-      ['d', 'i', 'data', 'op', 'sequenceTime', 'frame', 'totalFrames', 'sequence', ...Object.keys(freeExports)],
+      [
+        'd',
+        'i',
+        'data',
+        'op',
+        'sequenceTime',
+        'frame',
+        'totalFrames',
+        'sequence',
+        ...Object.keys(freeExports),
+      ],
       `return ${expression}`,
       this.id
     )
@@ -6455,7 +6465,16 @@ export class CodeOp extends Operator<CodeOp> {
     // Create a context-aware getOp function for the code execution
     const contextualGetOp = (path: string) => getOp(path, this.id)
     const fn = fnWithSource(
-      ['data', 'd', 'op', 'sequenceTime', 'frame', 'totalFrames', 'sequence', ...Object.keys(freeExports)],
+      [
+        'data',
+        'd',
+        'op',
+        'sequenceTime',
+        'frame',
+        'totalFrames',
+        'sequence',
+        ...Object.keys(freeExports),
+      ],
       processedCode,
       this.id
     )
@@ -6537,7 +6556,16 @@ export class ExpressionOp extends Operator<ExpressionOp> {
     })
 
     const fn = fnWithSource(
-      ['data', 'd', 'op', 'sequenceTime', 'frame', 'totalFrames', 'sequence', ...Object.keys(freeExports)],
+      [
+        'data',
+        'd',
+        'op',
+        'sequenceTime',
+        'frame',
+        'totalFrames',
+        'sequence',
+        ...Object.keys(freeExports),
+      ],
       `return ${expression}`,
       this.id
     )

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -938,6 +938,11 @@ export abstract class Operator<OP extends IOperator> {
     this.unsubscribeListeners()
     this.executionState.complete()
     this.customFieldsChanged.complete()
+
+    // Cleanup timeline subscriptions
+    import('./utils/timeline-dependencies').then(({ timelineDependencyManager }) => {
+      timelineDependencyManager.unsubscribe(this.id)
+    })
   }
 }
 
@@ -6349,7 +6354,7 @@ export function fnWithSource(args: string[], body: string, id: string): Function
 export class AccessorOp extends Operator<AccessorOp> {
   static displayName = 'Accessor'
   static description =
-    'A function called for each row of your data and passed to Deck.gl layer properties. The current row is passed as the `d` variable (e.g., `d.population`, `d.properties.color`). Returns a value that controls visual properties like position, color, or size.'
+    'A function called for each row of your data and passed to Deck.gl layer properties. The current row is passed as the `d` variable (e.g., `d.population`, `d.properties.color`). Available variables: `d` (current row), `i` (index), `data` (all rows), `op()` (access operators), `sequenceTime` (timeline position), `frame` (current frame), `totalFrames`, `sequence` (timeline metadata). Includes d3, turf, and other utilities.'
   createInputs() {
     return {
       expression: new ExpressionField(),
@@ -6361,8 +6366,16 @@ export class AccessorOp extends Operator<AccessorOp> {
     }
   }
   execute({ expression }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    // Create timeline context with dependency tracking
+    const { createTrackedTimelineContext } = require('./utils/timeline-context')
+    const { timelineDependencyManager } = require('./utils/timeline-dependencies')
+    const accessedTimelineVars = new Set<string>()
+    const timelineContext = createTrackedTimelineContext((variable: string) => {
+      accessedTimelineVars.add(variable)
+    })
+
     const fn = fnWithSource(
-      ['d', 'i', 'data', 'op', ...Object.keys(freeExports)],
+      ['d', 'i', 'data', 'op', 'sequenceTime', 'frame', 'totalFrames', 'sequence', ...Object.keys(freeExports)],
       `return ${expression}`,
       this.id
     )
@@ -6370,13 +6383,30 @@ export class AccessorOp extends Operator<AccessorOp> {
     const accessor = (d: unknown, dInfo: { index: number; data: unknown; target: number[] }) => {
       const contextualGetOp = (path: string) => getOp(path, this.id)
       try {
-        return fn(d, dInfo.index, dInfo.data, contextualGetOp, ...Object.values(freeExports))
+        return fn(
+          d,
+          dInfo.index,
+          dInfo.data,
+          contextualGetOp,
+          timelineContext.sequenceTime,
+          timelineContext.frame,
+          timelineContext.totalFrames,
+          timelineContext.sequence,
+          ...Object.values(freeExports)
+        )
       } catch (_e) {
         // Swallow per-row errors — returning undefined lets deck.gl skip the item
         // rather than crashing the GPU process
         return undefined
       }
     }
+
+    // Register timeline dependencies after execution
+    if (accessedTimelineVars.size > 0) {
+      timelineDependencyManager.trackDependencies(this.id, accessedTimelineVars)
+      timelineDependencyManager.subscribe(this)
+    }
+
     return { accessor }
   }
 }
@@ -6384,7 +6414,7 @@ export class AccessorOp extends Operator<AccessorOp> {
 export class CodeOp extends Operator<CodeOp> {
   static displayName = 'Code'
   static description =
-    'Run custom JavaScript code to transform your data. Available variables: `data` (all input data), `d` (first element), `op()` (access other operators). Includes d3, turf, and other utilities. Use `this` to store state between executions.'
+    'Run custom JavaScript code to transform your data. Available variables: `data` (all input data), `d` (first element), `op()` (access other operators), `sequenceTime` (timeline position), `frame` (current frame), `totalFrames`, `sequence` (timeline metadata). Includes d3, turf, and other utilities. Use `this` to store state between executions.'
   static supportsCustomFields = true
   asDownload = () => this.outputs.data.value
   createInputs() {
@@ -6414,14 +6444,39 @@ export class CodeOp extends Operator<CodeOp> {
       return `op('${opId}').${inOut}.${fieldPath}`
     })
 
+    // Create timeline context with dependency tracking
+    const { createTrackedTimelineContext } = require('./utils/timeline-context')
+    const { timelineDependencyManager } = require('./utils/timeline-dependencies')
+    const accessedTimelineVars = new Set<string>()
+    const timelineContext = createTrackedTimelineContext((variable: string) => {
+      accessedTimelineVars.add(variable)
+    })
+
     // Create a context-aware getOp function for the code execution
     const contextualGetOp = (path: string) => getOp(path, this.id)
     const fn = fnWithSource(
-      ['data', 'd', 'op', ...Object.keys(freeExports)],
+      ['data', 'd', 'op', 'sequenceTime', 'frame', 'totalFrames', 'sequence', ...Object.keys(freeExports)],
       processedCode,
       this.id
     )
-    const result = fn.call(this, data, data[0], contextualGetOp, ...Object.values(freeExports))
+    const result = fn.call(
+      this,
+      data,
+      data[0],
+      contextualGetOp,
+      timelineContext.sequenceTime,
+      timelineContext.frame,
+      timelineContext.totalFrames,
+      timelineContext.sequence,
+      ...Object.values(freeExports)
+    )
+
+    // Register timeline dependencies after execution
+    if (accessedTimelineVars.size > 0) {
+      timelineDependencyManager.trackDependencies(this.id, accessedTimelineVars)
+      timelineDependencyManager.subscribe(this)
+    }
+
     const output = result instanceof Promise ? await result : result
     return { data: output }
   }
@@ -6457,7 +6512,7 @@ export class ContainerOp extends Operator<ContainerOp> {
 export class ExpressionOp extends Operator<ExpressionOp> {
   static displayName = 'Expression'
   static description =
-    'Evaluate a JavaScript expression to compute a single value. Available variables: `data` (all input data), `d` (first element), `op()` (access other operators). Includes d3, turf, and other utilities.'
+    'Evaluate a JavaScript expression to compute a single value. Available variables: `data` (all input data), `d` (first element), `op()` (access other operators), `sequenceTime` (timeline position), `frame` (current frame), `totalFrames`, `sequence` (timeline metadata). Includes d3, turf, and other utilities.'
   createInputs() {
     return {
       data: new ListField(new DataField()),
@@ -6473,8 +6528,16 @@ export class ExpressionOp extends Operator<ExpressionOp> {
     data,
     expression,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    // Create timeline context with dependency tracking
+    const { createTrackedTimelineContext } = require('./utils/timeline-context')
+    const { timelineDependencyManager } = require('./utils/timeline-dependencies')
+    const accessedTimelineVars = new Set<string>()
+    const timelineContext = createTrackedTimelineContext((variable: string) => {
+      accessedTimelineVars.add(variable)
+    })
+
     const fn = fnWithSource(
-      ['data', 'd', 'op', ...Object.keys(freeExports)],
+      ['data', 'd', 'op', 'sequenceTime', 'frame', 'totalFrames', 'sequence', ...Object.keys(freeExports)],
       `return ${expression}`,
       this.id
     )
@@ -6488,13 +6551,45 @@ export class ExpressionOp extends Operator<ExpressionOp> {
       // Return an accessor function that evaluates all data items and applies the expression
       const result = (...args: unknown[]) => {
         const evaluatedData = data.map(item => (isAccessor(item) ? item(...args) : item))
-        return fn(evaluatedData, evaluatedData[0], contextualGetOp, ...Object.values(freeExports))
+        return fn(
+          evaluatedData,
+          evaluatedData[0],
+          contextualGetOp,
+          timelineContext.sequenceTime,
+          timelineContext.frame,
+          timelineContext.totalFrames,
+          timelineContext.sequence,
+          ...Object.values(freeExports)
+        )
       }
+
+      // Register timeline dependencies
+      if (accessedTimelineVars.size > 0) {
+        timelineDependencyManager.trackDependencies(this.id, accessedTimelineVars)
+        timelineDependencyManager.subscribe(this)
+      }
+
       return { data: result }
     }
 
     // Static evaluation
-    const result = fn(data, data[0], contextualGetOp, ...Object.values(freeExports))
+    const result = fn(
+      data,
+      data[0],
+      contextualGetOp,
+      timelineContext.sequenceTime,
+      timelineContext.frame,
+      timelineContext.totalFrames,
+      timelineContext.sequence,
+      ...Object.values(freeExports)
+    )
+
+    // Register timeline dependencies
+    if (accessedTimelineVars.size > 0) {
+      timelineDependencyManager.trackDependencies(this.id, accessedTimelineVars)
+      timelineDependencyManager.subscribe(this)
+    }
+
     return { data: result }
   }
 }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -196,8 +196,8 @@ import { projectScheme } from './utils/filesystem'
 import type { OpId } from './utils/id-utils'
 import { isDirectChild } from './utils/path-utils'
 import { pick } from './utils/pick'
-import { createTrackedTimelineContext } from './utils/timeline-context'
-import { timelineDependencyManager } from './utils/timeline-dependencies'
+import { getTimelineContext } from './utils/timeline-context'
+import { subscribeOpToTimeline, unsubscribeOpFromTimeline } from './utils/timeline-dependencies'
 import { validateViewState } from './utils/viewstate-helpers'
 
 // https://stackoverflow.com/questions/66044717/typescript-infer-type-of-abstract-methods-implementation
@@ -942,7 +942,7 @@ export abstract class Operator<OP extends IOperator> {
     this.customFieldsChanged.complete()
 
     // Cleanup timeline subscriptions
-    timelineDependencyManager.unsubscribe(this.id)
+    unsubscribeOpFromTimeline(this.id)
   }
 }
 
@@ -6366,12 +6366,6 @@ export class AccessorOp extends Operator<AccessorOp> {
     }
   }
   execute({ expression }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    // Create timeline context with dependency tracking
-    const accessedTimelineVars = new Set<string>()
-    const timelineContext = createTrackedTimelineContext((variable: string) => {
-      accessedTimelineVars.add(variable)
-    })
-
     const fn = fnWithSource(
       [
         'd',
@@ -6387,9 +6381,15 @@ export class AccessorOp extends Operator<AccessorOp> {
       `return ${expression}`,
       this.id
     )
+
+    // Subscribe to timeline changes - accessor will get fresh values on each call
+    subscribeOpToTimeline(this)
+
     // https://deck.gl/docs/developer-guide/using-layers#accessors
     const accessor = (d: unknown, dInfo: { index: number; data: unknown; target: number[] }) => {
       const contextualGetOp = (path: string) => getOp(path, this.id)
+      // Get fresh timeline values for each accessor call
+      const timelineContext = getTimelineContext()
       try {
         return fn(
           d,
@@ -6407,12 +6407,6 @@ export class AccessorOp extends Operator<AccessorOp> {
         // rather than crashing the GPU process
         return undefined
       }
-    }
-
-    // Register timeline dependencies after execution
-    if (accessedTimelineVars.size > 0) {
-      timelineDependencyManager.trackDependencies(this.id, accessedTimelineVars)
-      timelineDependencyManager.subscribe(this)
     }
 
     return { accessor }
@@ -6452,11 +6446,11 @@ export class CodeOp extends Operator<CodeOp> {
       return `op('${opId}').${inOut}.${fieldPath}`
     })
 
-    // Create timeline context with dependency tracking
-    const accessedTimelineVars = new Set<string>()
-    const timelineContext = createTrackedTimelineContext((variable: string) => {
-      accessedTimelineVars.add(variable)
-    })
+    // Get current timeline values
+    const timelineContext = getTimelineContext()
+
+    // Subscribe to timeline changes for reactive updates
+    subscribeOpToTimeline(this)
 
     // Create a context-aware getOp function for the code execution
     const contextualGetOp = (path: string) => getOp(path, this.id)
@@ -6485,12 +6479,6 @@ export class CodeOp extends Operator<CodeOp> {
       timelineContext.sequence,
       ...Object.values(freeExports)
     )
-
-    // Register timeline dependencies after execution
-    if (accessedTimelineVars.size > 0) {
-      timelineDependencyManager.trackDependencies(this.id, accessedTimelineVars)
-      timelineDependencyManager.subscribe(this)
-    }
 
     const output = result instanceof Promise ? await result : result
     return { data: output }
@@ -6543,11 +6531,11 @@ export class ExpressionOp extends Operator<ExpressionOp> {
     data,
     expression,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    // Create timeline context with dependency tracking
-    const accessedTimelineVars = new Set<string>()
-    const timelineContext = createTrackedTimelineContext((variable: string) => {
-      accessedTimelineVars.add(variable)
-    })
+    // Get current timeline values
+    const timelineContext = getTimelineContext()
+
+    // Subscribe to timeline changes for reactive updates
+    subscribeOpToTimeline(this)
 
     const fn = fnWithSource(
       [
@@ -6573,22 +6561,18 @@ export class ExpressionOp extends Operator<ExpressionOp> {
       // Return an accessor function that evaluates all data items and applies the expression
       const result = (...args: unknown[]) => {
         const evaluatedData = data.map(item => (isAccessor(item) ? item(...args) : item))
+        // Get fresh timeline values for each accessor call
+        const freshTimeline = getTimelineContext()
         return fn(
           evaluatedData,
           evaluatedData[0],
           contextualGetOp,
-          timelineContext.sequenceTime,
-          timelineContext.frame,
-          timelineContext.totalFrames,
-          timelineContext.sequence,
+          freshTimeline.sequenceTime,
+          freshTimeline.frame,
+          freshTimeline.totalFrames,
+          freshTimeline.sequence,
           ...Object.values(freeExports)
         )
-      }
-
-      // Register timeline dependencies
-      if (accessedTimelineVars.size > 0) {
-        timelineDependencyManager.trackDependencies(this.id, accessedTimelineVars)
-        timelineDependencyManager.subscribe(this)
       }
 
       return { data: result }
@@ -6605,12 +6589,6 @@ export class ExpressionOp extends Operator<ExpressionOp> {
       timelineContext.sequence,
       ...Object.values(freeExports)
     )
-
-    // Register timeline dependencies
-    if (accessedTimelineVars.size > 0) {
-      timelineDependencyManager.trackDependencies(this.id, accessedTimelineVars)
-      timelineDependencyManager.subscribe(this)
-    }
 
     return { data: result }
   }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -196,6 +196,8 @@ import { projectScheme } from './utils/filesystem'
 import type { OpId } from './utils/id-utils'
 import { isDirectChild } from './utils/path-utils'
 import { pick } from './utils/pick'
+import { createTrackedTimelineContext } from './utils/timeline-context'
+import { timelineDependencyManager } from './utils/timeline-dependencies'
 import { validateViewState } from './utils/viewstate-helpers'
 
 // https://stackoverflow.com/questions/66044717/typescript-infer-type-of-abstract-methods-implementation
@@ -940,9 +942,7 @@ export abstract class Operator<OP extends IOperator> {
     this.customFieldsChanged.complete()
 
     // Cleanup timeline subscriptions
-    import('./utils/timeline-dependencies').then(({ timelineDependencyManager }) => {
-      timelineDependencyManager.unsubscribe(this.id)
-    })
+    timelineDependencyManager.unsubscribe(this.id)
   }
 }
 
@@ -6367,8 +6367,6 @@ export class AccessorOp extends Operator<AccessorOp> {
   }
   execute({ expression }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     // Create timeline context with dependency tracking
-    const { createTrackedTimelineContext } = require('./utils/timeline-context')
-    const { timelineDependencyManager } = require('./utils/timeline-dependencies')
     const accessedTimelineVars = new Set<string>()
     const timelineContext = createTrackedTimelineContext((variable: string) => {
       accessedTimelineVars.add(variable)
@@ -6455,8 +6453,6 @@ export class CodeOp extends Operator<CodeOp> {
     })
 
     // Create timeline context with dependency tracking
-    const { createTrackedTimelineContext } = require('./utils/timeline-context')
-    const { timelineDependencyManager } = require('./utils/timeline-dependencies')
     const accessedTimelineVars = new Set<string>()
     const timelineContext = createTrackedTimelineContext((variable: string) => {
       accessedTimelineVars.add(variable)
@@ -6548,8 +6544,6 @@ export class ExpressionOp extends Operator<ExpressionOp> {
     expression,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     // Create timeline context with dependency tracking
-    const { createTrackedTimelineContext } = require('./utils/timeline-context')
-    const { timelineDependencyManager } = require('./utils/timeline-dependencies')
     const accessedTimelineVars = new Set<string>()
     const timelineContext = createTrackedTimelineContext((variable: string) => {
       accessedTimelineVars.add(variable)

--- a/noodles-editor/src/noodles/timeline-integration.test.ts
+++ b/noodles-editor/src/noodles/timeline-integration.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useTimelineStore } from '../timeline/timeline-store'
+import { CodeOp, ExpressionOp, AccessorOp } from './operators'
+import { timelineDependencyManager } from './utils/timeline-dependencies'
+
+describe('Timeline Variables Integration', () => {
+  beforeEach(() => {
+    // Reset timeline store
+    const store = useTimelineStore.getState()
+    store.setPosition(0)
+    store.setLength(10)
+    store.setFps(30)
+  })
+
+  describe('CodeOp with timeline variables', () => {
+    it('exposes sequenceTime variable', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(5.5)
+
+      const op = new CodeOp('/test', { code: 'return sequenceTime' })
+      const result = await op.execute({ data: [], code: 'return sequenceTime' })
+
+      expect(result.data).toBe(5.5)
+    })
+
+    it('exposes frame variable', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(2)
+      store.setFps(30)
+
+      const op = new CodeOp('/test', { code: 'return frame' })
+      const result = await op.execute({ data: [], code: 'return frame' })
+
+      expect(result.data).toBe(60) // 2 * 30
+    })
+
+    it('exposes totalFrames variable', async () => {
+      const store = useTimelineStore.getState()
+      store.setLength(10)
+      store.setFps(30)
+
+      const op = new CodeOp('/test', { code: 'return totalFrames' })
+      const result = await op.execute({ data: [], code: 'return totalFrames' })
+
+      expect(result.data).toBe(300) // 10 * 30
+    })
+
+    it('exposes sequence object', async () => {
+      const store = useTimelineStore.getState()
+      store.setLength(15)
+      store.setFps(24)
+
+      const op = new CodeOp('/test', { code: 'return sequence' })
+      const result = await op.execute({ data: [], code: 'return sequence' })
+
+      expect(result.data).toEqual({ length: 15, fps: 24 })
+    })
+
+    it('can access sequence.length', async () => {
+      const store = useTimelineStore.getState()
+      store.setLength(20)
+
+      const op = new CodeOp('/test', { code: 'return sequence.length' })
+      const result = await op.execute({ data: [], code: 'return sequence.length' })
+
+      expect(result.data).toBe(20)
+    })
+
+    it('can access sequence.fps', async () => {
+      const store = useTimelineStore.getState()
+      store.setFps(60)
+
+      const op = new CodeOp('/test', { code: 'return sequence.fps' })
+      const result = await op.execute({ data: [], code: 'return sequence.fps' })
+
+      expect(result.data).toBe(60)
+    })
+
+    it('can use timeline variables in expressions', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(3)
+
+      const op = new CodeOp('/test', {
+        code: 'return Math.sin(sequenceTime * Math.PI)',
+      })
+      const result = await op.execute({
+        data: [],
+        code: 'return Math.sin(sequenceTime * Math.PI)',
+      })
+
+      expect(result.data).toBeCloseTo(Math.sin(3 * Math.PI), 5)
+    })
+
+    it('can combine timeline variables with data', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(2)
+
+      const op = new CodeOp('/test', {
+        code: 'return data.map(d => ({ ...d, time: sequenceTime }))',
+      })
+      const result = await op.execute({
+        data: [{ id: 1 }, { id: 2 }],
+        code: 'return data.map(d => ({ ...d, time: sequenceTime }))',
+      })
+
+      expect(result.data).toEqual([
+        { id: 1, time: 2 },
+        { id: 2, time: 2 },
+      ])
+    })
+
+    it('provides sequenceTime value correctly', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(7.5)
+
+      const op = new CodeOp('/test', { code: 'return sequenceTime' })
+      const result = await op.execute({ data: [], code: 'return sequenceTime' })
+
+      expect(result.data).toBe(7.5)
+    })
+
+    it('provides frame value correctly', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(3)
+      store.setFps(24)
+
+      const op = new CodeOp('/test', { code: 'return frame' })
+      const result = await op.execute({ data: [], code: 'return frame' })
+
+      expect(result.data).toBe(72)
+    })
+
+    it('provides sequence object correctly', async () => {
+      const store = useTimelineStore.getState()
+      store.setLength(15)
+      store.setFps(60)
+
+      const op = new CodeOp('/test', { code: 'return sequence.length' })
+      const result = await op.execute({ data: [], code: 'return sequence.length' })
+
+      expect(result.data).toBe(15)
+    })
+
+    it('returns regular values when timeline vars not used', async () => {
+      const op = new CodeOp('/test', { code: 'return 42' })
+      const result = await op.execute({ data: [], code: 'return 42' })
+
+      expect(result.data).toBe(42)
+    })
+
+    it('re-executes when timeline position changes', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(1)
+
+      const op = new CodeOp('/test', { code: 'return sequenceTime' })
+
+      // First execution - establishes dependencies
+      let result = await op.execute({ data: [], code: 'return sequenceTime' })
+      expect(result.data).toBe(1)
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      // Change position
+      store.setPosition(5)
+
+      // Should be marked dirty
+      expect(markDirtySpy).toHaveBeenCalled()
+
+      // Execute again
+      result = await op.execute({ data: [], code: 'return sequenceTime' })
+      expect(result.data).toBe(5)
+
+      timelineDependencyManager.unsubscribe(op.id)
+    })
+  })
+
+  describe('ExpressionOp with timeline variables', () => {
+    it('exposes sequenceTime variable', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(3.5)
+
+      const op = new ExpressionOp('/test', { expression: 'sequenceTime' })
+      const result = op.execute({ data: [], expression: 'sequenceTime' })
+
+      expect(result.data).toBe(3.5)
+    })
+
+    it('exposes frame variable', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(1)
+      store.setFps(24)
+
+      const op = new ExpressionOp('/test', { expression: 'frame' })
+      const result = op.execute({ data: [], expression: 'frame' })
+
+      expect(result.data).toBe(24)
+    })
+
+    it('can use in arithmetic expressions', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(2)
+      store.setFps(30)
+
+      const op = new ExpressionOp('/test', { expression: 'frame * 2' })
+      const result = op.execute({ data: [], expression: 'frame * 2' })
+
+      expect(result.data).toBe(120) // (2 * 30) * 2
+    })
+
+    it('can use with conditional logic', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(3)
+      store.setLength(10)
+
+      const op = new ExpressionOp('/test', {
+        expression: 'sequenceTime',
+      })
+      const result = op.execute({
+        data: [],
+        expression: 'sequenceTime',
+      })
+
+      expect(result.data).toBe(3)
+    })
+
+    it('combines multiple timeline variables', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(2)
+      store.setFps(30)
+
+      const op = new ExpressionOp('/test', { expression: 'sequenceTime + frame' })
+      const result = op.execute({ data: [], expression: 'sequenceTime + frame' })
+
+      expect(result.data).toBe(62) // 2 + 60
+    })
+  })
+
+  describe('AccessorOp with timeline variables', () => {
+    it('exposes timeline variables in accessor function', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(2)
+      store.setFps(30)
+
+      const op = new AccessorOp('/test', { expression: 'd.value + sequenceTime' })
+      const result = op.execute({ expression: 'd.value + sequenceTime' })
+
+      const accessor = result.accessor
+      const value = accessor({ value: 10 }, { index: 0, data: [], target: [] })
+
+      expect(value).toBe(12) // 10 + 2
+    })
+
+    it('can use frame in accessor', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(1)
+      store.setFps(30)
+
+      const op = new AccessorOp('/test', { expression: 'd.x * frame' })
+      const result = op.execute({ expression: 'd.x * frame' })
+
+      const accessor = result.accessor
+      const value = accessor({ x: 2 }, { index: 0, data: [], target: [] })
+
+      expect(value).toBe(60) // 2 * (1 * 30)
+    })
+
+    it('provides timeline variables in accessor context', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(3)
+
+      const op = new AccessorOp('/test', { expression: 'd.value * sequenceTime' })
+      const result = op.execute({ expression: 'd.value * sequenceTime' })
+
+      const accessor = result.accessor
+      const value = accessor({ value: 10 }, { index: 0, data: [], target: [] })
+
+      expect(value).toBe(30) // 10 * 3
+    })
+
+    it('accessor updates when timeline changes', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(1)
+
+      const op = new AccessorOp('/test', { expression: 'sequenceTime' })
+      const result1 = op.execute({ expression: 'sequenceTime' })
+      const value1 = result1.accessor({}, { index: 0, data: [], target: [] })
+      expect(value1).toBe(1)
+
+      // Change timeline
+      store.setPosition(5)
+
+      // Re-execute (would happen via dirty tracking in real scenario)
+      const result2 = op.execute({ expression: 'sequenceTime' })
+      const value2 = result2.accessor({}, { index: 0, data: [], target: [] })
+      expect(value2).toBe(5)
+    })
+  })
+
+  describe('Operator disposal cleanup', () => {
+    it('cleans up timeline subscriptions on dispose', async () => {
+      const op = new CodeOp('/test', { code: 'return sequenceTime' })
+      await op.execute({ data: [], code: 'return sequenceTime' })
+
+      // Dispose operator
+      op.dispose()
+
+      // Dependencies should be cleaned up
+      const depsAfter = timelineDependencyManager.getDependencies(op.id)
+      expect(depsAfter).toBeUndefined()
+    })
+
+    it('does not trigger markDirty after disposal', async () => {
+      const store = useTimelineStore.getState()
+      const op = new CodeOp('/test', { code: 'return sequenceTime' })
+      await op.execute({ data: [], code: 'return sequenceTime' })
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      // Dispose
+      op.dispose()
+
+      // Change timeline
+      store.setPosition(10)
+
+      // Should not have been called
+      expect(markDirtySpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('handles operators without data input', async () => {
+      const op = new CodeOp('/test', { code: 'return sequenceTime' })
+      const result = await op.execute({ data: [], code: 'return sequenceTime' })
+
+      expect(result.data).toBe(0)
+    })
+
+    it('handles zero values', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(0)
+      store.setFps(0)
+
+      const op = new CodeOp('/test', { code: 'return { time: sequenceTime, frame }' })
+      const result = await op.execute({
+        data: [],
+        code: 'return { time: sequenceTime, frame }',
+      })
+
+      expect(result.data).toEqual({ time: 0, frame: 0 })
+    })
+
+    it('handles very large frame numbers', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(10)
+      store.setFps(60)
+
+      const op = new CodeOp('/test', { code: 'return frame' })
+      const result = await op.execute({ data: [], code: 'return frame' })
+
+      expect(result.data).toBe(600) // 10 * 60
+    })
+
+    it('handles fractional seconds correctly', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(1.5)
+      store.setFps(30)
+
+      const op = new CodeOp('/test', { code: 'return frame' })
+      const result = await op.execute({ data: [], code: 'return frame' })
+
+      expect(result.data).toBe(45) // Math.floor(1.5 * 30)
+    })
+  })
+
+  describe('Performance', () => {
+    it('does not subscribe operators without timeline references', async () => {
+      const op = new CodeOp('/test', { code: 'return data.length' })
+      await op.execute({ data: [1, 2, 3], code: 'return data.length' })
+
+      const deps = timelineDependencyManager.getDependencies(op.id)
+      expect(deps?.size || 0).toBe(0)
+    })
+
+    it('provides values when accessed', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(4)
+
+      const op = new CodeOp('/test', {
+        code: 'return sequenceTime',
+      })
+      const result = await op.execute({
+        data: [],
+        code: 'return sequenceTime',
+      })
+
+      expect(result.data).toBe(4)
+    })
+  })
+
+  describe('Complex expressions', () => {
+    it('handles combined timeline and data expressions', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(2)
+      store.setFps(30)
+
+      const op = new CodeOp('/test', {
+        code: `
+          const progress = sequenceTime / sequence.length
+          return data.map((d, i) => ({
+            ...d,
+            time: sequenceTime,
+            frame: frame,
+            progress: progress,
+            index: i
+          }))
+        `,
+      })
+
+      const result = await op.execute({
+        data: [{ id: 1 }, { id: 2 }],
+        code: `
+          const progress = sequenceTime / sequence.length
+          return data.map((d, i) => ({
+            ...d,
+            time: sequenceTime,
+            frame: frame,
+            progress: progress,
+            index: i
+          }))
+        `,
+      })
+
+      expect(result.data).toEqual([
+        { id: 1, time: 2, frame: 60, progress: 0.2, index: 0 },
+        { id: 2, time: 2, frame: 60, progress: 0.2, index: 1 },
+      ])
+    })
+
+    it('handles animation with sine wave', async () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(0)
+
+      const op = new CodeOp('/test', {
+        code: 'return Math.sin(sequenceTime * 2 * Math.PI / 5)',
+      })
+
+      const result = await op.execute({
+        data: [],
+        code: 'return Math.sin(sequenceTime * 2 * Math.PI / 5)',
+      })
+
+      expect(result.data).toBeCloseTo(0, 5)
+    })
+  })
+})

--- a/noodles-editor/src/noodles/timeline-integration.test.ts
+++ b/noodles-editor/src/noodles/timeline-integration.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useTimelineStore } from '../timeline/timeline-store'
-import { CodeOp, ExpressionOp, AccessorOp } from './operators'
-import { timelineDependencyManager } from './utils/timeline-dependencies'
+import { AccessorOp, CodeOp, ExpressionOp } from './operators'
+import { unsubscribeOpFromTimeline } from './utils/timeline-dependencies'
 
 describe('Timeline Variables Integration', () => {
   beforeEach(() => {
@@ -154,7 +154,7 @@ describe('Timeline Variables Integration', () => {
 
       const op = new CodeOp('/test', { code: 'return sequenceTime' })
 
-      // First execution - establishes dependencies
+      // First execution - establishes subscriptions
       let result = await op.execute({ data: [], code: 'return sequenceTime' })
       expect(result.data).toBe(1)
 
@@ -170,7 +170,7 @@ describe('Timeline Variables Integration', () => {
       result = await op.execute({ data: [], code: 'return sequenceTime' })
       expect(result.data).toBe(5)
 
-      timelineDependencyManager.unsubscribe(op.id)
+      unsubscribeOpFromTimeline(op.id)
     })
   })
 
@@ -298,31 +298,19 @@ describe('Timeline Variables Integration', () => {
 
   describe('Operator disposal cleanup', () => {
     it('cleans up timeline subscriptions on dispose', async () => {
-      const op = new CodeOp('/test', { code: 'return sequenceTime' })
-      await op.execute({ data: [], code: 'return sequenceTime' })
-
-      // Dispose operator
-      op.dispose()
-
-      // Dependencies should be cleaned up
-      const depsAfter = timelineDependencyManager.getDependencies(op.id)
-      expect(depsAfter).toBeUndefined()
-    })
-
-    it('does not trigger markDirty after disposal', async () => {
       const store = useTimelineStore.getState()
       const op = new CodeOp('/test', { code: 'return sequenceTime' })
       await op.execute({ data: [], code: 'return sequenceTime' })
 
       const markDirtySpy = vi.spyOn(op, 'markDirty')
 
-      // Dispose
+      // Dispose operator
       op.dispose()
 
       // Change timeline
       store.setPosition(10)
 
-      // Should not have been called
+      // Should not trigger markDirty after disposal
       expect(markDirtySpy).not.toHaveBeenCalled()
     })
   })
@@ -372,16 +360,8 @@ describe('Timeline Variables Integration', () => {
     })
   })
 
-  describe('Performance', () => {
-    it('does not subscribe operators without timeline references', async () => {
-      const op = new CodeOp('/test', { code: 'return data.length' })
-      await op.execute({ data: [1, 2, 3], code: 'return data.length' })
-
-      const deps = timelineDependencyManager.getDependencies(op.id)
-      expect(deps?.size || 0).toBe(0)
-    })
-
-    it('provides values when accessed', async () => {
+  describe('Timeline reactivity', () => {
+    it('provides current values on each execution', async () => {
       const store = useTimelineStore.getState()
       store.setPosition(4)
 

--- a/noodles-editor/src/noodles/utils/expression-context.ts
+++ b/noodles-editor/src/noodles/utils/expression-context.ts
@@ -46,6 +46,27 @@ const EXPRESSION_GLOBALS: GlobalDefinition[] = [
   { name: 'data', description: 'Full data array', type: 'variable' },
   { name: 'op', description: 'Access other operators by path', type: 'function' },
   {
+    name: 'sequenceTime',
+    description: 'Current timeline position in seconds',
+    type: 'variable',
+  },
+  {
+    name: 'frame',
+    description: 'Current frame number (computed from sequenceTime * fps)',
+    type: 'variable',
+  },
+  {
+    name: 'totalFrames',
+    description: 'Total frames in sequence (sequence.length * sequence.fps)',
+    type: 'variable',
+  },
+  {
+    name: 'sequence',
+    description: 'Sequence metadata',
+    type: 'library',
+    properties: ['length', 'fps'],
+  },
+  {
     name: 'utils',
     description: 'Utility functions',
     type: 'library',

--- a/noodles-editor/src/noodles/utils/timeline-context.test.ts
+++ b/noodles-editor/src/noodles/utils/timeline-context.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useTimelineStore } from '../../timeline/timeline-store'
+import {
+  getTimelineContext,
+  createTrackedTimelineContext,
+  type TimelineVariable,
+} from './timeline-context'
+
+describe('timeline-context', () => {
+  beforeEach(() => {
+    // Reset timeline store to known state
+    const store = useTimelineStore.getState()
+    store.setPosition(0)
+    store.setLength(10)
+    store.setFps(30)
+  })
+
+  describe('getTimelineContext', () => {
+    it('returns current timeline values', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(5)
+      store.setLength(20)
+      store.setFps(60)
+
+      const context = getTimelineContext()
+
+      expect(context.sequenceTime).toBe(5)
+      expect(context.frame).toBe(300) // 5 * 60
+      expect(context.totalFrames).toBe(1200) // 20 * 60
+      expect(context.sequence).toEqual({ length: 20, fps: 60 })
+    })
+
+    it('computes frame from position and fps', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(2.5)
+      store.setFps(24)
+
+      const context = getTimelineContext()
+
+      expect(context.frame).toBe(60) // Math.floor(2.5 * 24)
+    })
+
+    it('computes totalFrames from sequence length and fps', () => {
+      const store = useTimelineStore.getState()
+      store.setLength(15)
+      store.setFps(30)
+
+      const context = getTimelineContext()
+
+      expect(context.totalFrames).toBe(450) // Math.floor(15 * 30)
+    })
+  })
+
+  describe('createTrackedTimelineContext', () => {
+    it('tracks property access via callback', () => {
+      const accessedVars: TimelineVariable[] = []
+      const context = createTrackedTimelineContext((variable) => {
+        accessedVars.push(variable)
+      })
+
+      // Access properties
+      const _time = context.sequenceTime
+      const _frame = context.frame
+      const _length = context.sequence.length
+
+      expect(accessedVars).toContain('sequenceTime')
+      expect(accessedVars).toContain('frame')
+      expect(accessedVars).toContain('sequence')
+    })
+
+    it('returns correct values when accessed', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(3)
+      store.setFps(30)
+      store.setLength(10)
+
+      const context = createTrackedTimelineContext(() => {})
+
+      expect(context.sequenceTime).toBe(3)
+      expect(context.frame).toBe(90)
+      expect(context.totalFrames).toBe(300)
+      expect(context.sequence.length).toBe(10)
+      expect(context.sequence.fps).toBe(30)
+    })
+
+    it('tracks multiple accesses to same property', () => {
+      const accessedVars: TimelineVariable[] = []
+      const context = createTrackedTimelineContext((variable) => {
+        accessedVars.push(variable)
+      })
+
+      const _time1 = context.sequenceTime
+      const _time2 = context.sequenceTime
+      const _time3 = context.sequenceTime
+
+      expect(accessedVars.filter((v) => v === 'sequenceTime')).toHaveLength(3)
+    })
+
+    it('does not track access to non-timeline properties', () => {
+      const accessedVars: TimelineVariable[] = []
+      const context = createTrackedTimelineContext((variable) => {
+        accessedVars.push(variable)
+      })
+
+      // Try to access non-existent property (should not track)
+      const _invalid = (context as any).nonExistentProperty
+
+      expect(accessedVars).toHaveLength(0)
+    })
+
+    it('tracks nested sequence property access', () => {
+      const accessedVars: TimelineVariable[] = []
+      const context = createTrackedTimelineContext((variable) => {
+        accessedVars.push(variable)
+      })
+
+      const _seq = context.sequence
+      expect(accessedVars).toContain('sequence')
+
+      // Accessing properties of sequence object doesn't trigger additional tracking
+      const _len = _seq.length
+      const _fps = _seq.fps
+      expect(accessedVars).toHaveLength(1)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles zero position', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(0)
+      store.setFps(30)
+
+      const context = getTimelineContext()
+
+      expect(context.sequenceTime).toBe(0)
+      expect(context.frame).toBe(0)
+    })
+
+    it('handles fractional positions', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(1.234)
+      store.setFps(30)
+
+      const context = getTimelineContext()
+
+      expect(context.sequenceTime).toBe(1.234)
+      expect(context.frame).toBe(37) // Math.floor(1.234 * 30)
+    })
+
+    it('handles high fps values', () => {
+      const store = useTimelineStore.getState()
+      store.setPosition(1)
+      store.setFps(120)
+      store.setLength(10)
+
+      const context = getTimelineContext()
+
+      expect(context.frame).toBe(120)
+      expect(context.totalFrames).toBe(1200)
+    })
+  })
+})

--- a/noodles-editor/src/noodles/utils/timeline-context.test.ts
+++ b/noodles-editor/src/noodles/utils/timeline-context.test.ts
@@ -1,10 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { useTimelineStore } from '../../timeline/timeline-store'
-import {
-  getTimelineContext,
-  createTrackedTimelineContext,
-  type TimelineVariable,
-} from './timeline-context'
+import { getTimelineContext } from './timeline-context'
 
 describe('timeline-context', () => {
   beforeEach(() => {
@@ -51,78 +47,6 @@ describe('timeline-context', () => {
     })
   })
 
-  describe('createTrackedTimelineContext', () => {
-    it('tracks property access via callback', () => {
-      const accessedVars: TimelineVariable[] = []
-      const context = createTrackedTimelineContext((variable) => {
-        accessedVars.push(variable)
-      })
-
-      // Access properties
-      const _time = context.sequenceTime
-      const _frame = context.frame
-      const _length = context.sequence.length
-
-      expect(accessedVars).toContain('sequenceTime')
-      expect(accessedVars).toContain('frame')
-      expect(accessedVars).toContain('sequence')
-    })
-
-    it('returns correct values when accessed', () => {
-      const store = useTimelineStore.getState()
-      store.setPosition(3)
-      store.setFps(30)
-      store.setLength(10)
-
-      const context = createTrackedTimelineContext(() => {})
-
-      expect(context.sequenceTime).toBe(3)
-      expect(context.frame).toBe(90)
-      expect(context.totalFrames).toBe(300)
-      expect(context.sequence.length).toBe(10)
-      expect(context.sequence.fps).toBe(30)
-    })
-
-    it('tracks multiple accesses to same property', () => {
-      const accessedVars: TimelineVariable[] = []
-      const context = createTrackedTimelineContext((variable) => {
-        accessedVars.push(variable)
-      })
-
-      const _time1 = context.sequenceTime
-      const _time2 = context.sequenceTime
-      const _time3 = context.sequenceTime
-
-      expect(accessedVars.filter((v) => v === 'sequenceTime')).toHaveLength(3)
-    })
-
-    it('does not track access to non-timeline properties', () => {
-      const accessedVars: TimelineVariable[] = []
-      const context = createTrackedTimelineContext((variable) => {
-        accessedVars.push(variable)
-      })
-
-      // Try to access non-existent property (should not track)
-      const _invalid = (context as any).nonExistentProperty
-
-      expect(accessedVars).toHaveLength(0)
-    })
-
-    it('tracks nested sequence property access', () => {
-      const accessedVars: TimelineVariable[] = []
-      const context = createTrackedTimelineContext((variable) => {
-        accessedVars.push(variable)
-      })
-
-      const _seq = context.sequence
-      expect(accessedVars).toContain('sequence')
-
-      // Accessing properties of sequence object doesn't trigger additional tracking
-      const _len = _seq.length
-      const _fps = _seq.fps
-      expect(accessedVars).toHaveLength(1)
-    })
-  })
 
   describe('edge cases', () => {
     it('handles zero position', () => {

--- a/noodles-editor/src/noodles/utils/timeline-context.ts
+++ b/noodles-editor/src/noodles/utils/timeline-context.ts
@@ -10,9 +10,7 @@ export interface TimelineContext {
   }
 }
 
-export type TimelineVariable = 'sequenceTime' | 'frame' | 'totalFrames' | 'sequence'
-
-// Get current timeline values without tracking
+// Get current timeline values
 export function getTimelineContext(): TimelineContext {
   const store = useTimelineStore.getState()
   return {
@@ -24,20 +22,4 @@ export function getTimelineContext(): TimelineContext {
       fps: store.sequence.fps,
     },
   }
-}
-
-// Create a proxy that tracks property access
-export function createTrackedTimelineContext(
-  onAccess: (variable: TimelineVariable) => void
-): TimelineContext {
-  const context = getTimelineContext()
-
-  return new Proxy(context, {
-    get(target, prop: string | symbol) {
-      if (typeof prop === 'string' && prop in target) {
-        onAccess(prop as TimelineVariable)
-      }
-      return target[prop as keyof TimelineContext]
-    },
-  })
 }

--- a/noodles-editor/src/noodles/utils/timeline-context.ts
+++ b/noodles-editor/src/noodles/utils/timeline-context.ts
@@ -1,0 +1,43 @@
+import { useTimelineStore } from '../../timeline/timeline-store'
+
+export interface TimelineContext {
+  sequenceTime: number
+  frame: number
+  totalFrames: number
+  sequence: {
+    length: number
+    fps: number
+  }
+}
+
+export type TimelineVariable = 'sequenceTime' | 'frame' | 'totalFrames' | 'sequence'
+
+// Get current timeline values without tracking
+export function getTimelineContext(): TimelineContext {
+  const store = useTimelineStore.getState()
+  return {
+    sequenceTime: store.position,
+    frame: Math.floor(store.position * store.sequence.fps),
+    totalFrames: Math.floor(store.sequence.length * store.sequence.fps),
+    sequence: {
+      length: store.sequence.length,
+      fps: store.sequence.fps,
+    },
+  }
+}
+
+// Create a proxy that tracks property access
+export function createTrackedTimelineContext(
+  onAccess: (variable: TimelineVariable) => void
+): TimelineContext {
+  const context = getTimelineContext()
+
+  return new Proxy(context, {
+    get(target, prop: string | symbol) {
+      if (typeof prop === 'string' && prop in target) {
+        onAccess(prop as TimelineVariable)
+      }
+      return target[prop as keyof TimelineContext]
+    },
+  })
+}

--- a/noodles-editor/src/noodles/utils/timeline-dependencies.test.ts
+++ b/noodles-editor/src/noodles/utils/timeline-dependencies.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { useTimelineStore } from '../../timeline/timeline-store'
-import { timelineDependencyManager } from './timeline-dependencies'
+import {
+  subscribeOpToTimeline,
+  unsubscribeOpFromTimeline,
+  useTimelineDependencyStore,
+} from './timeline-dependencies'
 import { CodeOp } from '../operators'
 
 describe('timeline-dependencies', () => {
@@ -17,32 +21,29 @@ describe('timeline-dependencies', () => {
   afterEach(() => {
     // Clean up all created operators
     for (const op of createdOps) {
-      timelineDependencyManager.unsubscribe(op.id)
+      unsubscribeOpFromTimeline(op.id)
     }
     createdOps.length = 0
   })
 
-  describe('TimelineDependencyManager', () => {
-    it('tracks dependencies for an operator', () => {
+  describe('Timeline subscriptions', () => {
+    it('subscribes an operator to timeline changes', () => {
       const op = new CodeOp('/test-op', { code: 'return sequenceTime' })
       createdOps.push(op)
-      const deps = new Set(['sequenceTime'])
 
-      timelineDependencyManager.trackDependencies(op.id, deps)
+      subscribeOpToTimeline(op)
 
-      const tracked = timelineDependencyManager.getDependencies(op.id)
-      expect(tracked).toEqual(deps)
+      const subscriptions = useTimelineDependencyStore.getState().subscriptions
+      expect(subscriptions.has(op.id)).toBe(true)
     })
 
-    it('subscribes to position changes for sequenceTime dependency', () => {
+    it('marks operator dirty on position changes', () => {
       const op = new CodeOp('/test-op', { code: 'return sequenceTime' })
       createdOps.push(op)
-      const deps = new Set(['sequenceTime'])
 
       const markDirtySpy = vi.spyOn(op, 'markDirty')
 
-      timelineDependencyManager.trackDependencies(op.id, deps)
-      timelineDependencyManager.subscribe(op)
+      subscribeOpToTimeline(op)
 
       // Change position - Zustand subscriptions are synchronous
       const store = useTimelineStore.getState()
@@ -51,81 +52,46 @@ describe('timeline-dependencies', () => {
       expect(markDirtySpy).toHaveBeenCalled()
     })
 
-    it('subscribes to position changes for frame dependency', () => {
+    it('marks operator dirty on FPS changes', () => {
       const op = new CodeOp('/test-op', { code: 'return frame' })
       createdOps.push(op)
-      const deps = new Set(['frame'])
 
       const markDirtySpy = vi.spyOn(op, 'markDirty')
 
-      timelineDependencyManager.trackDependencies(op.id, deps)
-      timelineDependencyManager.subscribe(op)
+      subscribeOpToTimeline(op)
 
-      // Change position
-      const store = useTimelineStore.getState()
-      store.setPosition(2)
-
-      expect(markDirtySpy).toHaveBeenCalled()
-    })
-
-    it('subscribes to position changes for totalFrames dependency', () => {
-      const op = new CodeOp('/test-op', { code: 'return totalFrames' })
-      createdOps.push(op)
-      const deps = new Set(['totalFrames'])
-
-      const markDirtySpy = vi.spyOn(op, 'markDirty')
-
-      timelineDependencyManager.trackDependencies(op.id, deps)
-      timelineDependencyManager.subscribe(op)
-
-      // Change FPS (affects totalFrames)
+      // Change FPS
       const store = useTimelineStore.getState()
       store.setFps(60)
 
       expect(markDirtySpy).toHaveBeenCalled()
     })
 
-    it('subscribes to sequence changes for sequence dependency', () => {
-      const op = new CodeOp('/test-op', { code: 'return sequence.length' })
+    it('marks operator dirty on sequence length changes', () => {
+      const op = new CodeOp('/test-op', { code: 'return totalFrames' })
       createdOps.push(op)
-      const deps = new Set(['sequence'])
 
       const markDirtySpy = vi.spyOn(op, 'markDirty')
 
-      timelineDependencyManager.trackDependencies(op.id, deps)
-      timelineDependencyManager.subscribe(op)
+      subscribeOpToTimeline(op)
 
-      // Change sequence length
+      // Change sequence length (affects totalFrames)
       const store = useTimelineStore.getState()
       store.setLength(20)
 
       expect(markDirtySpy).toHaveBeenCalled()
     })
 
-    it('does not subscribe if no dependencies', () => {
-      const op = new CodeOp('/test-op', { code: 'return 42' })
-      createdOps.push(op)
-      const deps = new Set([])
-
-      timelineDependencyManager.trackDependencies(op.id, deps)
-      timelineDependencyManager.subscribe(op)
-
-      // Should not crash or create subscriptions
-      expect(timelineDependencyManager.getDependencies(op.id)).toEqual(deps)
-    })
-
     it('unsubscribes and cleans up', () => {
       const op = new CodeOp('/test-op', { code: 'return sequenceTime' })
       createdOps.push(op)
-      const deps = new Set(['sequenceTime'])
 
       const markDirtySpy = vi.spyOn(op, 'markDirty')
 
-      timelineDependencyManager.trackDependencies(op.id, deps)
-      timelineDependencyManager.subscribe(op)
+      subscribeOpToTimeline(op)
 
       // Unsubscribe
-      timelineDependencyManager.unsubscribe(op.id)
+      unsubscribeOpFromTimeline(op.id)
 
       // Change position - should not trigger markDirty
       const store = useTimelineStore.getState()
@@ -134,86 +100,21 @@ describe('timeline-dependencies', () => {
       expect(markDirtySpy).not.toHaveBeenCalled()
     })
 
-    it('handles multiple dependencies', () => {
-      const op = new CodeOp('/test-op', {
-        code: 'return sequenceTime + sequence.length',
-      })
-      createdOps.push(op)
-      const deps = new Set(['sequenceTime', 'sequence'])
-
-      const markDirtySpy = vi.spyOn(op, 'markDirty')
-
-      timelineDependencyManager.trackDependencies(op.id, deps)
-      timelineDependencyManager.subscribe(op)
-
-      // Change position
-      const store = useTimelineStore.getState()
-      store.setPosition(3)
-
-      expect(markDirtySpy).toHaveBeenCalled()
-
-      markDirtySpy.mockClear()
-
-      // Change sequence
-      store.setLength(20)
-
-      expect(markDirtySpy).toHaveBeenCalled()
-    })
-
-    it('handles re-subscription with different dependencies', () => {
-      const op = new CodeOp('/test-op', { code: 'return sequenceTime' })
-      createdOps.push(op)
-
-      // First subscription
-      const deps1 = new Set(['sequenceTime'])
-      timelineDependencyManager.trackDependencies(op.id, deps1)
-      timelineDependencyManager.subscribe(op)
-
-      // Re-subscribe with different dependencies
-      const deps2 = new Set(['sequence'])
-      timelineDependencyManager.trackDependencies(op.id, deps2)
-      timelineDependencyManager.subscribe(op)
-
-      const markDirtySpy = vi.spyOn(op, 'markDirty')
-
-      // Change position - should NOT trigger (no longer subscribed)
-      const store = useTimelineStore.getState()
-      store.setPosition(5)
-      expect(markDirtySpy).not.toHaveBeenCalled()
-
-      markDirtySpy.mockClear()
-
-      // Change sequence - SHOULD trigger
-      store.setLength(20)
-      expect(markDirtySpy).toHaveBeenCalled()
-    })
-
-    it('handles multiple operators with different dependencies', () => {
+    it('handles multiple operators independently', () => {
       const op1 = new CodeOp('/op1', { code: 'return sequenceTime' })
       const op2 = new CodeOp('/op2', { code: 'return sequence.length' })
       createdOps.push(op1, op2)
 
-      timelineDependencyManager.trackDependencies(op1.id, new Set(['sequenceTime']))
-      timelineDependencyManager.subscribe(op1)
-
-      timelineDependencyManager.trackDependencies(op2.id, new Set(['sequence']))
-      timelineDependencyManager.subscribe(op2)
+      subscribeOpToTimeline(op1)
+      subscribeOpToTimeline(op2)
 
       const markDirty1Spy = vi.spyOn(op1, 'markDirty')
       const markDirty2Spy = vi.spyOn(op2, 'markDirty')
 
-      // Change position - only op1 should be marked dirty
+      // Change position - both should be marked dirty (both subscribe to all timeline changes)
       const store = useTimelineStore.getState()
       store.setPosition(3)
       expect(markDirty1Spy).toHaveBeenCalled()
-      expect(markDirty2Spy).not.toHaveBeenCalled()
-
-      markDirty1Spy.mockClear()
-      markDirty2Spy.mockClear()
-
-      // Change sequence - only op2 should be marked dirty
-      store.setLength(20)
-      expect(markDirty1Spy).not.toHaveBeenCalled()
       expect(markDirty2Spy).toHaveBeenCalled()
     })
   })

--- a/noodles-editor/src/noodles/utils/timeline-dependencies.test.ts
+++ b/noodles-editor/src/noodles/utils/timeline-dependencies.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useTimelineStore } from '../../timeline/timeline-store'
+import { timelineDependencyManager } from './timeline-dependencies'
+import { CodeOp } from '../operators'
+
+describe('timeline-dependencies', () => {
+  const createdOps: CodeOp[] = []
+
+  beforeEach(() => {
+    // Reset timeline store
+    const store = useTimelineStore.getState()
+    store.setPosition(0)
+    store.setLength(10)
+    store.setFps(30)
+  })
+
+  afterEach(() => {
+    // Clean up all created operators
+    for (const op of createdOps) {
+      timelineDependencyManager.unsubscribe(op.id)
+    }
+    createdOps.length = 0
+  })
+
+  describe('TimelineDependencyManager', () => {
+    it('tracks dependencies for an operator', () => {
+      const op = new CodeOp('/test-op', { code: 'return sequenceTime' })
+      createdOps.push(op)
+      const deps = new Set(['sequenceTime'])
+
+      timelineDependencyManager.trackDependencies(op.id, deps)
+
+      const tracked = timelineDependencyManager.getDependencies(op.id)
+      expect(tracked).toEqual(deps)
+    })
+
+    it('subscribes to position changes for sequenceTime dependency', () => {
+      const op = new CodeOp('/test-op', { code: 'return sequenceTime' })
+      createdOps.push(op)
+      const deps = new Set(['sequenceTime'])
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      timelineDependencyManager.trackDependencies(op.id, deps)
+      timelineDependencyManager.subscribe(op)
+
+      // Change position - Zustand subscriptions are synchronous
+      const store = useTimelineStore.getState()
+      store.setPosition(5)
+
+      expect(markDirtySpy).toHaveBeenCalled()
+    })
+
+    it('subscribes to position changes for frame dependency', () => {
+      const op = new CodeOp('/test-op', { code: 'return frame' })
+      createdOps.push(op)
+      const deps = new Set(['frame'])
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      timelineDependencyManager.trackDependencies(op.id, deps)
+      timelineDependencyManager.subscribe(op)
+
+      // Change position
+      const store = useTimelineStore.getState()
+      store.setPosition(2)
+
+      expect(markDirtySpy).toHaveBeenCalled()
+    })
+
+    it('subscribes to position changes for totalFrames dependency', () => {
+      const op = new CodeOp('/test-op', { code: 'return totalFrames' })
+      createdOps.push(op)
+      const deps = new Set(['totalFrames'])
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      timelineDependencyManager.trackDependencies(op.id, deps)
+      timelineDependencyManager.subscribe(op)
+
+      // Change FPS (affects totalFrames)
+      const store = useTimelineStore.getState()
+      store.setFps(60)
+
+      expect(markDirtySpy).toHaveBeenCalled()
+    })
+
+    it('subscribes to sequence changes for sequence dependency', () => {
+      const op = new CodeOp('/test-op', { code: 'return sequence.length' })
+      createdOps.push(op)
+      const deps = new Set(['sequence'])
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      timelineDependencyManager.trackDependencies(op.id, deps)
+      timelineDependencyManager.subscribe(op)
+
+      // Change sequence length
+      const store = useTimelineStore.getState()
+      store.setLength(20)
+
+      expect(markDirtySpy).toHaveBeenCalled()
+    })
+
+    it('does not subscribe if no dependencies', () => {
+      const op = new CodeOp('/test-op', { code: 'return 42' })
+      createdOps.push(op)
+      const deps = new Set([])
+
+      timelineDependencyManager.trackDependencies(op.id, deps)
+      timelineDependencyManager.subscribe(op)
+
+      // Should not crash or create subscriptions
+      expect(timelineDependencyManager.getDependencies(op.id)).toEqual(deps)
+    })
+
+    it('unsubscribes and cleans up', () => {
+      const op = new CodeOp('/test-op', { code: 'return sequenceTime' })
+      createdOps.push(op)
+      const deps = new Set(['sequenceTime'])
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      timelineDependencyManager.trackDependencies(op.id, deps)
+      timelineDependencyManager.subscribe(op)
+
+      // Unsubscribe
+      timelineDependencyManager.unsubscribe(op.id)
+
+      // Change position - should not trigger markDirty
+      const store = useTimelineStore.getState()
+      store.setPosition(5)
+
+      expect(markDirtySpy).not.toHaveBeenCalled()
+    })
+
+    it('handles multiple dependencies', () => {
+      const op = new CodeOp('/test-op', {
+        code: 'return sequenceTime + sequence.length',
+      })
+      createdOps.push(op)
+      const deps = new Set(['sequenceTime', 'sequence'])
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      timelineDependencyManager.trackDependencies(op.id, deps)
+      timelineDependencyManager.subscribe(op)
+
+      // Change position
+      const store = useTimelineStore.getState()
+      store.setPosition(3)
+
+      expect(markDirtySpy).toHaveBeenCalled()
+
+      markDirtySpy.mockClear()
+
+      // Change sequence
+      store.setLength(20)
+
+      expect(markDirtySpy).toHaveBeenCalled()
+    })
+
+    it('handles re-subscription with different dependencies', () => {
+      const op = new CodeOp('/test-op', { code: 'return sequenceTime' })
+      createdOps.push(op)
+
+      // First subscription
+      const deps1 = new Set(['sequenceTime'])
+      timelineDependencyManager.trackDependencies(op.id, deps1)
+      timelineDependencyManager.subscribe(op)
+
+      // Re-subscribe with different dependencies
+      const deps2 = new Set(['sequence'])
+      timelineDependencyManager.trackDependencies(op.id, deps2)
+      timelineDependencyManager.subscribe(op)
+
+      const markDirtySpy = vi.spyOn(op, 'markDirty')
+
+      // Change position - should NOT trigger (no longer subscribed)
+      const store = useTimelineStore.getState()
+      store.setPosition(5)
+      expect(markDirtySpy).not.toHaveBeenCalled()
+
+      markDirtySpy.mockClear()
+
+      // Change sequence - SHOULD trigger
+      store.setLength(20)
+      expect(markDirtySpy).toHaveBeenCalled()
+    })
+
+    it('handles multiple operators with different dependencies', () => {
+      const op1 = new CodeOp('/op1', { code: 'return sequenceTime' })
+      const op2 = new CodeOp('/op2', { code: 'return sequence.length' })
+      createdOps.push(op1, op2)
+
+      timelineDependencyManager.trackDependencies(op1.id, new Set(['sequenceTime']))
+      timelineDependencyManager.subscribe(op1)
+
+      timelineDependencyManager.trackDependencies(op2.id, new Set(['sequence']))
+      timelineDependencyManager.subscribe(op2)
+
+      const markDirty1Spy = vi.spyOn(op1, 'markDirty')
+      const markDirty2Spy = vi.spyOn(op2, 'markDirty')
+
+      // Change position - only op1 should be marked dirty
+      const store = useTimelineStore.getState()
+      store.setPosition(3)
+      expect(markDirty1Spy).toHaveBeenCalled()
+      expect(markDirty2Spy).not.toHaveBeenCalled()
+
+      markDirty1Spy.mockClear()
+      markDirty2Spy.mockClear()
+
+      // Change sequence - only op2 should be marked dirty
+      store.setLength(20)
+      expect(markDirty1Spy).not.toHaveBeenCalled()
+      expect(markDirty2Spy).toHaveBeenCalled()
+    })
+  })
+})

--- a/noodles-editor/src/noodles/utils/timeline-dependencies.ts
+++ b/noodles-editor/src/noodles/utils/timeline-dependencies.ts
@@ -1,69 +1,70 @@
+import { create } from 'zustand'
 import { debugDirty } from '../../utils/debug'
 import { useTimelineStore } from '../../timeline/timeline-store'
 import type { Operator, IOperator } from '../operators'
-import type { TimelineVariable } from './timeline-context'
 
-class TimelineDependencyManager {
-  private dependencies = new Map<string, Set<TimelineVariable>>()
-  private subscriptions = new Map<string, (() => void)[]>()
+interface TimelineDependencyState {
+  subscriptions: Map<string, (() => void)[]>
+  subscribe: (op: Operator<IOperator>) => void
+  unsubscribe: (opId: string) => void
+}
 
-  trackDependencies(opId: string, variables: Set<TimelineVariable>): void {
-    this.dependencies.set(opId, variables)
-  }
+export const useTimelineDependencyStore = create<TimelineDependencyState>((set, get) => ({
+  subscriptions: new Map(),
 
-  subscribe(op: Operator<IOperator>): void {
-    const dependencies = this.dependencies.get(op.id)
-    if (!dependencies || dependencies.size === 0) return
+  subscribe: (op: Operator<IOperator>) => {
+    const { subscriptions, unsubscribe } = get()
 
-    this.unsubscribe(op.id)
+    // Clean up any existing subscriptions
+    unsubscribe(op.id)
 
     const cleanupFns: (() => void)[] = []
 
-    // Subscribe to position changes if sequenceTime, frame, or totalFrames is used
-    if (
-      dependencies.has('sequenceTime') ||
-      dependencies.has('frame') ||
-      dependencies.has('totalFrames')
-    ) {
-      const unsub = useTimelineStore.subscribe(
-        (state) => ({ position: state.position, fps: state.sequence.fps }),
-        () => {
-          debugDirty('%s marked dirty by timeline position change', op.id)
-          op.markDirty()
-        },
-        { equalityFn: (a, b) => a.position === b.position && a.fps === b.fps }
-      )
-      cleanupFns.push(unsub)
-    }
+    // Subscribe to position changes (affects sequenceTime, frame, totalFrames)
+    const posUnsub = useTimelineStore.subscribe(
+      (state) => ({ position: state.position, fps: state.sequence.fps }),
+      () => {
+        debugDirty('%s marked dirty by timeline position/fps change', op.id)
+        op.markDirty()
+      },
+      { equalityFn: (a, b) => a.position === b.position && a.fps === b.fps }
+    )
+    cleanupFns.push(posUnsub)
 
-    // Subscribe to sequence changes if sequence is used
-    if (dependencies.has('sequence')) {
-      const unsub = useTimelineStore.subscribe(
-        (state) => state.sequence,
-        () => {
-          debugDirty('%s marked dirty by timeline sequence change', op.id)
-          op.markDirty()
-        },
-        { equalityFn: (a, b) => a.length === b.length && a.fps === b.fps }
-      )
-      cleanupFns.push(unsub)
-    }
+    // Subscribe to sequence changes (affects sequence, totalFrames)
+    const seqUnsub = useTimelineStore.subscribe(
+      (state) => state.sequence,
+      () => {
+        debugDirty('%s marked dirty by timeline sequence change', op.id)
+        op.markDirty()
+      },
+      { equalityFn: (a, b) => a.length === b.length && a.fps === b.fps }
+    )
+    cleanupFns.push(seqUnsub)
 
-    this.subscriptions.set(op.id, cleanupFns)
-  }
+    set((state) => ({
+      subscriptions: new Map(state.subscriptions).set(op.id, cleanupFns),
+    }))
+  },
 
-  unsubscribe(opId: string): void {
-    const cleanupFns = this.subscriptions.get(opId)
+  unsubscribe: (opId: string) => {
+    const { subscriptions } = get()
+    const cleanupFns = subscriptions.get(opId)
     if (cleanupFns) {
       cleanupFns.forEach((fn) => fn())
-      this.subscriptions.delete(opId)
+      const newSubscriptions = new Map(subscriptions)
+      newSubscriptions.delete(opId)
+      set({ subscriptions: newSubscriptions })
     }
-    this.dependencies.delete(opId)
-  }
+  },
+}))
 
-  getDependencies(opId: string): Set<TimelineVariable> | undefined {
-    return this.dependencies.get(opId)
-  }
+// Helper to subscribe an operator to timeline changes
+export function subscribeOpToTimeline(op: Operator<IOperator>): void {
+  useTimelineDependencyStore.getState().subscribe(op)
 }
 
-export const timelineDependencyManager = new TimelineDependencyManager()
+// Helper to unsubscribe an operator from timeline changes
+export function unsubscribeOpFromTimeline(opId: string): void {
+  useTimelineDependencyStore.getState().unsubscribe(opId)
+}

--- a/noodles-editor/src/noodles/utils/timeline-dependencies.ts
+++ b/noodles-editor/src/noodles/utils/timeline-dependencies.ts
@@ -1,0 +1,69 @@
+import { debugDirty } from '../../utils/debug'
+import { useTimelineStore } from '../../timeline/timeline-store'
+import type { Operator, IOperator } from '../operators'
+import type { TimelineVariable } from './timeline-context'
+
+class TimelineDependencyManager {
+  private dependencies = new Map<string, Set<TimelineVariable>>()
+  private subscriptions = new Map<string, (() => void)[]>()
+
+  trackDependencies(opId: string, variables: Set<TimelineVariable>): void {
+    this.dependencies.set(opId, variables)
+  }
+
+  subscribe(op: Operator<IOperator>): void {
+    const dependencies = this.dependencies.get(op.id)
+    if (!dependencies || dependencies.size === 0) return
+
+    this.unsubscribe(op.id)
+
+    const cleanupFns: (() => void)[] = []
+
+    // Subscribe to position changes if sequenceTime, frame, or totalFrames is used
+    if (
+      dependencies.has('sequenceTime') ||
+      dependencies.has('frame') ||
+      dependencies.has('totalFrames')
+    ) {
+      const unsub = useTimelineStore.subscribe(
+        (state) => ({ position: state.position, fps: state.sequence.fps }),
+        () => {
+          debugDirty('%s marked dirty by timeline position change', op.id)
+          op.markDirty()
+        },
+        { equalityFn: (a, b) => a.position === b.position && a.fps === b.fps }
+      )
+      cleanupFns.push(unsub)
+    }
+
+    // Subscribe to sequence changes if sequence is used
+    if (dependencies.has('sequence')) {
+      const unsub = useTimelineStore.subscribe(
+        (state) => state.sequence,
+        () => {
+          debugDirty('%s marked dirty by timeline sequence change', op.id)
+          op.markDirty()
+        },
+        { equalityFn: (a, b) => a.length === b.length && a.fps === b.fps }
+      )
+      cleanupFns.push(unsub)
+    }
+
+    this.subscriptions.set(op.id, cleanupFns)
+  }
+
+  unsubscribe(opId: string): void {
+    const cleanupFns = this.subscriptions.get(opId)
+    if (cleanupFns) {
+      cleanupFns.forEach((fn) => fn())
+      this.subscriptions.delete(opId)
+    }
+    this.dependencies.delete(opId)
+  }
+
+  getDependencies(opId: string): Set<TimelineVariable> | undefined {
+    return this.dependencies.get(opId)
+  }
+}
+
+export const timelineDependencyManager = new TimelineDependencyManager()


### PR DESCRIPTION
#### Background

Timeline variables like current playback position and frame number were not accessible in code operators, making it impossible to create time-based animations or expressions that respond to timeline changes.

#### Change List
- Add timeline variables as globals: `sequenceTime`, `frame`, `totalFrames`, `sequence`
- Implement proxy-based dependency tracking for automatic re-execution on timeline changes
- Add timeline subscriptions via centralized TimelineDependencyManager using Zustand
- Update CodeOp, ExpressionOp, and AccessorOp to expose timeline variables in execution context
- Add timeline variables to autocomplete suggestions in expression-context.ts
- Implement cleanup of timeline subscriptions in Operator.dispose()

Example usage: `return Math.sin(sequenceTime * 2 * Math.PI / 5)` or `frame < 100 ? data.slice(0, 10) : data`