### PR TITLE
feat: update keyframe values in real-time during timeline editing

### DIFF
--- a/noodles-editor/src/timeline/components/KeyframeValuePopup.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeValuePopup.tsx
@@ -3,6 +3,13 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import {
+  Point2DField,
+  Point3DField,
+  Vec2Field,
+  Vec3Field,
+} from '../../noodles/fields'
+import { getFieldFromTrackPath, keyframeValueToFieldValue } from '../field-bindings'
 import { captureTimelineState, fireTimelineMutation, useTimelineStore } from '../timeline-store'
 import type { Keyframe, KeyframeValue, Point2D, Point3D, RGBA, Vec2, Vec3 } from '../types'
 import s from './TimelinePanel.module.css'
@@ -296,7 +303,52 @@ export function KeyframeValuePopup({
   const handleValueChange = useCallback(
     (newValue: KeyframeValue) => {
       hasChangedRef.current = true
+
+      // Update keyframe in timeline store
       useTimelineStore.getState().updateKeyframe(trackId, keyframe.id, { value: newValue })
+
+      // Re-evaluate timeline at current position and apply to field
+      const timelineStore = useTimelineStore.getState()
+      const currentPosition = timelineStore.position
+      const evaluatedValue = timelineStore.evaluateTrack(trackId, currentPosition)
+
+      if (evaluatedValue !== undefined) {
+        const fieldInfo = getFieldFromTrackPath(trackId)
+
+        if (fieldInfo && !fieldInfo.operator.locked?.value) {
+          const { field, subPath } = fieldInfo
+
+          // Handle vec/point channel updates (e.g., "position / x")
+          if (subPath && subPath.length > 0) {
+            const channelKey = subPath[0]
+            const channelValue = evaluatedValue as number
+
+            if (
+              field instanceof Vec2Field ||
+              field instanceof Vec3Field ||
+              field instanceof Point2DField ||
+              field instanceof Point3DField
+            ) {
+              // Update specific channel while preserving others
+              if (field.returnType === 'tuple') {
+                const channelKeys = (field.constructor as typeof Vec2Field).channelKeys
+                const idx = channelKeys.indexOf(channelKey as (typeof channelKeys)[number])
+                const tuple = [...(field.value as number[])]
+                tuple[idx] = channelValue
+                field.setValue(tuple as any)
+              } else {
+                field.setValue({ ...field.value, [channelKey]: channelValue } as any)
+              }
+            }
+          } else {
+            // Regular field update (not a channel)
+            const fieldValue = keyframeValueToFieldValue(field, evaluatedValue)
+            if (fieldValue !== undefined) {
+              field.setValue(fieldValue)
+            }
+          }
+        }
+      }
     },
     [trackId, keyframe.id]
   )

--- a/noodles-editor/src/timeline/components/KeyframeValuePopup.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeValuePopup.tsx
@@ -319,29 +319,29 @@ export function KeyframeValuePopup({
           const { field, subPath } = fieldInfo
 
           // Handle vec/point channel updates (e.g., "position / x")
-          if (subPath && subPath.length > 0) {
+          if (
+            subPath &&
+            subPath.length > 0 &&
+            (field instanceof Vec2Field ||
+              field instanceof Vec3Field ||
+              field instanceof Point2DField ||
+              field instanceof Point3DField)
+          ) {
             const channelKey = subPath[0]
             const channelValue = evaluatedValue as number
 
-            if (
-              field instanceof Vec2Field ||
-              field instanceof Vec3Field ||
-              field instanceof Point2DField ||
-              field instanceof Point3DField
-            ) {
-              // Update specific channel while preserving others
-              if (field.returnType === 'tuple') {
-                const channelKeys = (field.constructor as typeof Vec2Field).channelKeys
-                const idx = channelKeys.indexOf(channelKey as (typeof channelKeys)[number])
-                const tuple = [...(field.value as number[])]
-                tuple[idx] = channelValue
-                field.setValue(tuple as any)
-              } else {
-                field.setValue({ ...field.value, [channelKey]: channelValue } as any)
-              }
+            // Update specific channel while preserving others
+            if (field.returnType === 'tuple') {
+              const channelKeys = (field.constructor as typeof Vec2Field).channelKeys
+              const idx = channelKeys.indexOf(channelKey as (typeof channelKeys)[number])
+              const tuple = [...(field.value as number[])]
+              tuple[idx] = channelValue
+              field.setValue(tuple as any)
+            } else {
+              field.setValue({ ...field.value, [channelKey]: channelValue } as any)
             }
           } else {
-            // Regular field update (not a channel)
+            // Regular field update (not a vec/point channel)
             const fieldValue = keyframeValueToFieldValue(field, evaluatedValue)
             if (fieldValue !== undefined) {
               field.setValue(fieldValue)

--- a/noodles-editor/src/timeline/field-bindings.ts
+++ b/noodles-editor/src/timeline/field-bindings.ts
@@ -243,14 +243,24 @@ export function getFieldFromTrackPath(fieldPath: string): {
   const parts = fieldPath.split(' / ')
   if (parts.length < 2) return null
 
-  // Reconstruct operator ID: "maplibre-basemap" → "/maplibre-basemap"
-  const opId = `/${parts[0].replace(/ \/ /g, '/')}`
+  // Reconstruct operator ID by trying each split point
+  // "container / nested / fieldName" → try "/container/nested", then "/container"
+  let operator: Operator<IOperator> | null = null
+  let opPartCount = 0
 
-  const operator = getOp(opId)
+  for (let i = parts.length - 2; i >= 0; i--) {
+    const opId = `/${parts.slice(0, i + 1).join('/')}`
+    operator = getOp(opId)
+    if (operator) {
+      opPartCount = i + 1
+      break
+    }
+  }
+
   if (!operator) return null
 
-  const fieldName = parts[1]
-  const subPath = parts.slice(2)
+  const fieldName = parts[opPartCount]
+  const subPath = parts.slice(opPartCount + 1)
 
   // Navigate to the field
   let field: AnyField | undefined = operator.inputs[fieldName] as AnyField
@@ -370,7 +380,12 @@ export function bindFieldToTimeline(
       }
     },
     {
-      equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b),
+      equalityFn: (a, b) => {
+        if (a === b) return true
+        if (!a || !b || a.length !== b.length) return false
+        // Shallow compare keyframes by reference - new array is created on mutation
+        return a.every((kf, i) => kf === b[i])
+      },
     }
   )
 
@@ -591,7 +606,12 @@ function bindVecChannelToTimeline(
       }
     },
     {
-      equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b),
+      equalityFn: (a, b) => {
+        if (a === b) return true
+        if (!a || !b || a.length !== b.length) return false
+        // Shallow compare keyframes by reference - new array is created on mutation
+        return a.every((kf, i) => kf === b[i])
+      },
     }
   )
 

--- a/noodles-editor/src/timeline/field-bindings.ts
+++ b/noodles-editor/src/timeline/field-bindings.ts
@@ -20,6 +20,7 @@ import {
   Vec3Field,
 } from '../noodles/fields'
 import type { IOperator, Operator } from '../noodles/operators'
+import { getOp } from '../noodles/store'
 import { type RGBA as ColorRGBA, colorToRgba, hexToRgba, rgbaToHex } from '../utils/color'
 import { debugBinding, debugKeyframe, debugTimeline } from '../utils/debug'
 import type { TimelineStore } from './timeline-store'
@@ -231,6 +232,40 @@ export function getFieldPath(opId: string, fieldName: string, subPath?: string[]
   return parts.join(' / ')
 }
 
+// Parse a track ID and return the corresponding operator and field
+// Returns null if operator/field not found
+export function getFieldFromTrackPath(fieldPath: string): {
+  operator: Operator<IOperator>
+  fieldName: string
+  subPath?: string[]
+  field: AnyField
+} | null {
+  const parts = fieldPath.split(' / ')
+  if (parts.length < 2) return null
+
+  // Reconstruct operator ID: "maplibre-basemap" → "/maplibre-basemap"
+  const opId = `/${parts[0].replace(/ \/ /g, '/')}`
+
+  const operator = getOp(opId)
+  if (!operator) return null
+
+  const fieldName = parts[1]
+  const subPath = parts.slice(2)
+
+  // Navigate to the field
+  let field: AnyField | undefined = operator.inputs[fieldName] as AnyField
+  if (!field) return null
+
+  // For compound fields, navigate to sub-field
+  if (subPath.length > 0 && field instanceof CompoundPropsField) {
+    field = field.fields[subPath[0]] as AnyField
+  }
+
+  if (!field) return null
+
+  return { operator, fieldName, subPath: subPath.length > 0 ? subPath : undefined, field }
+}
+
 // ============================================================================
 // Binding Management
 // ============================================================================
@@ -295,6 +330,47 @@ export function bindFieldToTimeline(
         debugTimeline(`Error syncing timeline to field for ${op.id}.${fieldName}:`, e)
       }
       updating = false
+    }
+  )
+
+  // Subscribe to track keyframe changes -> update field
+  // Handles undo/redo and any other keyframe modifications
+  const unsubscribeTracks = useTimelineStore.subscribe(
+    state => {
+      const track = state.tracks.get(fieldPath)
+      return track?.keyframes
+    },
+    _keyframes => {
+      if (op.locked?.value || updating) return
+
+      // Re-evaluate at current position
+      const position = getTimelineStore().position
+      const value = timelineStore.evaluateTrack(fieldPath, position)
+
+      if (value !== undefined) {
+        // Skip if value hasn't changed
+        if (
+          lastKeyframeValue !== undefined &&
+          JSON.stringify(value) === JSON.stringify(lastKeyframeValue)
+        ) {
+          return
+        }
+        lastKeyframeValue = value
+
+        updating = true
+        try {
+          const fieldValue = keyframeValueToFieldValue(field, value)
+          if (fieldValue !== undefined && field.value !== fieldValue) {
+            field.setValue(fieldValue)
+          }
+        } catch (e) {
+          debugTimeline(`Error syncing track changes to field for ${op.id}.${fieldName}:`, e)
+        }
+        updating = false
+      }
+    },
+    {
+      equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b),
     }
   )
 
