### PR TITLE
fix: correct IconLayer sizeBasis and add 'common' unit support

### DIFF
--- a/noodles-editor/src/noodles/layer-sizing.test.ts
+++ b/noodles-editor/src/noodles/layer-sizing.test.ts
@@ -129,6 +129,13 @@ describe('Layer Sizing and Width Units', () => {
       result = await arcLayer.execute(getInputProps(arcLayer))
       expect(result.layer.widthUnits).toBe('common')
     })
+
+    it('should have correct default values', async () => {
+      const arcLayer = new ArcLayerOp('/test-arc')
+      const result = await arcLayer.execute(getInputProps(arcLayer))
+
+      expect(result.layer.widthUnits).toBe('meters')
+    })
   })
 
   describe('LineLayerOp', () => {

--- a/noodles-editor/src/noodles/layer-sizing.test.ts
+++ b/noodles-editor/src/noodles/layer-sizing.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { IconLayerOp, PathLayerOp, TripsLayerOp, ArcLayerOp, LineLayerOp, GreatCircleLayerOp } from './operators'
+import {
+  IconLayerOp,
+  PathLayerOp,
+  TripsLayerOp,
+  ArcLayerOp,
+  LineLayerOp,
+  GreatCircleLayerOp,
+} from './operators'
 
 // Helper to get all input values from an operator
 function getInputProps(op: { inputs: Record<string, { value: unknown }> }) {

--- a/noodles-editor/src/noodles/layer-sizing.test.ts
+++ b/noodles-editor/src/noodles/layer-sizing.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import { IconLayerOp, PathLayerOp, TripsLayerOp, ArcLayerOp, LineLayerOp, GreatCircleLayerOp } from './operators'
+
+// Helper to get all input values from an operator
+function getInputProps(op: { inputs: Record<string, { value: unknown }> }) {
+  const props: Record<string, unknown> = {}
+  for (const [key, field] of Object.entries(op.inputs)) {
+    props[key] = field.value
+  }
+  return props
+}
+
+describe('Layer Sizing and Width Units', () => {
+  describe('IconLayerOp', () => {
+    it('should accept sizeBasis values: height and width', async () => {
+      const iconLayer = new IconLayerOp('/test-icon')
+
+      iconLayer.inputs.sizeBasis.setValue('height')
+      let result = await iconLayer.execute(getInputProps(iconLayer))
+      expect(result.layer.sizeBasis).toBe('height')
+
+      iconLayer.inputs.sizeBasis.setValue('width')
+      result = await iconLayer.execute(getInputProps(iconLayer))
+      expect(result.layer.sizeBasis).toBe('width')
+    })
+
+    it('should accept sizeUnits values: pixels, meters, and common', async () => {
+      const iconLayer = new IconLayerOp('/test-icon')
+
+      iconLayer.inputs.sizeUnits.setValue('pixels')
+      let result = await iconLayer.execute(getInputProps(iconLayer))
+      expect(result.layer.sizeUnits).toBe('pixels')
+
+      iconLayer.inputs.sizeUnits.setValue('meters')
+      result = await iconLayer.execute(getInputProps(iconLayer))
+      expect(result.layer.sizeUnits).toBe('meters')
+
+      iconLayer.inputs.sizeUnits.setValue('common')
+      result = await iconLayer.execute(getInputProps(iconLayer))
+      expect(result.layer.sizeUnits).toBe('common')
+    })
+
+    it('should have correct default values', async () => {
+      const iconLayer = new IconLayerOp('/test-icon')
+      const result = await iconLayer.execute(getInputProps(iconLayer))
+
+      expect(result.layer.sizeUnits).toBe('pixels')
+      expect(result.layer.sizeBasis).toBe('height')
+      expect(result.layer.sizeScale).toBe(1)
+      expect(result.layer.sizeMinPixels).toBe(0)
+      expect(result.layer.sizeMaxPixels).toBe(2048)
+    })
+  })
+
+  describe('PathLayerOp', () => {
+    it('should accept widthUnits values: pixels, meters, and common', async () => {
+      const pathLayer = new PathLayerOp('/test-path')
+
+      pathLayer.inputs.widthUnits.setValue('pixels')
+      let result = await pathLayer.execute(getInputProps(pathLayer))
+      expect(result.layer.widthUnits).toBe('pixels')
+
+      pathLayer.inputs.widthUnits.setValue('meters')
+      result = await pathLayer.execute(getInputProps(pathLayer))
+      expect(result.layer.widthUnits).toBe('meters')
+
+      pathLayer.inputs.widthUnits.setValue('common')
+      result = await pathLayer.execute(getInputProps(pathLayer))
+      expect(result.layer.widthUnits).toBe('common')
+    })
+
+    it('should have correct default values', async () => {
+      const pathLayer = new PathLayerOp('/test-path')
+      const result = await pathLayer.execute(getInputProps(pathLayer))
+
+      expect(result.layer.widthUnits).toBe('meters')
+      expect(result.layer.widthScale).toBe(20)
+      expect(result.layer.widthMinPixels).toBe(2)
+    })
+  })
+
+  describe('TripsLayerOp', () => {
+    it('should accept widthUnits values: pixels, meters, and common', async () => {
+      const tripsLayer = new TripsLayerOp('/test-trips')
+
+      tripsLayer.inputs.widthUnits.setValue('pixels')
+      let result = await tripsLayer.execute(getInputProps(tripsLayer))
+      expect(result.layer.widthUnits).toBe('pixels')
+
+      tripsLayer.inputs.widthUnits.setValue('meters')
+      result = await tripsLayer.execute(getInputProps(tripsLayer))
+      expect(result.layer.widthUnits).toBe('meters')
+
+      tripsLayer.inputs.widthUnits.setValue('common')
+      result = await tripsLayer.execute(getInputProps(tripsLayer))
+      expect(result.layer.widthUnits).toBe('common')
+    })
+
+    it('should have correct default values', async () => {
+      const tripsLayer = new TripsLayerOp('/test-trips')
+      const result = await tripsLayer.execute(getInputProps(tripsLayer))
+
+      expect(result.layer.widthUnits).toBe('meters')
+      expect(result.layer.widthScale).toBe(20)
+      expect(result.layer.widthMinPixels).toBe(2)
+    })
+  })
+
+  describe('ArcLayerOp', () => {
+    it('should accept widthUnits values: pixels, meters, and common', async () => {
+      const arcLayer = new ArcLayerOp('/test-arc')
+
+      arcLayer.inputs.widthUnits.setValue('pixels')
+      let result = await arcLayer.execute(getInputProps(arcLayer))
+      expect(result.layer.widthUnits).toBe('pixels')
+
+      arcLayer.inputs.widthUnits.setValue('meters')
+      result = await arcLayer.execute(getInputProps(arcLayer))
+      expect(result.layer.widthUnits).toBe('meters')
+
+      arcLayer.inputs.widthUnits.setValue('common')
+      result = await arcLayer.execute(getInputProps(arcLayer))
+      expect(result.layer.widthUnits).toBe('common')
+    })
+  })
+
+  describe('LineLayerOp', () => {
+    it('should accept widthUnits values: pixels, meters, and common', async () => {
+      const lineLayer = new LineLayerOp('/test-line')
+
+      lineLayer.inputs.widthUnits.setValue('pixels')
+      let result = await lineLayer.execute(getInputProps(lineLayer))
+      expect(result.layer.widthUnits).toBe('pixels')
+
+      lineLayer.inputs.widthUnits.setValue('meters')
+      result = await lineLayer.execute(getInputProps(lineLayer))
+      expect(result.layer.widthUnits).toBe('meters')
+
+      lineLayer.inputs.widthUnits.setValue('common')
+      result = await lineLayer.execute(getInputProps(lineLayer))
+      expect(result.layer.widthUnits).toBe('common')
+    })
+
+    it('should have correct default values', async () => {
+      const lineLayer = new LineLayerOp('/test-line')
+      const result = await lineLayer.execute(getInputProps(lineLayer))
+
+      expect(result.layer.widthUnits).toBe('pixels')
+      expect(result.layer.widthScale).toBe(1)
+      expect(result.layer.widthMinPixels).toBe(0)
+      expect(result.layer.widthMaxPixels).toBe(100)
+    })
+  })
+
+  describe('GreatCircleLayerOp', () => {
+    it('should accept widthUnits values: pixels, meters, and common', async () => {
+      const greatCircleLayer = new GreatCircleLayerOp('/test-great-circle')
+
+      greatCircleLayer.inputs.widthUnits.setValue('pixels')
+      let result = await greatCircleLayer.execute(getInputProps(greatCircleLayer))
+      expect(result.layer.widthUnits).toBe('pixels')
+
+      greatCircleLayer.inputs.widthUnits.setValue('meters')
+      result = await greatCircleLayer.execute(getInputProps(greatCircleLayer))
+      expect(result.layer.widthUnits).toBe('meters')
+
+      greatCircleLayer.inputs.widthUnits.setValue('common')
+      result = await greatCircleLayer.execute(getInputProps(greatCircleLayer))
+      expect(result.layer.widthUnits).toBe('common')
+    })
+
+    it('should have correct default values', async () => {
+      const greatCircleLayer = new GreatCircleLayerOp('/test-great-circle')
+      const result = await greatCircleLayer.execute(getInputProps(greatCircleLayer))
+
+      expect(result.layer.widthUnits).toBe('pixels')
+      expect(result.layer.widthScale).toBe(1)
+      expect(result.layer.widthMinPixels).toBe(0)
+      expect(result.layer.widthMaxPixels).toBe(100)
+    })
+  })
+})

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4896,7 +4896,7 @@ export class PathLayerOp extends Operator<PathLayerOp> {
       getColor: new ColorField('#006ac6', { accessor: true, transform: hexToColor }),
       getWidth: new NumberField(8, { min: 0, softMax: 100, accessor: true }),
       widthUnits: new StringLiteralField('meters', {
-        values: ['pixels', 'meters'],
+        values: ['pixels', 'meters', 'common'],
         showByDefault: false,
       }),
       widthScale: new NumberField(20, { min: 0, softMax: 100, showByDefault: false }),
@@ -5004,7 +5004,7 @@ export class TripsLayerOp extends Operator<TripsLayerOp> {
       fadeTrail: new BooleanField(false),
       trailLength: new NumberField(120, { min: 0 }),
       widthUnits: new StringLiteralField('meters', {
-        values: ['pixels', 'meters'],
+        values: ['pixels', 'meters', 'common'],
         showByDefault: false,
       }),
       widthMinPixels: new NumberField(2, { min: 0, softMax: 100, showByDefault: false }),
@@ -5179,7 +5179,7 @@ export class IconLayerOp extends Operator<IconLayerOp> {
       }), // Can be: uploaded file URL, external URL, or accessor function returning {url, width?, height?}
       getSize: new NumberField(1, { min: 0, softMax: 100, accessor: true }),
       sizeUnits: new StringLiteralField('pixels', {
-        values: ['pixels', 'meters'],
+        values: ['pixels', 'meters', 'common'],
         showByDefault: false,
       }),
       sizeScale: new NumberField(1, { min: 0, softMax: 10_000 }),
@@ -5191,8 +5191,9 @@ export class IconLayerOp extends Operator<IconLayerOp> {
       ),
       getColor: new ColorField('#fff', { accessor: true, transform: hexToColor }),
       getAngle: new NumberField(0, { accessor: true }),
-      sizeBasis: new StringLiteralField('pixels', {
-        values: ['pixels', 'meters', 'common'],
+      sizeBasis: new StringLiteralField('height', {
+        values: ['height', 'width'],
+        showByDefault: false,
         optional: true,
       }),
       parameters: new CompoundPropsField(
@@ -5731,7 +5732,7 @@ export class ArcLayerOp extends Operator<ArcLayerOp> {
       getSourceColor: new ColorField('#fff', { accessor: true, transform: hexToColor }),
       getTargetColor: new ColorField('#fff', { accessor: true, transform: hexToColor }),
       widthUnits: new StringLiteralField('meters', {
-        values: ['pixels', 'meters'],
+        values: ['pixels', 'meters', 'common'],
         showByDefault: false,
       }),
       getWidth: new NumberField(1, { min: 0, softMax: 100, accessor: true }),
@@ -7154,7 +7155,7 @@ export class LineLayerOp extends Operator<LineLayerOp> {
       visible: new BooleanField(true),
       opacity: new NumberField(1, { min: 0, max: 1, step: 0.01 }),
       widthUnits: new StringLiteralField('pixels', {
-        values: ['pixels', 'meters'],
+        values: ['pixels', 'meters', 'common'],
         showByDefault: false,
       }),
       widthScale: new NumberField(1, { min: 0, softMax: 100, showByDefault: false }),
@@ -7384,7 +7385,7 @@ export class GreatCircleLayerOp extends Operator<GreatCircleLayerOp> {
       opacity: new NumberField(1, { min: 0, max: 1, step: 0.01 }),
       numSegments: new NumberField(20, { min: 1, softMax: 100, showByDefault: false }),
       widthUnits: new StringLiteralField('pixels', {
-        values: ['pixels', 'meters'],
+        values: ['pixels', 'meters', 'common'],
         showByDefault: false,
       }),
       widthScale: new NumberField(1, { min: 0, softMax: 100, showByDefault: false }),


### PR DESCRIPTION
## Summary
- Fixed critical IconLayer sizeBasis bug (was using wrong enum values)  
- Added 'common' unit support to 6 Deck.gl layer operators for API parity

## Changes

### Critical Fix: IconLayer.sizeBasis
The `sizeBasis` field was incorrectly configured with `['pixels', 'meters', 'common']` values. This field controls **which dimension** drives icon scaling (height vs width), NOT measurement units. Changed to correct values: `['height', 'width']` with default `'height'`.

This bug caused sizeBasis values to be silently ignored by Deck.gl.

### Enhancement: Add 'common' Unit Support
Added `'common'` to unit enumerations for complete Deck.gl API parity:
- IconLayerOp.sizeUnits
- PathLayerOp.widthUnits
- TripsLayerOp.widthUnits
- ArcLayerOp.widthUnits
- LineLayerOp.widthUnits
- GreatCircleLayerOp.widthUnits

## Testing
- Added comprehensive test suite: `layer-sizing.test.ts` (12 tests)
- All tests verify parameter values, defaults, and unit support
- All existing tests pass (100 test files, 2120 tests)

## Related
Split from maplibre-flicker-fix branch to keep unit fixes separate from deep equality/performance improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)