### PR TITLE
fix: report accurate execution time when operators throw errors

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -495,6 +495,7 @@ export abstract class Operator<OP extends IOperator> {
     debugExecute('%s: starting %O', this.id, { inputs: this.data })
 
     let executionTime = 0
+    let startTime = 0
 
     try {
       // Pull upstream dependencies first
@@ -513,7 +514,7 @@ export abstract class Operator<OP extends IOperator> {
       }
 
       // Execute the operator - measure only own execution time
-      const startTime = performance.now()
+      startTime = performance.now()
       const result = this.execute(inputValues)
       const finalResult = result instanceof Promise ? await result : result
       executionTime = performance.now() - startTime
@@ -556,6 +557,9 @@ export abstract class Operator<OP extends IOperator> {
       return finalResult
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
+
+      // Calculate actual elapsed time even on error
+      executionTime = performance.now() - startTime
 
       // Only log if this is a new/different error
       if (this._lastLoggedError !== error.message) {


### PR DESCRIPTION
#### Background
Previously, when an operator's execute() method threw an error or returned a rejected Promise, the executionTime was always reported as 0 because it was only calculated after successful completion. This made timing data misleading for performance debugging of failing operators.

#### Change List
- Declare startTime outside try block to make it accessible in catch handler
- Calculate actual elapsed time in catch block before reporting error state
- Preserve original semantic of measuring only operator's own execution time (excluding upstream dependency pulls)