### PR TITLE
feat: add timeline edge bars from sequence boundaries to keyframes

### DIFF
--- a/noodles-editor/src/timeline/components/KeyframeTrack.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeTrack.tsx
@@ -238,6 +238,8 @@ export function KeyframeTrack({
   const selectedKeyframeIds = useTimelineStore(state => state.selectedKeyframeIds)
   const selectKeyframe = useTimelineStore(state => state.selectKeyframe)
   const addKeyframe = useTimelineStore(state => state.addKeyframe)
+  const inPoint = useTimelineStore(state => state.sequence.inPoint)
+  const outPoint = useTimelineStore(state => state.sequence.outPoint)
 
   const [openPopup, setOpenPopup] = useState<{
     k1: Keyframe
@@ -316,6 +318,36 @@ export function KeyframeTrack({
     })
   }
 
+  // Generate edge bars from sequence boundaries to first/last keyframes
+  const edgeBarSegments = []
+
+  if (track.keyframes.length > 0) {
+    const firstKf = track.keyframes[0]
+    const lastKf = track.keyframes[track.keyframes.length - 1]
+
+    // Bar from start (0) to first keyframe (if first keyframe is not at 0)
+    if (firstKf.position > 0) {
+      const startEdgeOutsideRange = firstKf.position < (inPoint ?? 0)
+      edgeBarSegments.push({
+        id: `edge-start-${firstKf.id}`,
+        left: 0,
+        width: firstKf.position * pixelsPerSecond,
+        isOutsideRange: startEdgeOutsideRange,
+      })
+    }
+
+    // Bar from last keyframe to sequence end (if last keyframe is not at sequenceLength)
+    if (lastKf.position < sequenceLength) {
+      const endEdgeOutsideRange = lastKf.position > (outPoint ?? sequenceLength)
+      edgeBarSegments.push({
+        id: `edge-end-${lastKf.id}`,
+        left: lastKf.position * pixelsPerSecond,
+        width: (sequenceLength - lastKf.position) * pixelsPerSecond,
+        isOutsideRange: endEdgeOutsideRange,
+      })
+    }
+  }
+
   // Render keyframe row
   return (
     <>
@@ -338,6 +370,14 @@ export function KeyframeTrack({
             fps={fps}
             selectedKeyframeIds={selectedKeyframeIds}
             onOpenPopup={handleBarClick}
+          />
+        ))}
+        {/* Edge bars from sequence boundaries to first/last keyframes */}
+        {edgeBarSegments.map(bar => (
+          <div
+            key={bar.id}
+            className={s.timelineKeyframeEdgeBar}
+            style={{ left: bar.left, width: bar.width, opacity: bar.isOutsideRange ? 0.3 : 1 }}
           />
         ))}
         {/* Keyframe diamonds */}

--- a/noodles-editor/src/timeline/components/TimelinePanel.module.css
+++ b/noodles-editor/src/timeline/components/TimelinePanel.module.css
@@ -297,6 +297,16 @@
   background: linear-gradient(90deg, rgb(102 235 237 / 0.55), rgb(102 235 237 / 0.7));
 }
 
+.timelineKeyframeEdgeBar {
+  position: absolute;
+  height: 4px;
+  background: linear-gradient(90deg, rgb(102 235 237 / 0.25), rgb(102 235 237 / 0.35));
+  top: 50%;
+  transform: translateY(-50%);
+  border-radius: 999px;
+  pointer-events: none;
+}
+
 .timelineKeyframe {
   position: absolute;
   width: 10px;


### PR DESCRIPTION
#### Background

Currently, timeline keyframe tracks only display bars between consecutive keyframes. When a keyframe isn't aligned to time = 0 or the sequence end, the value is implicitly held at the keyframe value, but there's no visual indicator for this implicit behavior.

#### Change List
- Add edge bars from sequence start (0) to first keyframe (when first keyframe > 0)
- Add edge bars from last keyframe to sequence end (when last keyframe < sequence length)
- Edge bars are visually distinct: thinner (4px vs 6px) and dimmer (0.25-0.35 opacity vs 0.4-0.55)
- Edge bars are non-interactive (pointer-events: none) as they represent implicit holds, not editable interpolations
- Edge bars respect in/out point dimming (opacity 0.3 when outside active range)