### PR TITLE
feat: add timeline in/out points with draggable markers and loop playback

### DIFF
--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -19,7 +19,7 @@ import { useDeckDrawLoop } from './render/draw-loop'
 import { captureScreenshot, useRenderer } from './render/renderer'
 import { TransformScale } from './render/transform-scale'
 import { CollapsibleTimelinePanel } from './timeline/components/CollapsibleTimelinePanel'
-import { useTimelineStore } from './timeline/timeline-store'
+import { getTimelineStore, useTimelineStore } from './timeline/timeline-store'
 import s from './timeline-editor.module.css'
 import { debugRender } from './utils/debug'
 import setRef from './utils/set-ref'
@@ -483,6 +483,8 @@ export default function TimelineEditor() {
       canvas = deckRef.current.canvas!
     }
 
+    const { inPoint, outPoint } = getTimelineStore().getState().sequence
+
     await startSequenceCapture({
       canvas,
       // Basemap scenes use mapProps.onIdle for frame readiness; pure-deck scenes need
@@ -491,8 +493,8 @@ export default function TimelineEditor() {
       directoryHandle: rendersDir,
       captureDelay,
       waitForData,
-      startFrame: 0,
-      endFrame: Math.floor(sequenceLength * framerate),
+      startFrame: Math.floor(inPoint * framerate),
+      endFrame: Math.floor(outPoint * framerate),
       onFrameStart: (frame, total) => debugRender('Exporting frame %d/%d', frame + 1, total),
       onFrameComplete: (frame, total) => debugRender('Completed frame %d/%d', frame, total),
     })

--- a/noodles-editor/src/timeline/components/KeyframeTrack.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeTrack.tsx
@@ -408,6 +408,11 @@ function KeyframeBar({
   const isDraggingRef = useRef(false)
   const beforeStateRef = useRef('')
 
+  // Get in/out points for dimming
+  const inPoint = useTimelineStore(state => state.sequence.inPoint)
+  const outPoint = useTimelineStore(state => state.sequence.outPoint)
+  const isOutsideActiveRange = k1.position > outPoint || k2.position < inPoint
+
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
       if (e.button !== 0) return
@@ -480,7 +485,7 @@ function KeyframeBar({
     // biome-ignore lint/a11y/noStaticElementInteractions: Bar is a drag handle for selected keyframes and click target for curve popup
     <div
       className={s.timelineKeyframeBar}
-      style={{ left, width }}
+      style={{ left, width, opacity: isOutsideActiveRange ? 0.3 : 1 }}
       onPointerDown={handlePointerDown}
       onMouseDown={e => e.stopPropagation()}
       onClick={handleClick}
@@ -520,6 +525,11 @@ function KeyframeDiamond({
   const [isHovered, setIsHovered] = useState(false)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+
+  // Get in/out points for dimming
+  const inPoint = useTimelineStore(state => state.sequence.inPoint)
+  const outPoint = useTimelineStore(state => state.sequence.outPoint)
+  const isOutsideActiveRange = keyframe.position < inPoint || keyframe.position > outPoint
 
   // Nudge the menu back into the viewport if it overflows at right/bottom edges
   useLayoutEffect(() => {
@@ -683,7 +693,7 @@ function KeyframeDiamond({
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Keyframe diamond is a drag handle */}
       <div
         className={`${s.timelineKeyframe} ${isSelected ? s.selected : ''} ${showDropTarget ? s.dropTarget : ''}`}
-        style={{ left: x }}
+        style={{ left: x, opacity: isOutsideActiveRange ? 0.3 : 1 }}
         onPointerDown={handlePointerDown}
         onClick={handleClick}
         onContextMenu={handleContextMenu}

--- a/noodles-editor/src/timeline/components/PlayControls.tsx
+++ b/noodles-editor/src/timeline/components/PlayControls.tsx
@@ -6,12 +6,20 @@ import s from './TimelinePanel.module.css'
 export function PlayControls() {
   const playing = useTimelineStore(state => state.playing)
   const loop = useTimelineStore(state => state.loop)
+  const loopInOut = useTimelineStore(state => state.loopInOut)
+  const inPoint = useTimelineStore(state => state.sequence.inPoint)
+  const outPoint = useTimelineStore(state => state.sequence.outPoint)
+  const sequenceLength = useTimelineStore(state => state.sequence.length)
 
   const play = useTimelineStore(state => state.play)
   const pause = useTimelineStore(state => state.pause)
   const toggleLoop = useTimelineStore(state => state.toggleLoop)
+  const toggleLoopInOut = useTimelineStore(state => state.toggleLoopInOut)
   const goToStart = useTimelineStore(state => state.goToStart)
   const goToEnd = useTimelineStore(state => state.goToEnd)
+
+  // Only show loop in/out button when in/out points are active
+  const hasActiveInOut = inPoint > 0 || outPoint < sequenceLength
 
   return (
     <div className={s.timelinePlayControls}>
@@ -40,6 +48,17 @@ export function PlayControls() {
       >
         <LoopIcon />
       </button>
+
+      {hasActiveInOut && (
+        <button
+          type="button"
+          onClick={toggleLoopInOut}
+          className={loopInOut ? s.active : ''}
+          title={loopInOut ? 'Loop in/out range on' : 'Loop in/out range off'}
+        >
+          <LoopInOutIcon />
+        </button>
+      )}
     </div>
   )
 }
@@ -80,6 +99,14 @@ function LoopIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
       <path d="M12.2 4.8H5.8a2.8 2.8 0 0 0 0 5.6h1.7M3.9 8.6l-1.6 1.8 1.6 1.7M3.8 11.2h6.4a2.8 2.8 0 0 0 0-5.6H8.5M12.1 7.4l1.6-1.8-1.6-1.7" />
+    </svg>
+  )
+}
+
+function LoopInOutIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M2.5 4v8M13.5 4v8M4.5 4h7M4.5 12h7M5 7l2 1-2 1V7zM11 7l-2 1 2 1V7z" />
     </svg>
   )
 }

--- a/noodles-editor/src/timeline/components/TimeRuler.tsx
+++ b/noodles-editor/src/timeline/components/TimeRuler.tsx
@@ -338,6 +338,32 @@ export function TimeRuler({
     }
   }, [])
 
+  // In/Out point handlers
+  const handleInPointMove = useCallback(
+    (newPosition: number) => {
+      useTimelineStore.getState().setInPoint(newPosition)
+    },
+    []
+  )
+
+  const handleOutPointMove = useCallback(
+    (newPosition: number) => {
+      useTimelineStore.getState().setOutPoint(newPosition)
+    },
+    []
+  )
+
+  const handleInPointMoveStart = useCallback(() => {
+    beforeStateRef.current = captureTimelineState()
+  }, [])
+
+  const handleInPointMoveEnd = useCallback(() => {
+    if (beforeStateRef.current) {
+      fireTimelineMutation('Move in/out point', beforeStateRef.current)
+      beforeStateRef.current = ''
+    }
+  }, [])
+
   const handleStartConnection = useCallback(
     (markerId: string, clientX: number, clientY: number) => {
       onStartMarkerConnection?.(markerId, clientX, clientY)
@@ -375,30 +401,32 @@ export function TimeRuler({
 
       {/* In Point Marker */}
       {inPoint > 0 && (
-        <div
-          className={s.inOutMarker}
-          data-type="in"
-          style={{
-            left: `${inPoint * pixelsPerSecond}px`,
-          }}
-        >
-          <div className={s.inOutMarkerLine} />
-          <div className={s.inOutMarkerLabel}>IN</div>
-        </div>
+        <InOutMarker
+          type="in"
+          position={inPoint}
+          pixelsPerSecond={pixelsPerSecond}
+          sequenceLength={sequenceLength}
+          outPoint={outPoint}
+          fps={fps}
+          onMove={handleInPointMove}
+          onMoveStart={handleInPointMoveStart}
+          onMoveEnd={handleInPointMoveEnd}
+        />
       )}
 
       {/* Out Point Marker */}
       {outPoint < sequenceLength && (
-        <div
-          className={s.inOutMarker}
-          data-type="out"
-          style={{
-            left: `${outPoint * pixelsPerSecond}px`,
-          }}
-        >
-          <div className={s.inOutMarkerLine} />
-          <div className={s.inOutMarkerLabel}>OUT</div>
-        </div>
+        <InOutMarker
+          type="out"
+          position={outPoint}
+          pixelsPerSecond={pixelsPerSecond}
+          sequenceLength={sequenceLength}
+          inPoint={inPoint}
+          fps={fps}
+          onMove={handleOutPointMove}
+          onMoveStart={handleInPointMoveStart}
+          onMoveEnd={handleInPointMoveEnd}
+        />
       )}
 
       {/* End-of-sequence marker */}
@@ -486,6 +514,96 @@ export function TimeRuler({
           </div>,
           document.body
         )}
+    </div>
+  )
+}
+
+// In/Out Point Marker component with drag support
+interface InOutMarkerProps {
+  type: 'in' | 'out'
+  position: number
+  pixelsPerSecond: number
+  sequenceLength: number
+  inPoint?: number
+  outPoint?: number
+  fps: number
+  onMove: (newPosition: number) => void
+  onMoveStart?: () => void
+  onMoveEnd?: () => void
+}
+
+function InOutMarker({
+  type,
+  position,
+  pixelsPerSecond,
+  sequenceLength,
+  inPoint = 0,
+  outPoint,
+  fps,
+  onMove,
+  onMoveStart,
+  onMoveEnd,
+}: InOutMarkerProps) {
+  const [isHovered, setIsHovered] = useState(false)
+  const dragStateRef = useRef<{ startX: number; startPosition: number } | null>(null)
+
+  const x = position * pixelsPerSecond
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return
+      e.stopPropagation()
+      e.preventDefault()
+
+      e.currentTarget.setPointerCapture(e.pointerId)
+      dragStateRef.current = {
+        startX: e.clientX,
+        startPosition: position,
+      }
+      onMoveStart?.()
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        if (!dragStateRef.current) return
+        const delta = (moveEvent.clientX - dragStateRef.current.startX) / pixelsPerSecond
+        let newPosition = snapToFrame(dragStateRef.current.startPosition + delta, fps)
+
+        // Clamp based on type
+        if (type === 'in') {
+          newPosition = Math.max(0, Math.min(newPosition, outPoint ?? sequenceLength))
+        } else {
+          newPosition = Math.max(inPoint, Math.min(newPosition, sequenceLength))
+        }
+
+        onMove(newPosition)
+      }
+
+      const handleUp = () => {
+        dragStateRef.current = null
+        onMoveEnd?.()
+        document.removeEventListener('pointermove', handleMove)
+        document.removeEventListener('pointerup', handleUp)
+      }
+
+      document.addEventListener('pointermove', handleMove)
+      document.addEventListener('pointerup', handleUp)
+    },
+    [position, pixelsPerSecond, fps, type, inPoint, outPoint, sequenceLength, onMove, onMoveStart, onMoveEnd]
+  )
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: Marker supports pointer drag
+    <div
+      className={`${s.inOutMarker} ${isHovered ? s.hovered : ''}`}
+      data-type={type}
+      style={{ left: x, cursor: 'ew-resize' }}
+      onPointerDown={handlePointerDown}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      title={`Drag to adjust ${type === 'in' ? 'in' : 'out'} point`}
+    >
+      <div className={s.inOutMarkerLine} />
+      <div className={s.inOutMarkerLabel}>{type === 'in' ? 'IN' : 'OUT'}</div>
+      <div className={s.inOutMarkerHandle} />
     </div>
   )
 }

--- a/noodles-editor/src/timeline/components/TimeRuler.tsx
+++ b/noodles-editor/src/timeline/components/TimeRuler.tsx
@@ -100,6 +100,10 @@ export function TimeRuler({
   const moveMarker = useTimelineStore(state => state.moveMarker)
   const selectMarker = useTimelineStore(state => state.selectMarker)
 
+  // Get in/out points from store
+  const inPoint = useTimelineStore(state => state.sequence.inPoint)
+  const outPoint = useTimelineStore(state => state.sequence.outPoint)
+
   // Close context menu on outside click or escape
   useEffect(() => {
     if (!contextMenu) return
@@ -369,6 +373,34 @@ export function TimeRuler({
         />
       ))}
 
+      {/* In Point Marker */}
+      {inPoint > 0 && (
+        <div
+          className={s.inOutMarker}
+          data-type="in"
+          style={{
+            left: `${inPoint * pixelsPerSecond}px`,
+          }}
+        >
+          <div className={s.inOutMarkerLine} />
+          <div className={s.inOutMarkerLabel}>IN</div>
+        </div>
+      )}
+
+      {/* Out Point Marker */}
+      {outPoint < sequenceLength && (
+        <div
+          className={s.inOutMarker}
+          data-type="out"
+          style={{
+            left: `${outPoint * pixelsPerSecond}px`,
+          }}
+        >
+          <div className={s.inOutMarkerLine} />
+          <div className={s.inOutMarkerLabel}>OUT</div>
+        </div>
+      )}
+
       {/* End-of-sequence marker */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Marker supports pointer drag and double-click editing */}
       <div
@@ -415,6 +447,42 @@ export function TimeRuler({
                 </button>
               </>
             )}
+            <div className={s.rulerContextMenuDivider} />
+            <button
+              type="button"
+              onClick={() => {
+                beforeStateRef.current = captureTimelineState()
+                const snapped = snapToFrame(contextMenu.time, fps)
+                useTimelineStore.getState().setInPoint(snapped)
+                fireTimelineMutation('Set in point')
+                setContextMenu(null)
+              }}
+            >
+              Mark In
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                beforeStateRef.current = captureTimelineState()
+                const snapped = snapToFrame(contextMenu.time, fps)
+                useTimelineStore.getState().setOutPoint(snapped)
+                fireTimelineMutation('Set out point')
+                setContextMenu(null)
+              }}
+            >
+              Mark Out
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                beforeStateRef.current = captureTimelineState()
+                useTimelineStore.getState().clearInOutPoints()
+                fireTimelineMutation('Clear in/out points')
+                setContextMenu(null)
+              }}
+            >
+              Clear In/Out
+            </button>
           </div>,
           document.body
         )}

--- a/noodles-editor/src/timeline/components/TimelinePanel.module.css
+++ b/noodles-editor/src/timeline/components/TimelinePanel.module.css
@@ -1477,3 +1477,46 @@
 .timelineTrackLabelBtn.hasKeyframes:hover:not(:disabled) {
   color: var(--tl-accent-strong);
 }
+
+/* In/Out Point Markers */
+.inOutMarker {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.inOutMarker[data-type="in"] .inOutMarkerLine {
+  border-left: 2px solid #4ade80;
+}
+
+.inOutMarker[data-type="out"] .inOutMarkerLine {
+  border-left: 2px solid #f87171;
+}
+
+.inOutMarkerLine {
+  height: 100%;
+}
+
+.inOutMarkerLabel {
+  position: absolute;
+  top: 2px;
+  left: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: currentColor;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+
+/* Dimming overlay for non-active timeline sections */
+.timelineDimOverlay {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  z-index: 5;
+}

--- a/noodles-editor/src/timeline/components/TimelinePanel.module.css
+++ b/noodles-editor/src/timeline/components/TimelinePanel.module.css
@@ -1483,8 +1483,9 @@
   position: absolute;
   top: 0;
   height: 100%;
-  pointer-events: none;
+  pointer-events: auto;
   z-index: 10;
+  cursor: ew-resize;
 }
 
 .inOutMarker[data-type="in"] .inOutMarkerLine {
@@ -1497,6 +1498,7 @@
 
 .inOutMarkerLine {
   height: 100%;
+  pointer-events: none;
 }
 
 .inOutMarkerLabel {
@@ -1509,6 +1511,25 @@
   background: rgba(0, 0, 0, 0.6);
   padding: 1px 4px;
   border-radius: 2px;
+  pointer-events: none;
+  user-select: none;
+}
+
+.inOutMarkerHandle {
+  position: absolute;
+  top: 0;
+  left: -4px;
+  width: 8px;
+  height: 100%;
+  cursor: ew-resize;
+}
+
+.inOutMarker:hover .inOutMarkerLine {
+  opacity: 0.8;
+}
+
+.inOutMarker:hover .inOutMarkerLabel {
+  background: rgba(0, 0, 0, 0.8);
 }
 
 /* Dimming overlay for non-active timeline sections */

--- a/noodles-editor/src/timeline/components/TimelinePanel.tsx
+++ b/noodles-editor/src/timeline/components/TimelinePanel.tsx
@@ -593,6 +593,25 @@ export function TimelinePanel({ height = 300, onCollapse }: TimelinePanelProps) 
                 mousePosition={connectionMousePos}
               />
               {boxSelectOverlay && <div className={s.timelineBoxSelect} style={boxSelectOverlay} />}
+              {/* Dim regions outside in/out range */}
+              {sequence.inPoint > 0 && (
+                <div
+                  className={s.timelineDimOverlay}
+                  style={{
+                    left: 0,
+                    width: `${sequence.inPoint * pixelsPerSecond}px`,
+                  }}
+                />
+              )}
+              {sequence.outPoint < sequence.length && (
+                <div
+                  className={s.timelineDimOverlay}
+                  style={{
+                    left: `${sequence.outPoint * pixelsPerSecond}px`,
+                    width: `${(sequence.length - sequence.outPoint) * pixelsPerSecond}px`,
+                  }}
+                />
+              )}
             </div>
           ) : (
             <CurveEditorView

--- a/noodles-editor/src/timeline/playback.ts
+++ b/noodles-editor/src/timeline/playback.ts
@@ -111,18 +111,34 @@ export function connectPlaybackToTimeline(): () => void {
     const store = getTimelineStore()
     if (!store.playing) return
 
-    const { position, sequence, playbackSpeed, loop } = store
+    const { position, sequence, playbackSpeed, loop, loopInOut } = store
     const deltaSeconds = (deltaMs / 1000) * playbackSpeed
     let newPosition = position + deltaSeconds
 
-    // Handle end of sequence
-    if (newPosition >= sequence.length) {
+    // Determine playback boundaries
+    const startBoundary = loopInOut ? sequence.inPoint : 0
+    const endBoundary = loopInOut ? sequence.outPoint : sequence.length
+
+    // Handle end of playback range
+    if (newPosition >= endBoundary) {
       if (loop) {
-        // Wrap around to beginning
-        newPosition = newPosition % sequence.length
+        // Wrap around to start of range
+        const overshoot = newPosition - endBoundary
+        newPosition = startBoundary + (overshoot % (endBoundary - startBoundary))
       } else {
         // Stop at end
-        newPosition = sequence.length
+        newPosition = endBoundary
+        store.pause()
+      }
+    }
+
+    // Handle going before start boundary (can happen with negative playback speed)
+    if (newPosition < startBoundary) {
+      if (loop) {
+        const undershoot = startBoundary - newPosition
+        newPosition = endBoundary - (undershoot % (endBoundary - startBoundary))
+      } else {
+        newPosition = startBoundary
         store.pause()
       }
     }

--- a/noodles-editor/src/timeline/timeline-store.ts
+++ b/noodles-editor/src/timeline/timeline-store.ts
@@ -46,6 +46,11 @@ export interface TimelineStore {
   setLength: (length: number) => void
   setFps: (fps: number) => void
 
+  // === In/Out Point Actions ===
+  setInPoint: (time: number) => void
+  setOutPoint: (time: number) => void
+  clearInOutPoints: () => void
+
   // === Playback Actions ===
   setPosition: (position: number) => void
   play: () => void
@@ -209,7 +214,11 @@ export const useTimelineStore = create<TimelineStore>()(
     // === Sequence Actions ===
     setLength: length => {
       set(state => ({
-        sequence: { ...state.sequence, length: Math.max(0.1, length) },
+        sequence: {
+          ...state.sequence,
+          length: Math.max(0.1, length),
+          outPoint: Math.min(state.sequence.outPoint, length),
+        },
         position: Math.min(state.position, length),
       }))
     },
@@ -217,6 +226,33 @@ export const useTimelineStore = create<TimelineStore>()(
     setFps: fps => {
       set(state => ({
         sequence: { ...state.sequence, fps: Math.max(1, Math.round(fps)) },
+      }))
+    },
+
+    // === In/Out Point Actions ===
+    setInPoint: time => {
+      set(state => {
+        const { sequence } = state
+        const clamped = Math.max(0, Math.min(time, sequence.outPoint))
+        return {
+          sequence: { ...sequence, inPoint: clamped },
+        }
+      })
+    },
+
+    setOutPoint: time => {
+      set(state => {
+        const { sequence } = state
+        const clamped = Math.max(sequence.inPoint, Math.min(time, sequence.length))
+        return {
+          sequence: { ...sequence, outPoint: clamped },
+        }
+      })
+    },
+
+    clearInOutPoints: () => {
+      set(state => ({
+        sequence: { ...state.sequence, inPoint: 0, outPoint: state.sequence.length },
       }))
     },
 
@@ -678,6 +714,8 @@ export const useTimelineStore = create<TimelineStore>()(
               subUnitsPerUnit: sequence.fps,
               tracksByObject,
               markers: serializedMarkers.length > 0 ? serializedMarkers : undefined,
+              inPoint: sequence.inPoint,
+              outPoint: sequence.outPoint,
             },
             staticOverrides: { byObject: {} },
           },
@@ -760,16 +798,20 @@ export const useTimelineStore = create<TimelineStore>()(
         })),
       }))
 
+      const length =
+        typeof seq.length === 'number' && seq.length > 0
+          ? seq.length
+          : DEFAULT_SEQUENCE_STATE.length
+
       set({
         sequence: {
-          length:
-            typeof seq.length === 'number' && seq.length > 0
-              ? seq.length
-              : DEFAULT_SEQUENCE_STATE.length,
+          length,
           fps:
             typeof seq.subUnitsPerUnit === 'number' && seq.subUnitsPerUnit > 0
               ? Math.round(seq.subUnitsPerUnit)
               : DEFAULT_SEQUENCE_STATE.fps,
+          inPoint: typeof seq.inPoint === 'number' ? seq.inPoint : 0,
+          outPoint: typeof seq.outPoint === 'number' ? seq.outPoint : length,
         },
         tracks: newTracks,
         markers,

--- a/noodles-editor/src/timeline/timeline-store.ts
+++ b/noodles-editor/src/timeline/timeline-store.ts
@@ -36,6 +36,7 @@ export interface TimelineStore {
   position: number
   playing: boolean
   loop: boolean
+  loopInOut: boolean
   playbackSpeed: number
   selectedKeyframeIds: Set<string>
   selectedTrackIds: Set<string>
@@ -57,6 +58,7 @@ export interface TimelineStore {
   pause: () => void
   togglePlay: () => void
   toggleLoop: () => void
+  toggleLoopInOut: () => void
   setPlaybackSpeed: (speed: number) => void
   stepForward: (frames?: number) => void
   stepBackward: (frames?: number) => void
@@ -205,6 +207,7 @@ export const useTimelineStore = create<TimelineStore>()(
     position: 0,
     playing: false,
     loop: true,
+    loopInOut: false,
     playbackSpeed: 1,
     selectedKeyframeIds: new Set(),
     selectedTrackIds: new Set(),
@@ -266,6 +269,7 @@ export const useTimelineStore = create<TimelineStore>()(
     pause: () => set({ playing: false }),
     togglePlay: () => set(state => ({ playing: !state.playing })),
     toggleLoop: () => set(state => ({ loop: !state.loop })),
+    toggleLoopInOut: () => set(state => ({ loopInOut: !state.loopInOut })),
 
     setPlaybackSpeed: speed => {
       set({ playbackSpeed: Math.max(0.1, Math.min(10, speed)) })

--- a/noodles-editor/src/timeline/types.ts
+++ b/noodles-editor/src/timeline/types.ts
@@ -86,11 +86,15 @@ export interface Track {
 export interface SequenceState {
   length: number // Duration in seconds
   fps: number // Frames per second (default: 30)
+  inPoint: number // Render start time in seconds (default: 0)
+  outPoint: number // Render end time in seconds (default: length)
 }
 
 export const DEFAULT_SEQUENCE_STATE: SequenceState = {
   length: 10,
   fps: 30,
+  inPoint: 0,
+  outPoint: 10,
 }
 
 // ============================================================================
@@ -181,6 +185,8 @@ export interface TimelineSequenceData {
     }
   >
   markers?: SerializedTimeMarker[]
+  inPoint?: number // Optional for backward compatibility
+  outPoint?: number // Optional for backward compatibility
 }
 
 // Top-level serialized timeline format


### PR DESCRIPTION
#### Background

Professional video editors like After Effects and DaVinci Resolve allow marking in/out points to render or loop specific sections of the timeline. This feature brings that workflow to Noodles.gl, improving iterative work on timeline sections without manual trimming.

#### Change List
- Add in/out point markers to timeline (green IN, red OUT) with right-click context menu
- Implement draggable markers with frame snapping and boundary clamping
- Add visual dimming of non-active regions (background + keyframes at 0.3 opacity)
- Add "Loop In/Out" toggle button for playback within marked range
- Update export to respect in/out frame range when rendering sequences
- Integrate with undo/redo system and project persistence with backward compatibility
- Add 9 files changed, 392 insertions, 16 deletions