### PR TITLE
feat: add keyframe shape variations based on interpolation type

### DIFF
--- a/noodles-editor/src/timeline/components/KeyframeTrack.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeTrack.tsx
@@ -542,20 +542,20 @@ function KeyframeShape({
         return { filled: 'M 2.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z' }
 
       case 'hold-ease-out':
-        // Square with right curved notch (ease out) - wider left side
-        return { filled: 'M 2.5 2 L 7 2 C 8.5 3.5 8.5 6.5 7 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z' }
+        // Square with right curved notch (ease out) - prominent square left side
+        return { filled: 'M 2 2 L 6 2 L 6 3 C 7.5 4 7.5 6 6 7 L 6 8 L 2 8 Z' }
 
       case 'hold-ease-in':
-        // Square with left curved notch (ease in) - wider right side
-        return { filled: 'M 3 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3 8 C 1.5 6.5 1.5 3.5 3 2 Z' }
+        // Square with left curved notch (ease in) - prominent square right side
+        return { filled: 'M 4 2 L 8 2 L 8 8 L 4 8 L 4 7 C 2.5 6 2.5 4 4 3 Z' }
 
       case 'hold-linear-out':
-        // Square with right sharp triangle - wider left side
-        return { filled: 'M 2.5 2 L 6.5 2 L 8.5 5 L 6.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z' }
+        // Square with right sharp triangle - prominent square left side
+        return { filled: 'M 2 2 L 6 2 L 8 5 L 6 8 L 2 8 Z' }
 
       case 'hold-linear-in':
-        // Square with left sharp triangle - wider right side
-        return { filled: 'M 3.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3.5 8 L 1.5 5 Z' }
+        // Square with left sharp triangle - prominent square right side
+        return { filled: 'M 4 2 L 8 2 L 8 8 L 4 8 L 2 5 Z' }
 
       default:
         return { filled: 'M 5 1 L 9 5 L 5 9 L 1 5 Z' }

--- a/noodles-editor/src/timeline/components/KeyframeTrack.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeTrack.tsx
@@ -10,10 +10,7 @@ import {
   useTimelineStore,
 } from '../timeline-store'
 import type { Keyframe, Track } from '../types'
-import {
-  type KeyframeShapeType,
-  getKeyframeShapeType,
-} from '../utils/keyframe-shape-utils'
+import { getKeyframeShapeType, type KeyframeShapeType } from '../utils/keyframe-shape-utils'
 import { CurvePopup } from './CurvePopup'
 import { KeyframeValuePopup } from './KeyframeValuePopup'
 import s from './TimelinePanel.module.css'
@@ -504,11 +501,9 @@ function KeyframeBar({
 function KeyframeShape({
   shapeType,
   isSelected,
-  isHovered,
 }: {
   shapeType: KeyframeShapeType
   isSelected: boolean
-  isHovered: boolean
 }) {
   const size = 10
   const strokeWidth = 1.5
@@ -538,20 +533,20 @@ function KeyframeShape({
         return 'M 2.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
 
       case 'hold-ease-out':
-        // Square with right curved notch (ease out)
-        return 'M 2.5 2 L 6.5 2 C 8 3.5 8 6.5 6.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
+        // Square with right curved notch (ease out) - wider left side
+        return 'M 2.5 2 L 7 2 C 8.5 3.5 8.5 6.5 7 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
 
       case 'hold-ease-in':
-        // Square with left curved notch (ease in)
-        return 'M 3.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3.5 8 C 2 6.5 2 3.5 3.5 2 Z'
+        // Square with left curved notch (ease in) - wider right side
+        return 'M 3 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3 8 C 1.5 6.5 1.5 3.5 3 2 Z'
 
       case 'hold-linear-out':
-        // Square with right sharp triangle
-        return 'M 2.5 2 L 6 2 L 8 5 L 6 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
+        // Square with right sharp triangle - wider left side
+        return 'M 2.5 2 L 6.5 2 L 8.5 5 L 6.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
 
       case 'hold-linear-in':
-        // Square with left sharp triangle
-        return 'M 4 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 4 8 L 2 5 Z'
+        // Square with left sharp triangle - wider right side
+        return 'M 3.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3.5 8 L 1.5 5 Z'
 
       default:
         return 'M 5 1 L 9 5 L 5 9 L 1 5 Z'
@@ -567,6 +562,8 @@ function KeyframeShape({
         display: 'block',
         overflow: 'visible',
       }}
+      role="img"
+      aria-label={`${shapeType} keyframe`}
     >
       <path
         d={path}
@@ -785,11 +782,26 @@ function KeyframeDiamond({
 
   const showDropTarget = isConnectionDropTarget && isHovered
 
+  // Build className - avoid undefined by only including shape class if it exists in CSS
+  const shapeClassName = shapeType.replace(/-/g, '_')
+  const className = [s.timelineKeyframe, isSelected && s.selected, showDropTarget && s.dropTarget]
+    .filter(Boolean)
+    .join(' ')
+
+  // Format keyframe value for tooltip
+  const valueStr =
+    typeof keyframe.value === 'number'
+      ? keyframe.value.toFixed(2)
+      : typeof keyframe.value === 'object'
+        ? JSON.stringify(keyframe.value)
+        : String(keyframe.value)
+
   return (
     <>
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Keyframe diamond is a drag handle */}
       <div
-        className={`${s.timelineKeyframe} ${s[`shape_${shapeType.replace(/-/g, '_')}`]} ${isSelected ? s.selected : ''} ${showDropTarget ? s.dropTarget : ''}`}
+        className={className}
+        data-shape={shapeClassName}
         style={{ left: x, opacity: isOutsideActiveRange ? 0.3 : 1 }}
         onPointerDown={handlePointerDown}
         onClick={handleClick}
@@ -797,9 +809,9 @@ function KeyframeDiamond({
         onPointerEnter={() => setIsHovered(true)}
         onPointerLeave={() => setIsHovered(false)}
         onPointerUp={handlePointerUp}
-        title={`${keyframe.position.toFixed(2)}s - ${shapeType}`}
+        title={`${keyframe.position.toFixed(2)}s - ${shapeType}\nValue: ${valueStr}`}
       >
-        <KeyframeShape shapeType={shapeType} isSelected={isSelected} isHovered={isHovered} />
+        <KeyframeShape shapeType={shapeType} isSelected={isSelected} />
       </div>
       {contextMenu &&
         createPortal(

--- a/noodles-editor/src/timeline/components/KeyframeTrack.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeTrack.tsx
@@ -1,7 +1,7 @@
 // Keyframe track component - renders a single track with its keyframes
 
 import { useReactFlow } from '@xyflow/react'
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   captureTimelineState,
@@ -10,6 +10,10 @@ import {
   useTimelineStore,
 } from '../timeline-store'
 import type { Keyframe, Track } from '../types'
+import {
+  type KeyframeShapeType,
+  getKeyframeShapeType,
+} from '../utils/keyframe-shape-utils'
 import { CurvePopup } from './CurvePopup'
 import { KeyframeValuePopup } from './KeyframeValuePopup'
 import s from './TimelinePanel.module.css'
@@ -341,10 +345,12 @@ export function KeyframeTrack({
           />
         ))}
         {/* Keyframe diamonds */}
-        {track.keyframes.map(keyframe => (
+        {track.keyframes.map((keyframe, index) => (
           <KeyframeDiamond
             key={keyframe.id}
             keyframe={keyframe}
+            prevKeyframe={track.keyframes[index - 1]}
+            nextKeyframe={track.keyframes[index + 1]}
             pixelsPerSecond={pixelsPerSecond}
             sequenceLength={sequenceLength}
             fps={fps}
@@ -494,9 +500,91 @@ function KeyframeBar({
   )
 }
 
+// SVG shape component for keyframe based on interpolation type
+function KeyframeShape({
+  shapeType,
+  isSelected,
+  isHovered,
+}: {
+  shapeType: KeyframeShapeType
+  isSelected: boolean
+  isHovered: boolean
+}) {
+  const size = 10
+  const strokeWidth = 1.5
+  const strokeColor = isSelected ? '#8aebef' : 'var(--tl-accent)'
+  const fillColor = isSelected ? 'var(--tl-accent)' : '#1f2632'
+
+  const path = useMemo(() => {
+    switch (shapeType) {
+      case 'linear':
+        // Diamond: rotated square
+        return 'M 5 1 L 9 5 L 5 9 L 1 5 Z'
+
+      case 'ease-in':
+        // Right chevron (flat left, curved right) - ease into next keyframe
+        return 'M 2 2 L 2 8 L 6 5 Z M 6 5 C 6 5 8 5 8 2.5 M 6 5 C 6 5 8 5 8 7.5'
+
+      case 'ease-out':
+        // Left chevron (curved left, flat right) - ease out from prev keyframe
+        return 'M 8 2 L 8 8 L 4 5 Z M 4 5 C 4 5 2 5 2 2.5 M 4 5 C 4 5 2 5 2 7.5'
+
+      case 'easy-ease':
+        // Hourglass/bowtie shape (curved both sides)
+        return 'M 2 2 C 4 3.5 4 3.5 5 5 C 6 6.5 6 6.5 8 8 M 2 8 C 4 6.5 4 6.5 5 5 C 6 3.5 6 3.5 8 2'
+
+      case 'hold':
+        // Square with rounded corners
+        return 'M 2.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
+
+      case 'hold-ease-out':
+        // Square with right curved notch (ease out)
+        return 'M 2.5 2 L 6.5 2 C 8 3.5 8 6.5 6.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
+
+      case 'hold-ease-in':
+        // Square with left curved notch (ease in)
+        return 'M 3.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3.5 8 C 2 6.5 2 3.5 3.5 2 Z'
+
+      case 'hold-linear-out':
+        // Square with right sharp triangle
+        return 'M 2.5 2 L 6 2 L 8 5 L 6 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
+
+      case 'hold-linear-in':
+        // Square with left sharp triangle
+        return 'M 4 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 4 8 L 2 5 Z'
+
+      default:
+        return 'M 5 1 L 9 5 L 5 9 L 1 5 Z'
+    }
+  }, [shapeType])
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 10 10"
+      style={{
+        display: 'block',
+        overflow: 'visible',
+      }}
+    >
+      <path
+        d={path}
+        fill={fillColor}
+        stroke={strokeColor}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
 // Keyframe diamond with drag support
 interface KeyframeDiamondProps {
   keyframe: Keyframe
+  prevKeyframe?: Keyframe
+  nextKeyframe?: Keyframe
   pixelsPerSecond: number
   sequenceLength: number
   fps: number
@@ -510,6 +598,8 @@ interface KeyframeDiamondProps {
 
 function KeyframeDiamond({
   keyframe,
+  prevKeyframe,
+  nextKeyframe,
   pixelsPerSecond,
   sequenceLength,
   fps,
@@ -526,6 +616,11 @@ function KeyframeDiamond({
   const [isHovered, setIsHovered] = useState(false)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+
+  const shapeType = useMemo(
+    () => getKeyframeShapeType(keyframe, prevKeyframe, nextKeyframe),
+    [keyframe, prevKeyframe, nextKeyframe]
+  )
 
   // Get in/out points for dimming
   const inPoint = useTimelineStore(state => state.sequence.inPoint)
@@ -694,7 +789,7 @@ function KeyframeDiamond({
     <>
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Keyframe diamond is a drag handle */}
       <div
-        className={`${s.timelineKeyframe} ${isSelected ? s.selected : ''} ${showDropTarget ? s.dropTarget : ''}`}
+        className={`${s.timelineKeyframe} ${s[`shape_${shapeType.replace(/-/g, '_')}`]} ${isSelected ? s.selected : ''} ${showDropTarget ? s.dropTarget : ''}`}
         style={{ left: x, opacity: isOutsideActiveRange ? 0.3 : 1 }}
         onPointerDown={handlePointerDown}
         onClick={handleClick}
@@ -702,8 +797,10 @@ function KeyframeDiamond({
         onPointerEnter={() => setIsHovered(true)}
         onPointerLeave={() => setIsHovered(false)}
         onPointerUp={handlePointerUp}
-        title={`${keyframe.position.toFixed(2)}s`}
-      />
+        title={`${keyframe.position.toFixed(2)}s - ${shapeType}`}
+      >
+        <KeyframeShape shapeType={shapeType} isSelected={isSelected} isHovered={isHovered} />
+      </div>
       {contextMenu &&
         createPortal(
           <div

--- a/noodles-editor/src/timeline/components/KeyframeTrack.tsx
+++ b/noodles-editor/src/timeline/components/KeyframeTrack.tsx
@@ -510,46 +510,55 @@ function KeyframeShape({
   const strokeColor = isSelected ? '#8aebef' : 'var(--tl-accent)'
   const fillColor = isSelected ? 'var(--tl-accent)' : '#1f2632'
 
-  const path = useMemo(() => {
+  const paths = useMemo(() => {
     switch (shapeType) {
       case 'linear':
         // Diamond: rotated square
-        return 'M 5 1 L 9 5 L 5 9 L 1 5 Z'
+        return { filled: 'M 5 1 L 9 5 L 5 9 L 1 5 Z' }
 
       case 'ease-in':
         // Right chevron (flat left, curved right) - ease into next keyframe
-        return 'M 2 2 L 2 8 L 6 5 Z M 6 5 C 6 5 8 5 8 2.5 M 6 5 C 6 5 8 5 8 7.5'
+        return {
+          filled: 'M 2 2 L 2 8 L 6 5 Z',
+          stroked: 'M 6 5 C 6 5 8 5 8 2.5 M 6 5 C 6 5 8 5 8 7.5',
+        }
 
       case 'ease-out':
         // Left chevron (curved left, flat right) - ease out from prev keyframe
-        return 'M 8 2 L 8 8 L 4 5 Z M 4 5 C 4 5 2 5 2 2.5 M 4 5 C 4 5 2 5 2 7.5'
+        return {
+          filled: 'M 8 2 L 8 8 L 4 5 Z',
+          stroked: 'M 4 5 C 4 5 2 5 2 2.5 M 4 5 C 4 5 2 5 2 7.5',
+        }
 
       case 'easy-ease':
-        // Hourglass/bowtie shape (curved both sides)
-        return 'M 2 2 C 4 3.5 4 3.5 5 5 C 6 6.5 6 6.5 8 8 M 2 8 C 4 6.5 4 6.5 5 5 C 6 3.5 6 3.5 8 2'
+        // Hourglass/bowtie shape (curved both sides) - all stroked, no fill
+        return {
+          stroked:
+            'M 2 2 C 4 3.5 4 3.5 5 5 C 6 6.5 6 6.5 8 8 M 2 8 C 4 6.5 4 6.5 5 5 C 6 3.5 6 3.5 8 2',
+        }
 
       case 'hold':
         // Square with rounded corners
-        return 'M 2.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
+        return { filled: 'M 2.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z' }
 
       case 'hold-ease-out':
         // Square with right curved notch (ease out) - wider left side
-        return 'M 2.5 2 L 7 2 C 8.5 3.5 8.5 6.5 7 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
+        return { filled: 'M 2.5 2 L 7 2 C 8.5 3.5 8.5 6.5 7 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z' }
 
       case 'hold-ease-in':
         // Square with left curved notch (ease in) - wider right side
-        return 'M 3 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3 8 C 1.5 6.5 1.5 3.5 3 2 Z'
+        return { filled: 'M 3 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3 8 C 1.5 6.5 1.5 3.5 3 2 Z' }
 
       case 'hold-linear-out':
         // Square with right sharp triangle - wider left side
-        return 'M 2.5 2 L 6.5 2 L 8.5 5 L 6.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z'
+        return { filled: 'M 2.5 2 L 6.5 2 L 8.5 5 L 6.5 8 L 2.5 8 Q 2 8 2 7.5 L 2 2.5 Q 2 2 2.5 2 Z' }
 
       case 'hold-linear-in':
         // Square with left sharp triangle - wider right side
-        return 'M 3.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3.5 8 L 1.5 5 Z'
+        return { filled: 'M 3.5 2 L 7.5 2 Q 8 2 8 2.5 L 8 7.5 Q 8 8 7.5 8 L 3.5 8 L 1.5 5 Z' }
 
       default:
-        return 'M 5 1 L 9 5 L 5 9 L 1 5 Z'
+        return { filled: 'M 5 1 L 9 5 L 5 9 L 1 5 Z' }
     }
   }, [shapeType])
 
@@ -565,14 +574,26 @@ function KeyframeShape({
       role="img"
       aria-label={`${shapeType} keyframe`}
     >
-      <path
-        d={path}
-        fill={fillColor}
-        stroke={strokeColor}
-        strokeWidth={strokeWidth}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      {paths.filled && (
+        <path
+          d={paths.filled}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+      {paths.stroked && (
+        <path
+          d={paths.stroked}
+          fill="none"
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
     </svg>
   )
 }
@@ -782,8 +803,6 @@ function KeyframeDiamond({
 
   const showDropTarget = isConnectionDropTarget && isHovered
 
-  // Build className - avoid undefined by only including shape class if it exists in CSS
-  const shapeClassName = shapeType.replace(/-/g, '_')
   const className = [s.timelineKeyframe, isSelected && s.selected, showDropTarget && s.dropTarget]
     .filter(Boolean)
     .join(' ')
@@ -801,7 +820,6 @@ function KeyframeDiamond({
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Keyframe diamond is a drag handle */}
       <div
         className={className}
-        data-shape={shapeClassName}
         style={{ left: x, opacity: isOutsideActiveRange ? 0.3 : 1 }}
         onPointerDown={handlePointerDown}
         onClick={handleClick}

--- a/noodles-editor/src/timeline/components/TimelinePanel.module.css
+++ b/noodles-editor/src/timeline/components/TimelinePanel.module.css
@@ -301,31 +301,43 @@
   position: absolute;
   width: 10px;
   height: 10px;
-  background: #1f2632;
-  transform: translate(-50%, -50%) rotate(45deg);
+  background: transparent;
+  transform: translate(-50%, -50%);
   top: 50%;
   cursor: pointer;
-  border: 1.5px solid var(--tl-accent);
-  box-shadow: 0 0 0 1px rgb(15 20 29 / 0.85);
+  border: none;
   z-index: 1;
-  transition:
-    transform 0.08s ease,
-    background 0.12s ease,
-    border-color 0.12s ease;
+  transition: transform 0.08s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .timelineKeyframe:hover {
-  background: rgb(72 198 207 / 0.25);
-  border-color: var(--tl-accent-strong);
-  transform: translate(-50%, -50%) rotate(45deg) scale(1.08);
+  transform: translate(-50%, -50%) scale(1.08);
 }
 
 .timelineKeyframe.selected {
-  background: var(--tl-accent);
-  border-color: #8aebef;
-  box-shadow:
-    0 0 0 1px rgb(9 14 20 / 0.9),
-    0 0 10px rgb(72 198 207 / 0.35);
+  /* Selection styling now handled by SVG fill/stroke colors */
+}
+
+.timelineKeyframe svg {
+  pointer-events: none;
+  filter: drop-shadow(0 0 1px rgb(15 20 29 / 0.85));
+}
+
+.timelineKeyframe.selected svg {
+  filter:
+    drop-shadow(0 0 1px rgb(9 14 20 / 0.9))
+    drop-shadow(0 0 10px rgb(72 198 207 / 0.35));
+}
+
+.timelineKeyframe.dropTarget {
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.timelineKeyframe.dropTarget svg {
+  filter: drop-shadow(0 0 8px rgb(72 198 207 / 0.6));
 }
 
 .timelinePlayhead {

--- a/noodles-editor/src/timeline/utils/__tests__/keyframe-shape-utils.test.ts
+++ b/noodles-editor/src/timeline/utils/__tests__/keyframe-shape-utils.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import type { BezierHandles, Keyframe } from '../../types'
+import { getKeyframeShapeType } from '../keyframe-shape-utils'
+
+// Test helpers
+function createKeyframe(
+  interpolation: 'hold' | 'linear' | 'bezier',
+  handles?: BezierHandles
+): Keyframe {
+  return {
+    id: 'test',
+    position: 0,
+    value: 0,
+    interpolation,
+    handles,
+  }
+}
+
+const linearHandles: BezierHandles = {
+  left: [0, 0],
+  right: [1, 1],
+  type: 'aligned',
+}
+
+const easeInHandles: BezierHandles = {
+  left: [0, 0],
+  right: [0.42, 1],
+  type: 'aligned',
+}
+
+const easeOutHandles: BezierHandles = {
+  left: [0.58, 0],
+  right: [1, 1],
+  type: 'aligned',
+}
+
+const easyEaseHandles: BezierHandles = {
+  left: [0.42, 0],
+  right: [0.58, 1],
+  type: 'aligned',
+}
+
+describe('getKeyframeShapeType', () => {
+  describe('basic interpolation types', () => {
+    it('returns linear for linear interpolation', () => {
+      const kf = createKeyframe('linear')
+      expect(getKeyframeShapeType(kf)).toBe('linear')
+    })
+
+    it('returns linear for bezier with linear handles', () => {
+      const kf = createKeyframe('bezier', linearHandles)
+      expect(getKeyframeShapeType(kf)).toBe('linear')
+    })
+
+    it('returns ease-in for bezier with ease-in handles', () => {
+      const kf = createKeyframe('bezier', easeInHandles)
+      expect(getKeyframeShapeType(kf)).toBe('ease-in')
+    })
+
+    it('returns ease-out for bezier with ease-out handles', () => {
+      const kf = createKeyframe('bezier', easeOutHandles)
+      expect(getKeyframeShapeType(kf)).toBe('ease-out')
+    })
+
+    it('returns easy-ease for bezier with curved handles on both sides', () => {
+      const kf = createKeyframe('bezier', easyEaseHandles)
+      expect(getKeyframeShapeType(kf)).toBe('easy-ease')
+    })
+  })
+
+  describe('hold keyframes without neighbors', () => {
+    it('returns hold when no prev/next keyframes', () => {
+      const kf = createKeyframe('hold')
+      expect(getKeyframeShapeType(kf)).toBe('hold')
+    })
+
+    it('returns hold when both neighbors are hold', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('hold')
+      const next = createKeyframe('hold')
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold')
+    })
+  })
+
+  describe('hold keyframes with easing neighbors', () => {
+    it('returns hold-ease-out when next keyframe has easing', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('hold')
+      const next = createKeyframe('bezier', easeInHandles)
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-ease-out')
+    })
+
+    it('returns hold-ease-in when prev keyframe has easing', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('bezier', easeInHandles)
+      const next = createKeyframe('hold')
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-ease-in')
+    })
+
+    it('returns hold-linear-out when next keyframe is linear', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('hold')
+      const next = createKeyframe('linear')
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-linear-out')
+    })
+
+    it('returns hold-linear-in when prev keyframe is linear', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('linear')
+      const next = createKeyframe('hold')
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-linear-in')
+    })
+  })
+
+  describe('hold keyframes with easing on both sides', () => {
+    it('prioritizes right side (next keyframe) for ease-out', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('bezier', easeInHandles)
+      const next = createKeyframe('bezier', easeInHandles)
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-ease-out')
+    })
+
+    it('prioritizes right side (next keyframe) for linear-out', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('bezier', easeInHandles)
+      const next = createKeyframe('linear')
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-linear-out')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles undefined prev keyframe', () => {
+      const kf = createKeyframe('hold')
+      const next = createKeyframe('bezier', easeInHandles)
+      expect(getKeyframeShapeType(kf, undefined, next)).toBe('hold-ease-out')
+    })
+
+    it('handles undefined next keyframe', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('bezier', easeInHandles)
+      expect(getKeyframeShapeType(kf, prev, undefined)).toBe('hold-ease-in')
+    })
+
+    it('returns hold when hold keyframe has no defined neighbors', () => {
+      const kf = createKeyframe('hold')
+      expect(getKeyframeShapeType(kf, undefined, undefined)).toBe('hold')
+    })
+  })
+})

--- a/noodles-editor/src/timeline/utils/__tests__/keyframe-shape-utils.test.ts
+++ b/noodles-editor/src/timeline/utils/__tests__/keyframe-shape-utils.test.ts
@@ -83,16 +83,30 @@ describe('getKeyframeShapeType', () => {
   })
 
   describe('hold keyframes with easing neighbors', () => {
-    it('returns hold-ease-out when next keyframe has easing', () => {
+    it('returns hold-linear-out when next keyframe is ease-in (linear left handle)', () => {
       const kf = createKeyframe('hold')
       const prev = createKeyframe('hold')
-      const next = createKeyframe('bezier', easeInHandles)
+      const next = createKeyframe('bezier', easeInHandles) // left: [0,0] is linear
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-linear-out')
+    })
+
+    it('returns hold-linear-in when prev keyframe is ease-out (linear right handle)', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('bezier', easeOutHandles) // right: [1,1] is linear
+      const next = createKeyframe('hold')
+      expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-linear-in')
+    })
+
+    it('returns hold-ease-out when next keyframe has curved left handle', () => {
+      const kf = createKeyframe('hold')
+      const prev = createKeyframe('hold')
+      const next = createKeyframe('bezier', easeOutHandles) // left: [0.58,0] is curved
       expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-ease-out')
     })
 
-    it('returns hold-ease-in when prev keyframe has easing', () => {
+    it('returns hold-ease-in when prev keyframe has curved right handle', () => {
       const kf = createKeyframe('hold')
-      const prev = createKeyframe('bezier', easeInHandles)
+      const prev = createKeyframe('bezier', easeInHandles) // right: [0.42,1] is curved
       const next = createKeyframe('hold')
       expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-ease-in')
     })
@@ -113,17 +127,17 @@ describe('getKeyframeShapeType', () => {
   })
 
   describe('hold keyframes with easing on both sides', () => {
-    it('prioritizes right side (next keyframe) for ease-out', () => {
+    it('prioritizes right side when next has curved left handle', () => {
       const kf = createKeyframe('hold')
-      const prev = createKeyframe('bezier', easeInHandles)
-      const next = createKeyframe('bezier', easeInHandles)
+      const prev = createKeyframe('bezier', easeInHandles) // right: [0.42,1] curved
+      const next = createKeyframe('bezier', easeOutHandles) // left: [0.58,0] curved
       expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-ease-out')
     })
 
-    it('prioritizes right side (next keyframe) for linear-out', () => {
+    it('shows linear-out when next has linear left handle despite prev having curve', () => {
       const kf = createKeyframe('hold')
-      const prev = createKeyframe('bezier', easeInHandles)
-      const next = createKeyframe('linear')
+      const prev = createKeyframe('bezier', easeInHandles) // right: [0.42,1] curved
+      const next = createKeyframe('bezier', easeInHandles) // left: [0,0] linear
       expect(getKeyframeShapeType(kf, prev, next)).toBe('hold-linear-out')
     })
   })
@@ -193,13 +207,13 @@ describe('getKeyframeShapeType', () => {
   describe('edge cases', () => {
     it('handles undefined prev keyframe', () => {
       const kf = createKeyframe('hold')
-      const next = createKeyframe('bezier', easeInHandles)
-      expect(getKeyframeShapeType(kf, undefined, next)).toBe('hold-ease-out')
+      const next = createKeyframe('bezier', easeInHandles) // left: [0,0] is linear
+      expect(getKeyframeShapeType(kf, undefined, next)).toBe('hold-linear-out')
     })
 
     it('handles undefined next keyframe', () => {
       const kf = createKeyframe('hold')
-      const prev = createKeyframe('bezier', easeInHandles)
+      const prev = createKeyframe('bezier', easeInHandles) // right: [0.42,1] is curved
       expect(getKeyframeShapeType(kf, prev, undefined)).toBe('hold-ease-in')
     })
 

--- a/noodles-editor/src/timeline/utils/__tests__/keyframe-shape-utils.test.ts
+++ b/noodles-editor/src/timeline/utils/__tests__/keyframe-shape-utils.test.ts
@@ -128,6 +128,68 @@ describe('getKeyframeShapeType', () => {
     })
   })
 
+  describe('custom bezier handles', () => {
+    it('classifies steep ease-in curve correctly', () => {
+      const steepEaseIn: BezierHandles = {
+        left: [0.05, 0.05],
+        right: [0.2, 1],
+        type: 'aligned',
+      }
+      const kf = createKeyframe('bezier', steepEaseIn)
+      expect(getKeyframeShapeType(kf)).toBe('ease-in')
+    })
+
+    it('classifies steep ease-out curve correctly', () => {
+      const steepEaseOut: BezierHandles = {
+        left: [0.8, 0],
+        right: [0.95, 0.95],
+        type: 'aligned',
+      }
+      const kf = createKeyframe('bezier', steepEaseOut)
+      expect(getKeyframeShapeType(kf)).toBe('ease-out')
+    })
+
+    it('classifies asymmetric easy-ease curve correctly', () => {
+      const asymmetricEase: BezierHandles = {
+        left: [0.3, 0.1],
+        right: [0.7, 0.9],
+        type: 'uneven',
+      }
+      const kf = createKeyframe('bezier', asymmetricEase)
+      expect(getKeyframeShapeType(kf)).toBe('easy-ease')
+    })
+
+    it('detects near-linear handles as linear', () => {
+      const nearLinear: BezierHandles = {
+        left: [0.02, 0.04],
+        right: [0.98, 0.96],
+        type: 'aligned',
+      }
+      const kf = createKeyframe('bezier', nearLinear)
+      expect(getKeyframeShapeType(kf)).toBe('linear')
+    })
+
+    it('detects handles just outside linear threshold as ease', () => {
+      const justOutsideLinear: BezierHandles = {
+        left: [0.1, 0],
+        right: [0.9, 1],
+        type: 'aligned',
+      }
+      const kf = createKeyframe('bezier', justOutsideLinear)
+      expect(getKeyframeShapeType(kf)).toBe('easy-ease')
+    })
+
+    it('handles extreme bezier curves (overshoot)', () => {
+      const overshoot: BezierHandles = {
+        left: [0.6, -0.28],
+        right: [0.735, 1.045],
+        type: 'free',
+      }
+      const kf = createKeyframe('bezier', overshoot)
+      expect(getKeyframeShapeType(kf)).toBe('easy-ease')
+    })
+  })
+
   describe('edge cases', () => {
     it('handles undefined prev keyframe', () => {
       const kf = createKeyframe('hold')
@@ -144,6 +206,12 @@ describe('getKeyframeShapeType', () => {
     it('returns hold when hold keyframe has no defined neighbors', () => {
       const kf = createKeyframe('hold')
       expect(getKeyframeShapeType(kf, undefined, undefined)).toBe('hold')
+    })
+
+    it('handles keyframe with no handles (uses defaults)', () => {
+      const kf = createKeyframe('bezier')
+      // Should use DEFAULT_BEZIER_HANDLES which are linear
+      expect(getKeyframeShapeType(kf)).toBe('linear')
     })
   })
 })

--- a/noodles-editor/src/timeline/utils/keyframe-shape-utils.ts
+++ b/noodles-editor/src/timeline/utils/keyframe-shape-utils.ts
@@ -1,0 +1,82 @@
+// Utilities for determining keyframe visual shape based on interpolation type
+
+import type { BezierHandles, Keyframe } from '../types'
+import { DEFAULT_BEZIER_HANDLES } from '../types'
+
+export type KeyframeShapeType =
+  | 'linear' // Diamond
+  | 'ease-in' // Right chevron (linear out)
+  | 'ease-out' // Left chevron (linear in)
+  | 'easy-ease' // Hourglass (bezier both sides)
+  | 'hold' // Square (both sides hold)
+  | 'hold-ease-out' // Square with right notch (left hold, right eases)
+  | 'hold-ease-in' // Square with left notch (left eases, right hold)
+  | 'hold-linear-out' // Square with right triangle (left hold, right linear)
+  | 'hold-linear-in' // Square with left triangle (left linear, right hold)
+
+type EasingType = 'hold' | 'linear' | 'ease-in' | 'ease-out' | 'easy-ease'
+
+// Determine if a bezier handle represents linear interpolation
+function isHandleLinear(handle: [number, number]): boolean {
+  const epsilon = 0.05
+  return Math.abs(handle[0] - handle[1]) < epsilon
+}
+
+// Classify the easing type from a keyframe's interpolation and handles
+function getEasingType(keyframe: Keyframe | undefined): EasingType {
+  if (!keyframe) return 'hold'
+  if (keyframe.interpolation === 'hold') return 'hold'
+  if (keyframe.interpolation === 'linear') return 'linear'
+
+  const handles = keyframe.handles || DEFAULT_BEZIER_HANDLES
+  const isLeftLinear = isHandleLinear(handles.left)
+  const isRightLinear = isHandleLinear(handles.right)
+
+  if (isLeftLinear && isRightLinear) return 'linear'
+  if (isLeftLinear) return 'ease-in'
+  if (isRightLinear) return 'ease-out'
+  return 'easy-ease'
+}
+
+// Determine the visual shape for a keyframe based on its interpolation
+// and the adjacent keyframes (for hold variants)
+export function getKeyframeShapeType(
+  keyframe: Keyframe,
+  prevKeyframe?: Keyframe,
+  nextKeyframe?: Keyframe
+): KeyframeShapeType {
+  const currentEasing = getEasingType(keyframe)
+
+  // Non-hold keyframes: determine shape from current keyframe only
+  if (currentEasing !== 'hold') {
+    return currentEasing
+  }
+
+  // Hold keyframes: check adjacent keyframes to determine variants
+  const prevEasing = getEasingType(prevKeyframe)
+  const nextEasing = getEasingType(nextKeyframe)
+
+  // Both sides hold or missing -> basic hold square
+  if (prevEasing === 'hold' && nextEasing === 'hold') {
+    return 'hold'
+  }
+
+  // Left side has easing, right side hold
+  if (prevEasing !== 'hold' && nextEasing === 'hold') {
+    if (prevEasing === 'linear') return 'hold-linear-in'
+    return 'hold-ease-in'
+  }
+
+  // Left side hold, right side has easing
+  if (prevEasing === 'hold' && nextEasing !== 'hold') {
+    if (nextEasing === 'linear') return 'hold-linear-out'
+    return 'hold-ease-out'
+  }
+
+  // Both sides have easing (unusual for hold, but handle it)
+  // Prioritize showing the right side since that's controlled by current keyframe
+  if (nextEasing === 'linear') return 'hold-linear-out'
+  if (nextEasing !== 'hold') return 'hold-ease-out'
+  if (prevEasing === 'linear') return 'hold-linear-in'
+  return 'hold-ease-in'
+}

--- a/noodles-editor/src/timeline/utils/keyframe-shape-utils.ts
+++ b/noodles-editor/src/timeline/utils/keyframe-shape-utils.ts
@@ -52,31 +52,51 @@ export function getKeyframeShapeType(
     return currentEasing
   }
 
-  // Hold keyframes: check adjacent keyframes to determine variants
-  const prevEasing = getEasingType(prevKeyframe)
-  const nextEasing = getEasingType(nextKeyframe)
+  // Hold keyframes: check adjacent handles (not overall easing type)
+  // For hold variants, we care about the *adjacent* handle:
+  // - prevKeyframe.handles.right (what leaves the prev keyframe toward this hold)
+  // - nextKeyframe.handles.left (what arrives at the next keyframe from this hold)
+
+  const prevIsHold = !prevKeyframe || prevKeyframe.interpolation === 'hold'
+  const nextIsHold = !nextKeyframe || nextKeyframe.interpolation === 'hold'
+
+  // Check adjacent handles for linear vs eased transitions
+  let prevHandleIsLinear = true
+  if (prevKeyframe && prevKeyframe.interpolation !== 'hold') {
+    const prevRightHandle =
+      prevKeyframe.interpolation === 'linear'
+        ? [1, 1] as [number, number]
+        : (prevKeyframe.handles || DEFAULT_BEZIER_HANDLES).right
+    prevHandleIsLinear = isHandleLinear(prevRightHandle)
+  }
+
+  let nextHandleIsLinear = true
+  if (nextKeyframe && nextKeyframe.interpolation !== 'hold') {
+    const nextLeftHandle =
+      nextKeyframe.interpolation === 'linear'
+        ? [0, 0] as [number, number]
+        : (nextKeyframe.handles || DEFAULT_BEZIER_HANDLES).left
+    nextHandleIsLinear = isHandleLinear(nextLeftHandle)
+  }
 
   // Both sides hold or missing -> basic hold square
-  if (prevEasing === 'hold' && nextEasing === 'hold') {
+  if (prevIsHold && nextIsHold) {
     return 'hold'
   }
 
   // Left side has easing, right side hold
-  if (prevEasing !== 'hold' && nextEasing === 'hold') {
-    if (prevEasing === 'linear') return 'hold-linear-in'
-    return 'hold-ease-in'
+  if (!prevIsHold && nextIsHold) {
+    return prevHandleIsLinear ? 'hold-linear-in' : 'hold-ease-in'
   }
 
   // Left side hold, right side has easing
-  if (prevEasing === 'hold' && nextEasing !== 'hold') {
-    if (nextEasing === 'linear') return 'hold-linear-out'
-    return 'hold-ease-out'
+  if (prevIsHold && !nextIsHold) {
+    return nextHandleIsLinear ? 'hold-linear-out' : 'hold-ease-out'
   }
 
-  // Both sides have easing (unusual for hold, but handle it)
-  // Prioritize showing the right side since that's controlled by current keyframe
-  if (nextEasing === 'linear') return 'hold-linear-out'
-  if (nextEasing !== 'hold') return 'hold-ease-out'
-  if (prevEasing === 'linear') return 'hold-linear-in'
-  return 'hold-ease-in'
+  // Both sides have easing - prioritize right side
+  if (!nextHandleIsLinear) return 'hold-ease-out'
+  if (nextHandleIsLinear) return 'hold-linear-out'
+  if (!prevHandleIsLinear) return 'hold-ease-in'
+  return 'hold-linear-in'
 }

--- a/noodles-editor/src/timeline/utils/keyframe-shape-utils.ts
+++ b/noodles-editor/src/timeline/utils/keyframe-shape-utils.ts
@@ -1,6 +1,6 @@
 // Utilities for determining keyframe visual shape based on interpolation type
 
-import type { BezierHandles, Keyframe } from '../types'
+import type { Keyframe } from '../types'
 import { DEFAULT_BEZIER_HANDLES } from '../types'
 
 export type KeyframeShapeType =


### PR DESCRIPTION
#### Background

Timeline keyframes previously all rendered as identical diamonds, making it difficult to identify interpolation types at a glance. This implements distinct visual shapes following After Effects conventions.

#### Change List
- Add 9 distinct keyframe shapes (linear, ease-in, ease-out, easy-ease, hold, and 4 hold variants)
- Replace CSS-rotated diamond with flexible SVG path rendering
- Analyze bezier handles to classify ease-in, ease-out, and easy-ease types
- Hold keyframes examine adjacent keyframes and show notches indicating transition types
- Add comprehensive test suite (23 tests covering all interpolation types, custom handles, and edge cases)
- Improve tooltip to show keyframe value alongside time and shape type