@@ -408,6 +484,7 @@ export function bindFieldToTimeline(
   // Return cleanup function
   return () => {
     unsubscribePosition()
+    unsubscribeTracks()
     fieldSub.unsubscribe()
   }
 }
@@ -481,6 +558,40 @@ function bindVecChannelToTimeline(
         debugTimeline(`Error syncing timeline to vec channel ${fieldPath}:`, e)
       }
       updating = false
+    }
+  )
+
+  // Subscribe to track keyframe changes -> update channel
+  const unsubscribeTracks = useTimelineStore.subscribe(
+    state => {
+      const track = state.tracks.get(fieldPath)
+      return track?.keyframes
+    },
+    _keyframes => {
+      if (op.locked?.value || updating) return
+
+      const position = getTimelineStore().position
+      const value = timelineStore.evaluateTrack(fieldPath, position) as number | undefined
+
+      if (value !== undefined) {
+        if (lastKfValue !== undefined && value === lastKfValue) {
+          return
+        }
+        lastKfValue = value
+
+        updating = true
+        try {
+          if (getChannel() !== value) {
+            setChannel(value)
+          }
+        } catch (e) {
+          debugTimeline(`Error syncing track changes to vec channel ${fieldPath}:`, e)
+        }
+        updating = false
+      }
+    },
+    {
+      equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b),
     }
   )
 
@@ -581,6 +692,7 @@ function bindVecChannelToTimeline(
 
   return () => {
     unsubscribePosition()
+    unsubscribeTracks()
     fieldSub.unsubscribe()
   }
 }


### PR DESCRIPTION
#### Background

When editing keyframe values in the timeline popup (clicking a keyframe diamond), the visualization didn't update until scrubbing the timeline playhead. This broke the interactive feedback loop that makes property panel inputs feel responsive.

#### Change List
- Add `getFieldFromTrackPath()` helper function to parse track IDs and retrieve corresponding operator fields
- Update `KeyframeValuePopup.handleValueChange()` to re-evaluate timeline at current playhead position and apply interpolated values to fields immediately
- Add track keyframe subscriptions to `bindFieldToTimeline()` and `bindVecChannelToTimeline()` to handle undo/redo operations
- Handle vec/point channel updates to preserve other channel values during edits
- Respect locked operators when applying field updates