### PR TITLE
feat: add SmoothOp for Gaussian/boxcar smoothing

### DIFF
--- a/noodles-editor/src/noodles/__snapshots__/operators.test.ts.snap
+++ b/noodles-editor/src/noodles/__snapshots__/operators.test.ts.snap
@@ -143,3 +143,35 @@ exports[`GeoJsonTransformOp > should translate a feature 1`] = `
   "type": "Feature",
 }
 `;
+
+exports[`SmoothOp > should apply boxcar smoothing to LineString 1`] = `
+{
+  "geometry": {
+    "coordinates": [
+      [
+        0.5,
+        0.5,
+      ],
+      [
+        1,
+        0.3333333333333333,
+      ],
+      [
+        2,
+        0.6666666666666666,
+      ],
+      [
+        3,
+        0.3333333333333333,
+      ],
+      [
+        3.5,
+        0.5,
+      ],
+    ],
+    "type": "LineString",
+  },
+  "properties": {},
+  "type": "Feature",
+}
+`;

--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -30,7 +30,7 @@ export const categories = {
     'Viewer',
     'ViewState',
   ],
-  geojson: ['GeoJson', 'GeoJsonTransform', 'KmlToGeoJson', 'Point', 'Rectangle'],
+  geojson: ['GeoJson', 'GeoJsonTransform', 'KmlToGeoJson', 'Point', 'Rectangle', 'Smooth'],
   layer: [
     'A5Layer',
     'ArcLayer',

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -1,4 +1,5 @@
 import { Temporal } from 'temporal-polyfill'
+import * as turf from '@turf/turf'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NumberField } from './fields'
 import {
@@ -31,6 +32,7 @@ import {
   RerouteOp,
   ScatterplotLayerOp,
   SelectOp,
+  SmoothOp,
   SwitchOp,
   Tile3DLayerOp,
   TimeSeriesOp,
@@ -1547,6 +1549,197 @@ describe('GeoJsonTransformOp', () => {
     expect(result.feature.geometry.coordinates).not.toEqual(inputFeature.geometry.coordinates)
     // Snapshot the transformed feature
     expect(result.feature).toMatchSnapshot()
+  })
+})
+
+describe('SmoothOp', () => {
+  it('should pass through unchanged with window size 1', () => {
+    const op = new SmoothOp('/smooth-0')
+    const inputFeature = turf.lineString([
+      [0, 0],
+      [1, 1],
+      [2, 0],
+      [3, 1],
+      [4, 0],
+    ])
+
+    const result = op.execute({
+      feature: inputFeature,
+      windowSize: 1,
+      method: 'boxcar',
+    })
+
+    expect(result.feature.geometry.coordinates).toEqual(inputFeature.geometry.coordinates)
+  })
+
+  it('should apply boxcar smoothing to LineString', () => {
+    const op = new SmoothOp('/smooth-1')
+    const inputFeature = turf.lineString([
+      [0, 0],
+      [1, 1],
+      [2, 0],
+      [3, 1],
+      [4, 0],
+    ])
+
+    const result = op.execute({
+      feature: inputFeature,
+      windowSize: 3,
+      method: 'boxcar',
+    })
+
+    expect(result.feature.type).toBe('Feature')
+    expect(result.feature.geometry.type).toBe('LineString')
+    // Middle point [2,0] should be average of [1,1], [2,0], [3,1]
+    // lon: (1+2+3)/3 = 2, lat: (1+0+1)/3 = 0.666...
+    expect(result.feature.geometry.coordinates[2][0]).toBeCloseTo(2, 5)
+    expect(result.feature.geometry.coordinates[2][1]).toBeCloseTo(2 / 3, 5)
+    expect(result.feature).toMatchSnapshot()
+  })
+
+  it('should preserve extra coordinate channels', () => {
+    const op = new SmoothOp('/smooth-2')
+    const inputFeature = turf.lineString([
+      [0, 0, 100],
+      [1, 1, 200],
+      [2, 0, 150],
+    ])
+
+    const result = op.execute({
+      feature: inputFeature,
+      windowSize: 3,
+      method: 'boxcar',
+    })
+
+    // Altitude values preserved (not smoothed)
+    expect(result.feature.geometry.coordinates[0][2]).toBe(100)
+    expect(result.feature.geometry.coordinates[1][2]).toBe(200)
+    expect(result.feature.geometry.coordinates[2][2]).toBe(150)
+  })
+
+  it('should apply Gaussian smoothing differently than boxcar', () => {
+    const op = new SmoothOp('/smooth-3')
+    const inputFeature = turf.lineString([
+      [0, 0],
+      [1, 1],
+      [2, 0],
+      [3, 1],
+      [4, 0],
+    ])
+
+    const boxcarResult = op.execute({
+      feature: inputFeature,
+      windowSize: 5,
+      method: 'boxcar',
+    })
+
+    const gaussianResult = op.execute({
+      feature: inputFeature,
+      windowSize: 5,
+      method: 'gaussian',
+    })
+
+    // Gaussian should weight center point more heavily
+    const boxcarY = boxcarResult.feature.geometry.coordinates[2][1]
+    const gaussianY = gaussianResult.feature.geometry.coordinates[2][1]
+    expect(gaussianY).not.toBeCloseTo(boxcarY, 5)
+  })
+
+  it('should handle MultiLineString', () => {
+    const op = new SmoothOp('/smooth-4')
+    const inputFeature = turf.multiLineString([
+      [
+        [0, 0],
+        [1, 1],
+        [2, 0],
+      ],
+      [
+        [5, 5],
+        [6, 6],
+        [7, 5],
+      ],
+    ])
+
+    const result = op.execute({
+      feature: inputFeature,
+      windowSize: 3,
+      method: 'boxcar',
+    })
+
+    expect(result.feature.geometry.type).toBe('MultiLineString')
+    expect(result.feature.geometry.coordinates).toHaveLength(2)
+  })
+
+  it('should pass through non-line geometries unchanged', () => {
+    const op = new SmoothOp('/smooth-5')
+    const pointFeature = turf.point([0, 0])
+
+    const result = op.execute({
+      feature: pointFeature,
+      windowSize: 5,
+      method: 'boxcar',
+    })
+
+    expect(result.feature).toEqual(pointFeature)
+  })
+
+  it('should preserve feature properties', () => {
+    const op = new SmoothOp('/smooth-6')
+    const inputFeature = turf.lineString(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 0],
+      ],
+      { name: 'test-route', id: 123 }
+    )
+
+    const result = op.execute({
+      feature: inputFeature,
+      windowSize: 3,
+      method: 'boxcar',
+    })
+
+    expect(result.feature.properties).toEqual({ name: 'test-route', id: 123 })
+  })
+
+  it('should handle edge points with asymmetric windows', () => {
+    const op = new SmoothOp('/smooth-7')
+    const inputFeature = turf.lineString([
+      [0, 0],
+      [2, 2],
+      [4, 4],
+    ])
+
+    const result = op.execute({
+      feature: inputFeature,
+      windowSize: 5, // Larger than array
+      method: 'boxcar',
+    })
+
+    // First point should be average of available points (itself and neighbors)
+    // With window=5, radius=2, but only indices 0,1,2 exist
+    const firstPoint = result.feature.geometry.coordinates[0]
+    expect(firstPoint[0]).toBeCloseTo(2, 5) // (0+2+4)/3
+    expect(firstPoint[1]).toBeCloseTo(2, 5)
+  })
+
+  it('should handle two-point LineStrings', () => {
+    const op = new SmoothOp('/smooth-8')
+    const twoPointFeature = turf.lineString([
+      [0, 0],
+      [1, 1],
+    ])
+
+    const result = op.execute({
+      feature: twoPointFeature,
+      windowSize: 5,
+      method: 'boxcar',
+    })
+
+    // With only two points, smoothing should have minimal effect
+    expect(result.feature.geometry.type).toBe('LineString')
+    expect(result.feature.geometry.coordinates).toHaveLength(2)
   })
 })
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -6971,14 +6971,14 @@ export class SimplifyOp extends Operator<SimplifyOp> {
 
 export class SmoothOp extends Operator<SmoothOp> {
   static displayName = 'Smooth'
-  static description = 'Apply smoothing to LineString coordinates using boxcar or Gaussian kernel'
+  static description = 'Apply smoothing to LineString coordinates using Gaussian or boxcar kernel'
   asDownload = () => this.outputData
 
   createInputs() {
     return {
       feature: new GeoJsonField(),
       windowSize: new NumberField(5, { min: 1, max: 100, step: 2 }),
-      method: new StringLiteralField('boxcar', ['boxcar', 'gaussian']),
+      method: new StringLiteralField('gaussian', ['gaussian', 'boxcar']),
     }
   }
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -6969,6 +6969,97 @@ export class SimplifyOp extends Operator<SimplifyOp> {
   }
 }
 
+export class SmoothOp extends Operator<SmoothOp> {
+  static displayName = 'Smooth'
+  static description = 'Apply smoothing to LineString coordinates using boxcar or Gaussian kernel'
+  asDownload = () => this.outputData
+
+  createInputs() {
+    return {
+      feature: new GeoJsonField(),
+      windowSize: new NumberField(5, { min: 1, max: 100, step: 2 }),
+      method: new StringLiteralField('boxcar', ['boxcar', 'gaussian']),
+    }
+  }
+
+  createOutputs() {
+    return {
+      feature: new GeoJsonField(),
+    }
+  }
+
+  execute({
+    feature,
+    windowSize,
+    method,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    // Handle LineString
+    if (feature.geometry.type === 'LineString') {
+      if (feature.geometry.coordinates.length <= 1) {
+        return { feature }
+      }
+
+      const smoothedCoords = this.smoothCoordinates(
+        feature.geometry.coordinates,
+        windowSize,
+        method
+      )
+      return { feature: turf.lineString(smoothedCoords, feature.properties) }
+    }
+
+    // Handle MultiLineString
+    if (feature.geometry.type === 'MultiLineString') {
+      const smoothedLines = feature.geometry.coordinates.map(line =>
+        this.smoothCoordinates(line, windowSize, method)
+      )
+      return { feature: turf.multiLineString(smoothedLines, feature.properties) }
+    }
+
+    // Pass through other geometry types unchanged
+    return { feature }
+  }
+
+  private smoothCoordinates(
+    coords: number[][],
+    windowSize: number,
+    method: 'boxcar' | 'gaussian'
+  ): number[][] {
+    const radius = Math.floor(windowSize / 2)
+    const sigma = method === 'gaussian' ? windowSize / 6 : 0
+
+    return coords.map((pt, i) => {
+      let lonSum = 0
+      let latSum = 0
+      let weightSum = 0
+
+      // Iterate over window centered on current point
+      for (let j = i - radius; j <= i + radius; j++) {
+        if (j < 0 || j >= coords.length) continue
+
+        // Calculate weight based on smoothing method
+        let weight: number
+        if (method === 'gaussian') {
+          const distance = Math.abs(j - i)
+          weight = Math.exp(-0.5 * Math.pow(distance / sigma, 2))
+        } else {
+          weight = 1 // Boxcar: uniform weights
+        }
+
+        lonSum += coords[j][0] * weight
+        latSum += coords[j][1] * weight
+        weightSum += weight
+      }
+
+      // Return smoothed lon/lat plus preserved extra channels
+      return [
+        lonSum / weightSum,
+        latSum / weightSum,
+        ...pt.slice(2), // Preserve altitude, timestamps, etc.
+      ]
+    })
+  }
+}
+
 // ==================== Core Layers (@deck.gl/layers) ====================
 
 export class BitmapLayerOp extends Operator<BitmapLayerOp> {
@@ -8135,6 +8226,7 @@ export const opTypes = {
   ScreenshotWidgetOp,
   SimpleMeshLayerOp,
   SimplifyOp,
+  SmoothOp,
   SelectOp,
   SliceOp,
   SolidPolygonLayerOp,


### PR DESCRIPTION
#### Background
Add a new operator for smoothing noisy GeoJSON LineString coordinates, useful for cleaning up GPS tracks, flight paths, and other geospatial line data.

#### Change List
- Add SmoothOp operator with Gaussian (default) and boxcar kernel smoothing
- Support for LineString and MultiLineString geometries
- Preserve extra coordinate channels (altitude, timestamps, headings) and feature properties
- Add comprehensive test suite with 9 tests covering all edge cases
- Register operator in geojson category
- Default to Gaussian smoothing for better quality (industry standard)