### PR TITLE
fix: support decimal values in TableEditorOp step size field

### DIFF
--- a/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
@@ -123,6 +123,7 @@ function ColumnEditor({ column, onChange, onDelete, onMoveUp, onMoveDown }: Colu
             Step:
             <InputNumber
               value={column.options?.step ?? 1}
+              step={0.001}
               onChange={e =>
                 onChange({
                   ...column,


### PR DESCRIPTION
## Summary
- Add `step={0.001}` prop to the Step field's InputNumber component in the schema editor dialog
- Enables fine-grained decimal input (0.001 increments) via increment/decrement buttons
- Users can still manually type any decimal value

## Test plan
- [ ] Start dev server and open a project with TableEditorOp
- [ ] Edit a number column's schema
- [ ] Test entering decimal values in Step field (e.g., 0.1, 0.5, 1.5)
- [ ] Verify increment/decrement buttons work with 0.001 increments
- [ ] Verify arbitrary decimal values can be entered manually
- [ ] Test that step values persist after save/reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)