### PR TITLE
feat: use in/out points to control rendering frame range

### DIFF
--- a/noodles-editor/src/noodles/layer-sizing.test.ts
+++ b/noodles-editor/src/noodles/layer-sizing.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ArcLayerOp,
+  GreatCircleLayerOp,
   IconLayerOp,
+  LineLayerOp,
   PathLayerOp,
   TripsLayerOp,
-  ArcLayerOp,
-  LineLayerOp,
-  GreatCircleLayerOp,
 } from './operators'
 
 // Helper to get all input values from an operator

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -483,7 +483,7 @@ export default function TimelineEditor() {
       canvas = deckRef.current.canvas!
     }
 
-    const { inPoint, outPoint } = getTimelineStore().getState().sequence
+    const { inPoint, outPoint, length } = getTimelineStore().getState().sequence
 
     await startSequenceCapture({
       canvas,
@@ -493,8 +493,8 @@ export default function TimelineEditor() {
       directoryHandle: rendersDir,
       captureDelay,
       waitForData,
-      startFrame: Math.floor(inPoint * framerate),
-      endFrame: Math.floor(outPoint * framerate),
+      startFrame: Math.floor((inPoint ?? 0) * framerate),
+      endFrame: Math.floor((outPoint ?? length) * framerate),
       onFrameStart: (frame, total) => debugRender('Exporting frame %d/%d', frame + 1, total),
       onFrameComplete: (frame, total) => debugRender('Completed frame %d/%d', frame, total),
     })

--- a/noodles-editor/src/timeline/__tests__/timeline-store.test.ts
+++ b/noodles-editor/src/timeline/__tests__/timeline-store.test.ts
@@ -47,10 +47,10 @@ describe('TimelineStore', () => {
   })
 
   describe('in/out points', () => {
-    it('has default in/out points', () => {
+    it('has default in/out points as undefined', () => {
       const { sequence } = useTimelineStore.getState()
-      expect(sequence.inPoint).toBe(0)
-      expect(sequence.outPoint).toBe(10) // matches default length
+      expect(sequence.inPoint).toBeUndefined()
+      expect(sequence.outPoint).toBeUndefined()
     })
 
     it('setInPoint updates in point', () => {
@@ -63,25 +63,25 @@ describe('TimelineStore', () => {
       expect(useTimelineStore.getState().sequence.outPoint).toBe(8)
     })
 
-    it('clearInOutPoints resets to sequence length', () => {
+    it('clearInOutPoints resets to undefined', () => {
       useTimelineStore.getState().setLength(15)
       useTimelineStore.getState().setInPoint(3)
       useTimelineStore.getState().setOutPoint(12)
       useTimelineStore.getState().clearInOutPoints()
 
       const { sequence } = useTimelineStore.getState()
-      expect(sequence.inPoint).toBe(0)
-      expect(sequence.outPoint).toBe(15) // matches current length
+      expect(sequence.inPoint).toBeUndefined()
+      expect(sequence.outPoint).toBeUndefined()
     })
 
-    it('setLength auto-updates outPoint when at default', () => {
-      // Initial state: outPoint === length (default)
-      expect(useTimelineStore.getState().sequence.outPoint).toBe(10)
+    it('setLength does not affect undefined outPoint', () => {
+      // Initial state: outPoint is undefined
+      expect(useTimelineStore.getState().sequence.outPoint).toBeUndefined()
 
       useTimelineStore.getState().setLength(20)
 
-      // outPoint should track the new length
-      expect(useTimelineStore.getState().sequence.outPoint).toBe(20)
+      // outPoint should remain undefined
+      expect(useTimelineStore.getState().sequence.outPoint).toBeUndefined()
     })
 
     it('setLength preserves user-set outPoint when extending', () => {
@@ -109,14 +109,14 @@ describe('TimelineStore', () => {
       useTimelineStore.getState().setLength(20)
       expect(useTimelineStore.getState().sequence.outPoint).toBe(8)
 
-      // Clear in/out points - resets to full length
+      // Clear in/out points - resets to undefined
       useTimelineStore.getState().clearInOutPoints()
-      expect(useTimelineStore.getState().sequence.inPoint).toBe(0)
-      expect(useTimelineStore.getState().sequence.outPoint).toBe(20)
+      expect(useTimelineStore.getState().sequence.inPoint).toBeUndefined()
+      expect(useTimelineStore.getState().sequence.outPoint).toBeUndefined()
 
-      // Extend again - outPoint should track length now
+      // Extend again - outPoint should remain undefined
       useTimelineStore.getState().setLength(30)
-      expect(useTimelineStore.getState().sequence.outPoint).toBe(30)
+      expect(useTimelineStore.getState().sequence.outPoint).toBeUndefined()
     })
   })
 

--- a/noodles-editor/src/timeline/__tests__/timeline-store.test.ts
+++ b/noodles-editor/src/timeline/__tests__/timeline-store.test.ts
@@ -46,6 +46,80 @@ describe('TimelineStore', () => {
     })
   })
 
+  describe('in/out points', () => {
+    it('has default in/out points', () => {
+      const { sequence } = useTimelineStore.getState()
+      expect(sequence.inPoint).toBe(0)
+      expect(sequence.outPoint).toBe(10) // matches default length
+    })
+
+    it('setInPoint updates in point', () => {
+      useTimelineStore.getState().setInPoint(2)
+      expect(useTimelineStore.getState().sequence.inPoint).toBe(2)
+    })
+
+    it('setOutPoint updates out point', () => {
+      useTimelineStore.getState().setOutPoint(8)
+      expect(useTimelineStore.getState().sequence.outPoint).toBe(8)
+    })
+
+    it('clearInOutPoints resets to sequence length', () => {
+      useTimelineStore.getState().setLength(15)
+      useTimelineStore.getState().setInPoint(3)
+      useTimelineStore.getState().setOutPoint(12)
+      useTimelineStore.getState().clearInOutPoints()
+
+      const { sequence } = useTimelineStore.getState()
+      expect(sequence.inPoint).toBe(0)
+      expect(sequence.outPoint).toBe(15) // matches current length
+    })
+
+    it('setLength auto-updates outPoint when at default', () => {
+      // Initial state: outPoint === length (default)
+      expect(useTimelineStore.getState().sequence.outPoint).toBe(10)
+
+      useTimelineStore.getState().setLength(20)
+
+      // outPoint should track the new length
+      expect(useTimelineStore.getState().sequence.outPoint).toBe(20)
+    })
+
+    it('setLength preserves user-set outPoint when extending', () => {
+      useTimelineStore.getState().setOutPoint(8)
+      useTimelineStore.getState().setLength(20)
+
+      // outPoint should stay at user-set value
+      expect(useTimelineStore.getState().sequence.outPoint).toBe(8)
+    })
+
+    it('setLength clamps outPoint when shrinking below it', () => {
+      useTimelineStore.getState().setOutPoint(8)
+      useTimelineStore.getState().setLength(5)
+
+      // outPoint should be clamped to new length
+      expect(useTimelineStore.getState().sequence.outPoint).toBe(5)
+    })
+
+    it('setLength handles the sequence: extend with user points, clear, extend again', () => {
+      // Set user in/out points
+      useTimelineStore.getState().setInPoint(2)
+      useTimelineStore.getState().setOutPoint(8)
+
+      // Extend sequence - user points should be preserved
+      useTimelineStore.getState().setLength(20)
+      expect(useTimelineStore.getState().sequence.outPoint).toBe(8)
+
+      // Clear in/out points - resets to full length
+      useTimelineStore.getState().clearInOutPoints()
+      expect(useTimelineStore.getState().sequence.inPoint).toBe(0)
+      expect(useTimelineStore.getState().sequence.outPoint).toBe(20)
+
+      // Extend again - outPoint should track length now
+      useTimelineStore.getState().setLength(30)
+      expect(useTimelineStore.getState().sequence.outPoint).toBe(30)
+    })
+  })
+
   describe('playback', () => {
     it('has default playback state', () => {
       const state = useTimelineStore.getState()

--- a/noodles-editor/src/timeline/components/PlayControls.tsx
+++ b/noodles-editor/src/timeline/components/PlayControls.tsx
@@ -19,7 +19,8 @@ export function PlayControls() {
   const goToEnd = useTimelineStore(state => state.goToEnd)
 
   // Only show loop in/out button when in/out points are active
-  const hasActiveInOut = inPoint > 0 || outPoint < sequenceLength
+  const hasActiveInOut =
+    (inPoint !== undefined && inPoint > 0) || (outPoint !== undefined && outPoint < sequenceLength)
 
   return (
     <div className={s.timelinePlayControls}>

--- a/noodles-editor/src/timeline/components/TimeRuler.tsx
+++ b/noodles-editor/src/timeline/components/TimeRuler.tsx
@@ -400,7 +400,7 @@ export function TimeRuler({
       ))}
 
       {/* In Point Marker */}
-      {inPoint > 0 && (
+      {inPoint !== undefined && inPoint > 0 && (
         <InOutMarker
           type="in"
           position={inPoint}
@@ -415,7 +415,7 @@ export function TimeRuler({
       )}
 
       {/* Out Point Marker */}
-      {outPoint < sequenceLength && (
+      {outPoint !== undefined && outPoint < sequenceLength && (
         <InOutMarker
           type="out"
           position={outPoint}

--- a/noodles-editor/src/timeline/components/TimeRuler.tsx
+++ b/noodles-editor/src/timeline/components/TimeRuler.tsx
@@ -485,6 +485,7 @@ export function TimeRuler({
                 fireTimelineMutation('Set in point')
                 setContextMenu(null)
               }}
+              title="Sets the start point for loop playback and rendering"
             >
               Mark In
             </button>
@@ -497,6 +498,7 @@ export function TimeRuler({
                 fireTimelineMutation('Set out point')
                 setContextMenu(null)
               }}
+              title="Sets the end point for loop playback and rendering"
             >
               Mark Out
             </button>
@@ -599,7 +601,7 @@ function InOutMarker({
       onPointerDown={handlePointerDown}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      title={`Drag to adjust ${type === 'in' ? 'in' : 'out'} point`}
+      title={`${type === 'in' ? 'In' : 'Out'} point - controls loop playback and render range`}
     >
       <div className={s.inOutMarkerLine} />
       <div className={s.inOutMarkerLabel}>{type === 'in' ? 'IN' : 'OUT'}</div>

--- a/noodles-editor/src/timeline/playback.ts
+++ b/noodles-editor/src/timeline/playback.ts
@@ -116,8 +116,8 @@ export function connectPlaybackToTimeline(): () => void {
     let newPosition = position + deltaSeconds
 
     // Determine playback boundaries
-    const startBoundary = loopInOut ? sequence.inPoint : 0
-    const endBoundary = loopInOut ? sequence.outPoint : sequence.length
+    const startBoundary = loopInOut ? (sequence.inPoint ?? 0) : 0
+    const endBoundary = loopInOut ? (sequence.outPoint ?? sequence.length) : sequence.length
 
     // Handle end of playback range
     if (newPosition >= endBoundary) {

--- a/noodles-editor/src/timeline/timeline-store.ts
+++ b/noodles-editor/src/timeline/timeline-store.ts
@@ -221,14 +221,22 @@ export const useTimelineStore = create<TimelineStore>()(
 
     // === Sequence Actions ===
     setLength: length => {
-      set(state => ({
-        sequence: {
-          ...state.sequence,
-          length: Math.max(0.1, length),
-          outPoint: Math.min(state.sequence.outPoint, length),
-        },
-        position: Math.min(state.position, length),
-      }))
+      set(state => {
+        const newLength = Math.max(0.1, length)
+        const wasOutPointAtEnd = state.sequence.outPoint === state.sequence.length
+
+        return {
+          sequence: {
+            ...state.sequence,
+            length: newLength,
+            // If outPoint was tracking length, update it; otherwise clamp
+            outPoint: wasOutPointAtEnd
+              ? newLength
+              : Math.min(state.sequence.outPoint, newLength),
+          },
+          position: Math.min(state.position, newLength),
+        }
+      })
     },
 
     setFps: fps => {
@@ -935,6 +943,10 @@ export const useTimelineStore = create<TimelineStore>()(
           ? seq.length
           : DEFAULT_SEQUENCE_STATE.length
 
+      const inPoint = typeof seq.inPoint === 'number' ? seq.inPoint : 0
+      const outPoint =
+        typeof seq.outPoint === 'number' ? Math.min(seq.outPoint, length) : length
+
       set({
         sequence: {
           length,
@@ -942,8 +954,8 @@ export const useTimelineStore = create<TimelineStore>()(
             typeof seq.subUnitsPerUnit === 'number' && seq.subUnitsPerUnit > 0
               ? Math.round(seq.subUnitsPerUnit)
               : DEFAULT_SEQUENCE_STATE.fps,
-          inPoint: typeof seq.inPoint === 'number' ? seq.inPoint : 0,
-          outPoint: typeof seq.outPoint === 'number' ? seq.outPoint : length,
+          inPoint,
+          outPoint,
         },
         tracks: newTracks,
         markers,

--- a/noodles-editor/src/timeline/timeline-store.ts
+++ b/noodles-editor/src/timeline/timeline-store.ts
@@ -944,8 +944,7 @@ export const useTimelineStore = create<TimelineStore>()(
           : DEFAULT_SEQUENCE_STATE.length
 
       const inPoint = typeof seq.inPoint === 'number' ? seq.inPoint : undefined
-      const outPoint =
-        typeof seq.outPoint === 'number' ? Math.min(seq.outPoint, length) : undefined
+      const outPoint = typeof seq.outPoint === 'number' ? Math.min(seq.outPoint, length) : undefined
 
       set({
         sequence: {

--- a/noodles-editor/src/timeline/timeline-store.ts
+++ b/noodles-editor/src/timeline/timeline-store.ts
@@ -223,16 +223,14 @@ export const useTimelineStore = create<TimelineStore>()(
     setLength: length => {
       set(state => {
         const newLength = Math.max(0.1, length)
-        const wasOutPointAtEnd = state.sequence.outPoint === state.sequence.length
+        const { outPoint } = state.sequence
 
         return {
           sequence: {
             ...state.sequence,
             length: newLength,
-            // If outPoint was tracking length, update it; otherwise clamp
-            outPoint: wasOutPointAtEnd
-              ? newLength
-              : Math.min(state.sequence.outPoint, newLength),
+            // If outPoint is set, clamp it; otherwise leave undefined
+            outPoint: outPoint !== undefined ? Math.min(outPoint, newLength) : undefined,
           },
           position: Math.min(state.position, newLength),
         }
@@ -249,7 +247,8 @@ export const useTimelineStore = create<TimelineStore>()(
     setInPoint: time => {
       set(state => {
         const { sequence } = state
-        const clamped = Math.max(0, Math.min(time, sequence.outPoint))
+        const max = sequence.outPoint ?? sequence.length
+        const clamped = Math.max(0, Math.min(time, max))
         return {
           sequence: { ...sequence, inPoint: clamped },
         }
@@ -259,7 +258,8 @@ export const useTimelineStore = create<TimelineStore>()(
     setOutPoint: time => {
       set(state => {
         const { sequence } = state
-        const clamped = Math.max(sequence.inPoint, Math.min(time, sequence.length))
+        const min = sequence.inPoint ?? 0
+        const clamped = Math.max(min, Math.min(time, sequence.length))
         return {
           sequence: { ...sequence, outPoint: clamped },
         }
@@ -268,7 +268,7 @@ export const useTimelineStore = create<TimelineStore>()(
 
     clearInOutPoints: () => {
       set(state => ({
-        sequence: { ...state.sequence, inPoint: 0, outPoint: state.sequence.length },
+        sequence: { ...state.sequence, inPoint: undefined, outPoint: undefined },
       }))
     },
 
@@ -943,9 +943,9 @@ export const useTimelineStore = create<TimelineStore>()(
           ? seq.length
           : DEFAULT_SEQUENCE_STATE.length
 
-      const inPoint = typeof seq.inPoint === 'number' ? seq.inPoint : 0
+      const inPoint = typeof seq.inPoint === 'number' ? seq.inPoint : undefined
       const outPoint =
-        typeof seq.outPoint === 'number' ? Math.min(seq.outPoint, length) : length
+        typeof seq.outPoint === 'number' ? Math.min(seq.outPoint, length) : undefined
 
       set({
         sequence: {

--- a/noodles-editor/src/timeline/types.ts
+++ b/noodles-editor/src/timeline/types.ts
@@ -86,15 +86,15 @@ export interface Track {
 export interface SequenceState {
   length: number // Duration in seconds
   fps: number // Frames per second (default: 30)
-  inPoint: number // Render start time in seconds (default: 0)
-  outPoint: number // Render end time in seconds (default: length)
+  inPoint?: number // Render start time in seconds (undefined = 0)
+  outPoint?: number // Render end time in seconds (undefined = length)
 }
 
 export const DEFAULT_SEQUENCE_STATE: SequenceState = {
   length: 10,
   fps: 30,
-  inPoint: 0,
-  outPoint: 10,
+  inPoint: undefined,
+  outPoint: undefined,
 }
 
 // ============================================================================


### PR DESCRIPTION
#### Background

PR #445 added timeline in/out points with draggable markers for playback looping. This PR extends that functionality so the in/out points also control the frame range when rendering/exporting videos.

#### Change List
- Use `undefined` for unset in/out points instead of explicit defaults (no bookkeeping needed)
- Rendering now respects in/out point boundaries: `startFrame = (inPoint ?? 0) * framerate`, `endFrame = (outPoint ?? length) * framerate`
- User-set in/out points are preserved when extending sequences; undefined points stay undefined
- Added tooltips clarifying dual purpose: "controls loop playback and render range"
- Added 8 comprehensive tests for in/out point behavior covering all edge cases