### PR TITLE
fix: apply in/out points to video rendering and fix related bugs

### DIFF
--- a/noodles-editor/src/render/renderer.ts
+++ b/noodles-editor/src/render/renderer.ts
@@ -113,7 +113,7 @@ export const useRenderer = ({
           frameRate: fps,
         })
 
-        let currentFrameIndex = startFrame
+        let currentFrameIndex = 0
         const videoEncoder = new VideoEncoder({
           output: (chunk, meta) => {
             // Use the simulated time as the timestamp, not the VideoFrame's real-time timestamp

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -99,6 +99,8 @@ export default function TimelineEditor() {
   const activeStorageType = useActiveStorageType()
 
   const sequenceLength = useSequenceLength()
+  const inPoint = useTimelineStore(state => state.sequence.inPoint)
+  const outPoint = useTimelineStore(state => state.sequence.outPoint)
 
   const {
     framerate,
@@ -401,17 +403,15 @@ export default function TimelineEditor() {
       return
     }
 
-    const { inPoint, outPoint, length } = getTimelineStore().getState().sequence
-
     await startCapture({
       canvas,
       codec,
       // This always scales the video to the specified value, regardless of `canvas` size
       ...resolution,
       startFrame: Math.floor((inPoint ?? 0) * framerate),
-      endFrame: Math.floor((outPoint ?? length) * framerate),
+      endFrame: Math.floor((outPoint ?? sequenceLength) * framerate),
     })
-  }, [startCapture, codec, resolution, basemapEnabled, framerate])
+  }, [startCapture, codec, resolution, basemapEnabled, framerate, inPoint, outPoint, sequenceLength])
 
   const takeScreenshot = useCallback(async () => {
     if (!deckRef.current) {
@@ -487,8 +487,6 @@ export default function TimelineEditor() {
       canvas = deckRef.current.canvas!
     }
 
-    const { inPoint, outPoint, length } = getTimelineStore().getState().sequence
-
     await startSequenceCapture({
       canvas,
       // Basemap scenes use mapProps.onIdle for frame readiness; pure-deck scenes need
@@ -498,13 +496,15 @@ export default function TimelineEditor() {
       captureDelay,
       waitForData,
       startFrame: Math.floor((inPoint ?? 0) * framerate),
-      endFrame: Math.floor((outPoint ?? length) * framerate),
+      endFrame: Math.floor((outPoint ?? sequenceLength) * framerate),
       onFrameStart: (frame, total) => debugRender('Exporting frame %d/%d', frame + 1, total),
       onFrameComplete: (frame, total) => debugRender('Completed frame %d/%d', frame, total),
     })
   }, [
     startSequenceCapture,
     sequenceLength,
+    inPoint,
+    outPoint,
     framerate,
     captureDelay,
     waitForData,

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -401,13 +401,17 @@ export default function TimelineEditor() {
       return
     }
 
+    const { inPoint, outPoint, length } = getTimelineStore().getState().sequence
+
     await startCapture({
       canvas,
       codec,
       // This always scales the video to the specified value, regardless of `canvas` size
       ...resolution,
+      startFrame: Math.floor((inPoint ?? 0) * framerate),
+      endFrame: Math.floor((outPoint ?? length) * framerate),
     })
-  }, [startCapture, codec, resolution, basemapEnabled])
+  }, [startCapture, codec, resolution, basemapEnabled, framerate])
 
   const takeScreenshot = useCallback(async () => {
     if (!deckRef.current) {

--- a/noodles-editor/src/timeline/__tests__/timeline-store.test.ts
+++ b/noodles-editor/src/timeline/__tests__/timeline-store.test.ts
@@ -118,6 +118,30 @@ describe('TimelineStore', () => {
       useTimelineStore.getState().setLength(30)
       expect(useTimelineStore.getState().sequence.outPoint).toBeUndefined()
     })
+
+    it('calculates correct frame range from in/out points for rendering', () => {
+      useTimelineStore.getState().setLength(10)
+      useTimelineStore.getState().setInPoint(2)
+      useTimelineStore.getState().setOutPoint(5)
+
+      const { inPoint, outPoint, length, fps } = useTimelineStore.getState().sequence
+      const startFrame = Math.floor((inPoint ?? 0) * fps)
+      const endFrame = Math.floor((outPoint ?? length) * fps)
+
+      expect(startFrame).toBe(60) // 2 seconds * 30 fps
+      expect(endFrame).toBe(150) // 5 seconds * 30 fps
+    })
+
+    it('calculates full sequence frame range when in/out points are undefined', () => {
+      useTimelineStore.getState().setLength(10)
+
+      const { inPoint, outPoint, length, fps } = useTimelineStore.getState().sequence
+      const startFrame = Math.floor((inPoint ?? 0) * fps)
+      const endFrame = Math.floor((outPoint ?? length) * fps)
+
+      expect(startFrame).toBe(0) // 0 seconds * 30 fps
+      expect(endFrame).toBe(300) // 10 seconds * 30 fps
+    })
   })
 
   describe('playback', () => {

--- a/noodles-editor/src/timeline/components/KeyframeTrack.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeTrack.tsx
@@ -411,7 +411,8 @@ function KeyframeBar({
   // Get in/out points for dimming
   const inPoint = useTimelineStore(state => state.sequence.inPoint)
   const outPoint = useTimelineStore(state => state.sequence.outPoint)
-  const isOutsideActiveRange = k1.position > outPoint || k2.position < inPoint
+  const isOutsideActiveRange =
+    k1.position > (outPoint ?? sequenceLength) || k2.position < (inPoint ?? 0)
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
@@ -529,7 +530,8 @@ function KeyframeDiamond({
   // Get in/out points for dimming
   const inPoint = useTimelineStore(state => state.sequence.inPoint)
   const outPoint = useTimelineStore(state => state.sequence.outPoint)
-  const isOutsideActiveRange = keyframe.position < inPoint || keyframe.position > outPoint
+  const isOutsideActiveRange =
+    keyframe.position < (inPoint ?? 0) || keyframe.position > (outPoint ?? sequenceLength)
 
   // Nudge the menu back into the viewport if it overflows at right/bottom edges
   useLayoutEffect(() => {


### PR DESCRIPTION
#### Background
PRs #445 and #454 added timeline in/out points for selective rendering, but video export was broken. Videos always rendered the full sequence and produced corrupted files that couldn't be played.

#### Change List
- Fix video rendering to read and pass in/out points to startCapture() (was only fixed for image sequence export in PR #454)
- Fix frame timestamp corruption by initializing currentFrameIndex to 0 instead of startFrame (MediaBunny MP4 container requires timestamps starting at 0)
- Fix stale closure bug where render callbacks didn't recreate when in/out points changed (move to reactive hooks and add to dependency arrays)
- Fix keyframe dimming to handle undefined in/out points with nullish coalescing (previously all keyframes were incorrectly dimmed when in/out points were at default values)
- Add tests verifying frame range calculation from in/out points