### PR TITLE
fix: add icon caching to IconLayerOp to prevent flicker

### DIFF
--- a/noodles-editor/src/noodles/icon-layer-upload.test.ts
+++ b/noodles-editor/src/noodles/icon-layer-upload.test.ts
@@ -564,4 +564,164 @@ describe('IconLayerOp Upload Support', () => {
       expect(op).toBeDefined()
     })
   })
+
+  describe('Icon Resolution Caching', () => {
+    let originalImage: typeof Image
+    let _mockImageInstance: any
+    let MockImageConstructor: any
+    let shouldSucceed: boolean
+    let mockWidth: number
+    let mockHeight: number
+
+    const defaultInputs = {
+      data: [],
+      visible: true,
+      opacity: 1,
+      getPosition: [0, 0] as [number, number],
+      iconAtlas: '',
+      iconMapping: {},
+      billboard: true,
+      getSize: 1,
+      sizeUnits: 'pixels' as const,
+      sizeScale: 1,
+      sizeMinPixels: 0,
+      sizeMaxPixels: 256,
+      getPixelOffset: [0, 0] as [number, number],
+      getColor: [255, 255, 255, 255] as [number, number, number, number],
+      getAngle: 0,
+      sizeBasis: 'pixels' as const,
+      parameters: { depthTest: true },
+      extensions: [],
+    }
+
+    beforeEach(() => {
+      originalImage = globalThis.Image
+      shouldSucceed = true
+      mockWidth = 64
+      mockHeight = 64
+
+      MockImageConstructor = function (this: any) {
+        const instance = {
+          naturalWidth: 0,
+          naturalHeight: 0,
+          onload: null as (() => void) | null,
+          onerror: null as (() => void) | null,
+          _src: '',
+        }
+
+        Object.defineProperty(instance, 'src', {
+          get() {
+            return this._src
+          },
+          set(value: string) {
+            this._src = value
+            queueMicrotask(() => {
+              if (shouldSucceed) {
+                instance.naturalWidth = mockWidth
+                instance.naturalHeight = mockHeight
+                instance.onload?.()
+              } else {
+                instance.onerror?.()
+              }
+            })
+          },
+        })
+
+        _mockImageInstance = instance
+        return instance
+      }
+
+      globalThis.Image = MockImageConstructor as any
+    })
+
+    afterEach(() => {
+      globalThis.Image = originalImage
+    })
+
+    it('should return cached icon data on subsequent executions with same URL', async () => {
+      const op = new IconLayerOp('/test-icon-layer')
+      mockWidth = 64
+      mockHeight = 64
+      shouldSucceed = true
+
+      const result1 = await op.execute({
+        ...defaultInputs,
+        getIcon: 'https://example.com/aircraft.png',
+      })
+
+      const result2 = await op.execute({
+        ...defaultInputs,
+        getIcon: 'https://example.com/aircraft.png',
+      })
+
+      const iconData1 = (result1.layer.getIcon as () => any)()
+      const iconData2 = (result2.layer.getIcon as () => any)()
+
+      // Should be the exact same object reference (cached)
+      expect(iconData1).toBe(iconData2)
+    })
+
+    it('should resolve a new icon when URL changes', async () => {
+      const op = new IconLayerOp('/test-icon-layer')
+      mockWidth = 64
+      mockHeight = 64
+      shouldSucceed = true
+
+      const result1 = await op.execute({
+        ...defaultInputs,
+        getIcon: 'https://example.com/aircraft.png',
+      })
+
+      const result2 = await op.execute({
+        ...defaultInputs,
+        getIcon: 'https://example.com/helicopter.png',
+      })
+
+      const iconData1 = (result1.layer.getIcon as () => any)()
+      const iconData2 = (result2.layer.getIcon as () => any)()
+
+      // Should be different objects (different URLs)
+      expect(iconData1.id).toBe('https://example.com/aircraft.png')
+      expect(iconData2.id).toBe('https://example.com/helicopter.png')
+    })
+
+    it('should resolve a new icon when sizeMaxPixels changes', async () => {
+      const op = new IconLayerOp('/test-icon-layer')
+      mockWidth = 1000
+      mockHeight = 1000
+      shouldSucceed = true
+
+      const result1 = await op.execute({
+        ...defaultInputs,
+        getIcon: 'https://example.com/icon.png',
+        sizeMaxPixels: 64,
+      })
+
+      const result2 = await op.execute({
+        ...defaultInputs,
+        getIcon: 'https://example.com/icon.png',
+        sizeMaxPixels: 128,
+      })
+
+      const iconData1 = (result1.layer.getIcon as () => any)()
+      const iconData2 = (result2.layer.getIcon as () => any)()
+
+      // Different sizeMaxPixels → different cache key → different resolution
+      expect(iconData1.width).toBe(128) // 64 * 2
+      expect(iconData2.width).toBe(256) // 128 * 2
+    })
+
+    it('should not cache when getIcon is an accessor function', async () => {
+      const op = new IconLayerOp('/test-icon-layer')
+      const getIconFn = () => ({ url: 'test.png', width: 32, height: 32, id: 'test' })
+
+      const result = await op.execute({
+        ...defaultInputs,
+        getIcon: getIconFn,
+      })
+
+      // Accessor function should be passed through directly, not cached
+      expect(result.layer.getIcon).toBe(getIconFn)
+    })
+  })
 })

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -5149,7 +5149,14 @@ export class TextLayerOp extends Operator<TextLayerOp> {
 export class IconLayerOp extends Operator<IconLayerOp> {
   static displayName = 'IconLayer'
   static description = 'Render a set of icons on the map'
-  private _iconCache = new Map<string, { url: string; width: number; height: number; id: string }>()
+  private _iconCache = new Map<
+    string,
+    {
+      data: { url: string; width: number; height: number; id: string }
+      accessor: () => { url: string; width: number; height: number; id: string }
+    }
+  >()
+  private readonly MAX_CACHE_SIZE = 50
   createInputs() {
     return {
       data: new DataField(),
@@ -5300,13 +5307,38 @@ export class IconLayerOp extends Operator<IconLayerOp> {
       iconProps = { getIcon }
     } else if (getIcon && typeof getIcon === 'string') {
       // Single-icon mode - cache resolved icon data to avoid re-resolving every frame
-      const cacheKey = `${getIcon}:${sizeMaxPixels}`
-      let iconData = this._iconCache.get(cacheKey)
-      if (!iconData) {
-        iconData = await resolveImageWithDimensions(getIcon, sizeMaxPixels)
-        this._iconCache.set(cacheKey, iconData)
+      // Skip caching for project-local URLs (@/) since they may change on disk
+      const isProjectLocal = getIcon.startsWith(projectScheme)
+
+      if (isProjectLocal) {
+        // Always re-resolve project-local assets to reflect updates
+        const iconData = await resolveImageWithDimensions(getIcon, sizeMaxPixels)
+        iconProps = { getIcon: () => iconData }
+      } else {
+        // Cache external URLs with stable accessor reference
+        const cacheKey = `${getIcon}:${sizeMaxPixels}`
+        let cached = this._iconCache.get(cacheKey)
+
+        if (!cached) {
+          const iconData = await resolveImageWithDimensions(getIcon, sizeMaxPixels)
+          const accessor = () => iconData
+          cached = { data: iconData, accessor }
+
+          // Simple LRU: if cache is full, delete oldest entry (first in Map)
+          if (this._iconCache.size >= this.MAX_CACHE_SIZE) {
+            const firstKey = this._iconCache.keys().next().value
+            this._iconCache.delete(firstKey)
+          }
+
+          this._iconCache.set(cacheKey, cached)
+        } else {
+          // Move to end for LRU (delete + re-add)
+          this._iconCache.delete(cacheKey)
+          this._iconCache.set(cacheKey, cached)
+        }
+
+        iconProps = { getIcon: cached.accessor }
       }
-      iconProps = { getIcon: () => iconData }
     } else {
       // Atlas mode - resolve atlas URL
       const resolvedIconAtlas = await resolveProjectUrl(iconAtlas)

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -5149,6 +5149,7 @@ export class TextLayerOp extends Operator<TextLayerOp> {
 export class IconLayerOp extends Operator<IconLayerOp> {
   static displayName = 'IconLayer'
   static description = 'Render a set of icons on the map'
+  private _iconCache = new Map<string, { url: string; width: number; height: number; id: string }>()
   createInputs() {
     return {
       data: new DataField(),
@@ -5257,7 +5258,8 @@ export class IconLayerOp extends Operator<IconLayerOp> {
           const naturalHeight = img.naturalHeight
 
           // Calculate max texture dimension based on display size
-          // Use 2x for quality buffer (like Retina), but cap at 512px to limit memory
+          // Use 2x for quality buffer (like Retina), cap at 512 to avoid
+          // Deck.gl icon atlas packing issues with large dimensions
           const maxDimension = Math.min(maxDisplaySize * 2, 512)
           const aspectRatio = naturalWidth / naturalHeight
           let width = naturalWidth
@@ -5297,8 +5299,13 @@ export class IconLayerOp extends Operator<IconLayerOp> {
       // Accessor function mode - pass through
       iconProps = { getIcon }
     } else if (getIcon && typeof getIcon === 'string') {
-      // Simple single-icon mode - resolve URL and extract dimensions automatically
-      const iconData = await resolveImageWithDimensions(getIcon, sizeMaxPixels)
+      // Single-icon mode - cache resolved icon data to avoid re-resolving every frame
+      const cacheKey = `${getIcon}:${sizeMaxPixels}`
+      let iconData = this._iconCache.get(cacheKey)
+      if (!iconData) {
+        iconData = await resolveImageWithDimensions(getIcon, sizeMaxPixels)
+        this._iconCache.set(cacheKey, iconData)
+      }
       iconProps = { getIcon: () => iconData }
     } else {
       // Atlas mode - resolve atlas URL


### PR DESCRIPTION
#### Background

IconLayerOp was re-resolving images on every execute call, causing texture re-uploads and icon flickering during timeline playback and panning/zooming.

#### Change List
- Add `_iconCache` Map to IconLayerOp to cache resolved icon data (URL, width, height, ID) by `${url}:${sizeMaxPixels}` key
- Cache prevents redundant image resolution calls that caused texture re-uploads
- Update comment about 512px dimension cap to clarify it avoids Deck.gl icon atlas packing issues
- Add 4 comprehensive tests for icon caching: verify cache hit/miss behavior, cache invalidation on URL or sizeMaxPixels changes, and accessor function bypass