### PR TITLE
fix: restrict analytics consent banner to production domain only

### DIFF
--- a/noodles-editor/src/components/analytics-consent-banner.tsx
+++ b/noodles-editor/src/components/analytics-consent-banner.tsx
@@ -6,9 +6,13 @@ export function AnalyticsConsentBanner() {
   const [showBanner, setShowBanner] = useState(false)
 
   useEffect(() => {
+    // Only show banner on production domain
+    const isProduction = window.location.hostname === 'noodles.gl'
+
     // Only show banner if user hasn't made a choice yet
     const hasSeenPrompt = analytics.hasSeenConsentPrompt()
-    setShowBanner(!hasSeenPrompt)
+
+    setShowBanner(isProduction && !hasSeenPrompt)
   }, [])
 
   const handleAccept = () => {


### PR DESCRIPTION
#### Background
The analytics consent banner ("Help improve Noodles") was appearing on all domains including localhost during development and preview/staging deployments, which was unnecessary and disruptive for developers.

#### Change List
- Added domain check in `AnalyticsConsentBanner` to only show the banner when `window.location.hostname === 'noodles.gl'`
- Banner now only appears on the production domain for first-time visitors
- Verified in local development that banner no longer shows on localhost
- All tests pass and linting is clean