### PR TITLE
feat: zoom timeline around playhead and add shift-scroll support

### DIFF
--- a/noodles-editor/src/timeline/components/TimelinePanel.tsx
+++ b/noodles-editor/src/timeline/components/TimelinePanel.tsx
@@ -104,16 +104,43 @@ export function TimelinePanel({ height = 300, onCollapse }: TimelinePanelProps) 
   // Convert pixels to time
   const pixelsToTime = useCallback((pixels: number) => pixels / pixelsPerSecond, [pixelsPerSecond])
 
-  // Handle zoom with mouse wheel
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    if (e.ctrlKey || e.metaKey) {
-      e.preventDefault()
-      const delta = e.deltaY > 0 ? 0.9 : 1.1
-      setPixelsPerSecond(prev =>
-        Math.max(MIN_PIXELS_PER_SECOND, Math.min(MAX_PIXELS_PER_SECOND, prev * delta))
+  // Zoom while keeping the playhead at the same screen position
+  const zoomAroundPlayhead = useCallback(
+    (newPixelsPerSecond: number) => {
+      if (!scrollAreaRef.current) return
+
+      const clampedZoom = Math.max(
+        MIN_PIXELS_PER_SECOND,
+        Math.min(MAX_PIXELS_PER_SECOND, newPixelsPerSecond)
       )
-    }
-  }, [])
+
+      // Calculate playhead pixel position before and after zoom
+      const playheadPxBefore = position * pixelsPerSecond
+      const playheadPxAfter = position * clampedZoom
+
+      // Adjust scroll to keep playhead at same screen position
+      const scrollDelta = playheadPxAfter - playheadPxBefore
+      scrollAreaRef.current.scrollLeft = Math.max(
+        0,
+        scrollAreaRef.current.scrollLeft + scrollDelta
+      )
+
+      setPixelsPerSecond(clampedZoom)
+    },
+    [position, pixelsPerSecond]
+  )
+
+  // Handle zoom with mouse wheel (Ctrl/Cmd/Shift + scroll)
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      if (e.ctrlKey || e.metaKey || e.shiftKey) {
+        e.preventDefault()
+        const delta = e.deltaY > 0 ? 0.9 : 1.1
+        zoomAroundPlayhead(pixelsPerSecond * delta)
+      }
+    },
+    [pixelsPerSecond, zoomAroundPlayhead]
+  )
 
   // Handle scroll on the right (keyframe) panel — keep the left labels panel in sync
   const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
@@ -456,7 +483,7 @@ export function TimelinePanel({ height = 300, onCollapse }: TimelinePanelProps) 
           <button
             type="button"
             className={s.timelineZoomBtn}
-            onClick={() => setPixelsPerSecond(prev => Math.max(MIN_PIXELS_PER_SECOND, prev * 0.8))}
+            onClick={() => zoomAroundPlayhead(pixelsPerSecond * 0.8)}
             title="Zoom out"
           >
             <span className={s.timelineZoomBtnText}>&minus;</span>
@@ -484,13 +511,13 @@ export function TimelinePanel({ height = 300, onCollapse }: TimelinePanelProps) 
             max={LOG_MAX}
             step={0.01}
             value={Math.log(pixelsPerSecond)}
-            onChange={e => setPixelsPerSecond(Math.exp(Number(e.target.value)))}
+            onChange={e => zoomAroundPlayhead(Math.exp(Number(e.target.value)))}
             title={`Zoom: ${Math.round(pixelsPerSecond)} px/s`}
           />
           <button
             type="button"
             className={s.timelineZoomBtn}
-            onClick={() => setPixelsPerSecond(prev => Math.min(MAX_PIXELS_PER_SECOND, prev * 1.25))}
+            onClick={() => zoomAroundPlayhead(pixelsPerSecond * 1.25)}
             title="Zoom in"
           >
             <span className={s.timelineZoomBtnText}>+</span>


### PR DESCRIPTION
#### Background
Previously, timeline zoom operations (buttons, slider, Ctrl/Cmd+scroll) centered around timestamp 0, making the playhead jump around on screen during zoom operations. This was disorienting when working with keyframes in the middle of the timeline.

#### Change List
- Add `zoomAroundPlayhead()` helper function that adjusts scroll position to keep the playhead at the same screen location during zoom operations
- Update zoom buttons (+/-) and zoom slider to use playhead-centered zoom
- Add shift-scroll support for smooth zooming (works identically to Ctrl/Cmd+scroll)
- Preserve "Fit" button behavior (continues to center entire timeline as before)

The zoom now feels natural and predictable, with the playhead staying stable on screen while the timeline content scales around it.