### PR TITLE
feat: add spreadsheet pane for tabular data inspection

### DIFF
--- a/noodles-editor/package.json
+++ b/noodles-editor/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-menubar": "^1.1.16",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.5",
     "@tmcw/togeojson": "^7.1.2",
     "@turf/turf": "^7.3.4",
     "@types/rbush": "^4.0.0",

--- a/noodles-editor/src/external-control/message-protocol.test.ts
+++ b/noodles-editor/src/external-control/message-protocol.test.ts
@@ -9,8 +9,8 @@ import {
   type Message,
   MessageMatcher,
   MessageType,
-  parseMessage,
   type PingMessage,
+  parseMessage,
   serializeMessage,
 } from './message-protocol'
 

--- a/noodles-editor/src/index.tsx
+++ b/noodles-editor/src/index.tsx
@@ -25,13 +25,16 @@ keyboardManager.init()
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement, {
   // Called when React catches an error in an Error Boundary
   onCaughtError: (error, errorInfo) => {
+    console.error('[Noodles] React caught error:', error, errorInfo.componentStack)
     analytics.captureException(error, {
       source: 'react_error_boundary',
       componentStack: errorInfo.componentStack,
     })
   },
-  // Called when an error is thrown and not caught by an Error Boundary
+  // Called when an error is thrown and not caught by an Error Boundary — log to console
+  // since this replaces React's default error logging
   onUncaughtError: (error, errorInfo) => {
+    console.error('[Noodles] React uncaught error:', error, errorInfo.componentStack)
     analytics.captureException(error, {
       source: 'react_uncaught',
       componentStack: errorInfo.componentStack,
@@ -39,6 +42,7 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement,
   },
   // Called when React automatically recovers from errors
   onRecoverableError: (error, errorInfo) => {
+    console.error('[Noodles] React recoverable error:', error, errorInfo.componentStack)
     analytics.captureException(error, {
       source: 'react_recoverable',
       componentStack: errorInfo.componentStack,

--- a/noodles-editor/src/layout.module.css
+++ b/noodles-editor/src/layout.module.css
@@ -85,6 +85,8 @@
   flex: 1;
   position: relative;
   min-width: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 /* Split mode: divide space vertically */

--- a/noodles-editor/src/layout.module.css
+++ b/noodles-editor/src/layout.module.css
@@ -65,12 +65,26 @@
   overflow: hidden;
 }
 
-.outputArea,
+.outputArea {
+  position: absolute;
+  left: 0;
+  right: 0;
+  overflow: hidden;
+}
+
 .noodlesArea {
   position: absolute;
   left: 0;
   right: 0;
   overflow: hidden;
+  display: flex;
+  flex-direction: row;
+}
+
+.nodeGraphArea {
+  flex: 1;
+  position: relative;
+  min-width: 0;
 }
 
 /* Split mode: divide space vertically */

--- a/noodles-editor/src/layout.tsx
+++ b/noodles-editor/src/layout.tsx
@@ -15,6 +15,7 @@ export function Layout({
   left,
   right,
   flowGraph,
+  spreadsheet,
   children,
   layoutMode = 'split',
 }: PropsWithChildren<{
@@ -23,6 +24,7 @@ export function Layout({
   left?: ReactNode
   right?: ReactNode
   flowGraph?: ReactNode
+  spreadsheet?: ReactNode
   layoutMode?: 'split' | 'noodles-on-top' | 'output-on-top'
 }>) {
   const sidebarVisible = useUIStore(state => state.sidebarVisible)
@@ -53,7 +55,10 @@ export function Layout({
       <div style={{ gridArea: 'bottom-widget' }}>{bottom}</div>
       <div className={cx(s.fillWidget, layoutClass)}>
         <div className={s.outputArea}>{children}</div>
-        <div className={s.noodlesArea}>{flowGraph}</div>
+        <div className={s.noodlesArea}>
+          <div className={s.nodeGraphArea}>{flowGraph}</div>
+          {spreadsheet}
+        </div>
       </div>
     </div>
   )

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.module.css
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.module.css
@@ -1,0 +1,79 @@
+.spreadsheetArea {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--color-border);
+  background: var(--color-bg-base);
+}
+
+.resizeHandle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  cursor: ew-resize;
+  background: transparent;
+  z-index: 10;
+}
+
+.resizeHandle:hover {
+  background: var(--color-accent);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-elevated);
+}
+
+.title {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--color-text-primary);
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.operatorName {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  font-family: monospace;
+}
+
+.pinButton {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+}
+
+.pinButton:hover {
+  color: var(--color-text-primary);
+}
+
+.content {
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.emptyState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.test.tsx
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.test.tsx
@@ -1,0 +1,171 @@
+import { cleanup, fireEvent, render, screen, act } from '@testing-library/react'
+import { Subject } from 'rxjs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock store
+const storeState = {
+  spreadsheetVisible: true,
+  spreadsheetWidth: 400,
+  pinnedSpreadsheetNodeId: null as string | null,
+}
+const mockSetWidth = vi.fn((w: number) => { storeState.spreadsheetWidth = w })
+const mockSetPinnedNodeId = vi.fn((id: string | null) => { storeState.pinnedSpreadsheetNodeId = id })
+
+vi.mock('../../store', () => ({
+  useUIStore: (selector: (s: typeof storeState & {
+    setSpreadsheetWidth: typeof mockSetWidth
+    setPinnedSpreadsheetNodeId: typeof mockSetPinnedNodeId
+  }) => unknown) =>
+    selector({
+      ...storeState,
+      setSpreadsheetWidth: mockSetWidth,
+      setPinnedSpreadsheetNodeId: mockSetPinnedNodeId,
+    }),
+  getOp: vi.fn(),
+}))
+
+vi.mock('./spreadsheet-pane.module.css', () => ({
+  default: new Proxy({}, { get: (_, prop) => String(prop) }),
+}))
+
+vi.mock('./spreadsheet-viewer', () => ({
+  SpreadsheetViewer: ({ operatorId }: { operatorId: string }) => (
+    <div data-testid="spreadsheet-viewer">{operatorId}</div>
+  ),
+}))
+
+// Import after mocks
+import { SpreadsheetPane } from './spreadsheet-pane'
+import { getOp } from '../../store'
+
+const mockGetOp = vi.mocked(getOp)
+
+describe('SpreadsheetPane', () => {
+  beforeEach(() => {
+    storeState.spreadsheetVisible = true
+    storeState.spreadsheetWidth = 400
+    storeState.pinnedSpreadsheetNodeId = null
+    mockGetOp.mockReset()
+    mockSetPinnedNodeId.mockClear()
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders nothing when spreadsheet is not visible', () => {
+    storeState.spreadsheetVisible = false
+    const { container } = render(<SpreadsheetPane selectedNodeIds={['/op-1']} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows empty state when no node is selected', () => {
+    render(<SpreadsheetPane selectedNodeIds={[]} />)
+    expect(screen.getByText('Select a node to view its data')).toBeTruthy()
+  })
+
+  it('shows empty state when multiple nodes are selected', () => {
+    render(<SpreadsheetPane selectedNodeIds={['/op-1', '/op-2']} />)
+    expect(screen.getByText('Select a node to view its data')).toBeTruthy()
+  })
+
+  it('shows operator not found error for missing operator', () => {
+    mockGetOp.mockReturnValue(undefined)
+    render(<SpreadsheetPane selectedNodeIds={['/missing']} />)
+    expect(screen.getByText('Operator not found')).toBeTruthy()
+  })
+
+  it('shows no outputs error for operator with no outputs', () => {
+    mockGetOp.mockReturnValue({ outputs: {} } as ReturnType<typeof getOp>)
+    render(<SpreadsheetPane selectedNodeIds={['/op-no-outputs']} />)
+    expect(screen.getByText('No outputs available')).toBeTruthy()
+  })
+
+  it('renders SpreadsheetViewer when operator has outputs', () => {
+    const subject = new Subject<unknown>()
+    mockGetOp.mockReturnValue({
+      outputs: { result: subject },
+    } as unknown as ReturnType<typeof getOp>)
+
+    render(<SpreadsheetPane selectedNodeIds={['/op-1']} />)
+    expect(screen.getByTestId('spreadsheet-viewer')).toBeTruthy()
+  })
+
+  it('subscribes to the first output field and receives data', () => {
+    const subject = new Subject<unknown>()
+    const subscribeSpy = vi.spyOn(subject, 'subscribe')
+    mockGetOp.mockReturnValue({
+      outputs: { result: subject },
+    } as unknown as ReturnType<typeof getOp>)
+
+    render(<SpreadsheetPane selectedNodeIds={['/op-1']} />)
+    expect(subscribeSpy).toHaveBeenCalledOnce()
+  })
+
+  it('unsubscribes when hidden', () => {
+    const subject = new Subject<unknown>()
+    const unsubSpy = vi.fn()
+    vi.spyOn(subject, 'subscribe').mockReturnValue({ unsubscribe: unsubSpy } as ReturnType<Subject<unknown>['subscribe']>)
+    mockGetOp.mockReturnValue({
+      outputs: { result: subject },
+    } as unknown as ReturnType<typeof getOp>)
+
+    const { rerender } = render(<SpreadsheetPane selectedNodeIds={['/op-1']} />)
+    storeState.spreadsheetVisible = false
+    rerender(<SpreadsheetPane selectedNodeIds={['/op-1']} />)
+    expect(unsubSpy).toHaveBeenCalledOnce()
+  })
+
+  it('clears pinned node when pinned operator is deleted', () => {
+    storeState.pinnedSpreadsheetNodeId = '/deleted-op'
+    mockGetOp.mockReturnValue(undefined)
+
+    render(<SpreadsheetPane selectedNodeIds={[]} />)
+    expect(mockSetPinnedNodeId).toHaveBeenCalledWith(null)
+  })
+
+  it('displays operator name in header when node is targeted', () => {
+    const subject = new Subject<unknown>()
+    mockGetOp.mockReturnValue({
+      outputs: { result: subject },
+    } as unknown as ReturnType<typeof getOp>)
+
+    render(<SpreadsheetPane selectedNodeIds={['/my-operator']} />)
+    // operatorName span in header (may also appear in mocked viewer, use getAllByText)
+    const matches = screen.getAllByText('/my-operator')
+    expect(matches.length).toBeGreaterThan(0)
+  })
+
+  describe('pin/unpin', () => {
+    it('shows pin button when a node is targeted', () => {
+      const subject = new Subject<unknown>()
+      mockGetOp.mockReturnValue({
+        outputs: { result: subject },
+      } as unknown as ReturnType<typeof getOp>)
+
+      render(<SpreadsheetPane selectedNodeIds={['/op-1']} />)
+      expect(screen.getByTitle('Pin current operator')).toBeTruthy()
+    })
+
+    it('pins when clicking the pin button', () => {
+      const subject = new Subject<unknown>()
+      mockGetOp.mockReturnValue({
+        outputs: { result: subject },
+      } as unknown as ReturnType<typeof getOp>)
+
+      render(<SpreadsheetPane selectedNodeIds={['/op-1']} />)
+      fireEvent.click(screen.getByTitle('Pin current operator'))
+      expect(mockSetPinnedNodeId).toHaveBeenCalledWith('/op-1')
+    })
+
+    it('unpins when clicking Unpin on a pinned node', () => {
+      storeState.pinnedSpreadsheetNodeId = '/op-1'
+      const subject = new Subject<unknown>()
+      mockGetOp.mockReturnValue({
+        outputs: { result: subject },
+      } as unknown as ReturnType<typeof getOp>)
+
+      render(<SpreadsheetPane selectedNodeIds={[]} />)
+      fireEvent.click(screen.getByTitle('Unpin'))
+      expect(mockSetPinnedNodeId).toHaveBeenCalledWith(null)
+    })
+  })
+})

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.tsx
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Subscription } from 'rxjs'
+import { getOp, useUIStore } from '../../store'
+import { SpreadsheetViewer } from './spreadsheet-viewer'
+import s from './spreadsheet-pane.module.css'
+
+const MIN_WIDTH = 300
+const MAX_WIDTH = 800
+
+export function SpreadsheetPane({ selectedNodeIds }: { selectedNodeIds: string[] }) {
+  const visible = useUIStore(state => state.spreadsheetVisible)
+  const width = useUIStore(state => state.spreadsheetWidth)
+  const setWidth = useUIStore(state => state.setSpreadsheetWidth)
+  const pinnedNodeId = useUIStore(state => state.pinnedSpreadsheetNodeId)
+  const setPinnedNodeId = useUIStore(state => state.setPinnedSpreadsheetNodeId)
+
+  const [data, setData] = useState<unknown>(null)
+  const [error, setError] = useState<string | null>(null)
+  const subscriptionRef = useRef<Subscription | null>(null)
+
+  // Determine which operator to display (pinned or selected)
+  const targetNodeId = pinnedNodeId || (selectedNodeIds.length === 1 ? selectedNodeIds[0] : null)
+
+  // Subscribe to operator's first output field
+  useEffect(() => {
+    if (!visible || !targetNodeId) {
+      setData(null)
+      setError(null)
+      return
+    }
+
+    const op = getOp(targetNodeId)
+    if (!op) {
+      setError('Operator not found')
+      return
+    }
+
+    const outputFields = Object.values(op.outputs)
+    if (outputFields.length === 0) {
+      setError('No outputs available')
+      return
+    }
+
+    const firstOutput = outputFields[0]
+    subscriptionRef.current = firstOutput.subscribe(value => {
+      setData(value)
+      setError(null)
+    })
+
+    return () => {
+      subscriptionRef.current?.unsubscribe()
+    }
+  }, [visible, targetNodeId])
+
+  // Resize handling
+  const handleResizeMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      const startX = e.clientX
+      const startWidth = width
+
+      function onMouseMove(moveEvent: MouseEvent) {
+        const deltaX = startX - moveEvent.clientX
+        const newWidth = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startWidth + deltaX))
+        setWidth(newWidth)
+      }
+
+      function onMouseUp() {
+        document.removeEventListener('mousemove', onMouseMove)
+        document.removeEventListener('mouseup', onMouseUp)
+      }
+
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+    },
+    [width, setWidth]
+  )
+
+  // Pin/unpin handler
+  const handleTogglePin = useCallback(() => {
+    if (pinnedNodeId) {
+      setPinnedNodeId(null)
+    } else if (targetNodeId) {
+      setPinnedNodeId(targetNodeId)
+    }
+  }, [pinnedNodeId, targetNodeId, setPinnedNodeId])
+
+  if (!visible) return null
+
+  return (
+    <div className={s.spreadsheetArea} style={{ width }}>
+      <div className={s.resizeHandle} onMouseDown={handleResizeMouseDown} />
+      <div className={s.header}>
+        <span className={s.title}>Spreadsheet</span>
+        <div className={s.controls}>
+          {targetNodeId && (
+            <>
+              <span className={s.operatorName}>{targetNodeId}</span>
+              <button
+                type="button"
+                className={s.pinButton}
+                onClick={handleTogglePin}
+                title={pinnedNodeId ? 'Unpin' : 'Pin current operator'}
+              >
+                <i className={pinnedNodeId ? 'pi pi-lock' : 'pi pi-lock-open'} />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+      <div className={s.content}>
+        {error ? (
+          <div className={s.emptyState}>{error}</div>
+        ) : targetNodeId ? (
+          <SpreadsheetViewer data={data} />
+        ) : (
+          <div className={s.emptyState}>Select a node to view its data</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.tsx
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import type { Subscription } from 'rxjs'
+import { useCallback, useEffect, useState } from 'react'
 import { getOp, useUIStore } from '../../store'
 import { SpreadsheetViewer } from './spreadsheet-viewer'
 import s from './spreadsheet-pane.module.css'
@@ -16,26 +15,22 @@ export function SpreadsheetPane({ selectedNodeIds }: { selectedNodeIds: string[]
 
   const [data, setData] = useState<unknown>(null)
   const [error, setError] = useState<string | null>(null)
-  const subscriptionRef = useRef<Subscription | null>(null)
 
   // Determine which operator to display (pinned or selected)
   const targetNodeId = pinnedNodeId || (selectedNodeIds.length === 1 ? selectedNodeIds[0] : null)
 
   // Subscribe to operator's first output field
   useEffect(() => {
-    if (!visible || !targetNodeId) {
-      setData(null)
-      setError(null)
-      return
-    }
+    setData(null)
+    setError(null)
+
+    if (!visible || !targetNodeId) return
 
     const op = getOp(targetNodeId)
     if (!op) {
       setError('Operator not found')
       // Clear pinned node if it was deleted
-      if (pinnedNodeId) {
-        setPinnedNodeId(null)
-      }
+      if (pinnedNodeId) setPinnedNodeId(null)
       return
     }
 
@@ -45,18 +40,14 @@ export function SpreadsheetPane({ selectedNodeIds }: { selectedNodeIds: string[]
       return
     }
 
-    const firstOutput = outputFields[0]
-    subscriptionRef.current = firstOutput.subscribe(value => {
+    // Capture subscription in a local const so cleanup always unsubscribes the right one
+    const sub = outputFields[0].subscribe(value => {
       setData(value)
       setError(null)
     })
-
-    return () => {
-      subscriptionRef.current?.unsubscribe()
-    }
+    return () => sub.unsubscribe()
   }, [visible, targetNodeId, pinnedNodeId, setPinnedNodeId])
 
-  // Resize handling
   const handleResizeMouseDown = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault()
@@ -64,9 +55,8 @@ export function SpreadsheetPane({ selectedNodeIds }: { selectedNodeIds: string[]
       const startWidth = width
 
       function onMouseMove(moveEvent: MouseEvent) {
-        const deltaX = startX - moveEvent.clientX
-        const newWidth = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startWidth + deltaX))
-        setWidth(newWidth)
+        const delta = startX - moveEvent.clientX
+        setWidth(Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startWidth + delta)))
       }
 
       function onMouseUp() {
@@ -80,13 +70,8 @@ export function SpreadsheetPane({ selectedNodeIds }: { selectedNodeIds: string[]
     [width, setWidth]
   )
 
-  // Pin/unpin handler
   const handleTogglePin = useCallback(() => {
-    if (pinnedNodeId) {
-      setPinnedNodeId(null)
-    } else if (targetNodeId) {
-      setPinnedNodeId(targetNodeId)
-    }
+    setPinnedNodeId(pinnedNodeId ? null : targetNodeId)
   }, [pinnedNodeId, targetNodeId, setPinnedNodeId])
 
   if (!visible) return null
@@ -116,7 +101,7 @@ export function SpreadsheetPane({ selectedNodeIds }: { selectedNodeIds: string[]
         {error ? (
           <div className={s.emptyState}>{error}</div>
         ) : targetNodeId ? (
-          <SpreadsheetViewer data={data} />
+          <SpreadsheetViewer data={data} operatorId={targetNodeId} />
         ) : (
           <div className={s.emptyState}>Select a node to view its data</div>
         )}

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.tsx
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-pane.tsx
@@ -32,6 +32,10 @@ export function SpreadsheetPane({ selectedNodeIds }: { selectedNodeIds: string[]
     const op = getOp(targetNodeId)
     if (!op) {
       setError('Operator not found')
+      // Clear pinned node if it was deleted
+      if (pinnedNodeId) {
+        setPinnedNodeId(null)
+      }
       return
     }
 
@@ -50,7 +54,7 @@ export function SpreadsheetPane({ selectedNodeIds }: { selectedNodeIds: string[]
     return () => {
       subscriptionRef.current?.unsubscribe()
     }
-  }, [visible, targetNodeId])
+  }, [visible, targetNodeId, pinnedNodeId, setPinnedNodeId])
 
   // Resize handling
   const handleResizeMouseDown = useCallback(

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-store.test.ts
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-store.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useUIStore } from '../../store'
+
+describe('UIStore — spreadsheet state', () => {
+  beforeEach(() => {
+    // Reset spreadsheet-related store state before each test
+    useUIStore.setState({
+      spreadsheetVisible: false,
+      spreadsheetWidth: 400,
+      pinnedSpreadsheetNodeId: null,
+    })
+    localStorage.removeItem('noodles-spreadsheet-width')
+  })
+
+  it('initializes spreadsheetVisible as false', () => {
+    expect(useUIStore.getState().spreadsheetVisible).toBe(false)
+  })
+
+  it('setSpreadsheetVisible updates state', () => {
+    useUIStore.getState().setSpreadsheetVisible(true)
+    expect(useUIStore.getState().spreadsheetVisible).toBe(true)
+    useUIStore.getState().setSpreadsheetVisible(false)
+    expect(useUIStore.getState().spreadsheetVisible).toBe(false)
+  })
+
+  it('initializes pinnedSpreadsheetNodeId as null', () => {
+    expect(useUIStore.getState().pinnedSpreadsheetNodeId).toBeNull()
+  })
+
+  it('setPinnedSpreadsheetNodeId updates state', () => {
+    useUIStore.getState().setPinnedSpreadsheetNodeId('/my-op')
+    expect(useUIStore.getState().pinnedSpreadsheetNodeId).toBe('/my-op')
+    useUIStore.getState().setPinnedSpreadsheetNodeId(null)
+    expect(useUIStore.getState().pinnedSpreadsheetNodeId).toBeNull()
+  })
+
+  it('spreadsheetWidth defaults to 400', () => {
+    expect(useUIStore.getState().spreadsheetWidth).toBe(400)
+  })
+
+  it('setSpreadsheetWidth updates state', () => {
+    useUIStore.getState().setSpreadsheetWidth(550)
+    expect(useUIStore.getState().spreadsheetWidth).toBe(550)
+  })
+
+  it('setSpreadsheetWidth writes to localStorage', () => {
+    useUIStore.getState().setSpreadsheetWidth(600)
+    expect(localStorage.getItem('noodles-spreadsheet-width')).toBe('600')
+  })
+
+  it('setSpreadsheetWidth silently handles localStorage errors', () => {
+    vi.spyOn(localStorage, 'setItem').mockImplementationOnce(() => {
+      throw new Error('QuotaExceededError')
+    })
+    expect(() => useUIStore.getState().setSpreadsheetWidth(300)).not.toThrow()
+    expect(useUIStore.getState().spreadsheetWidth).toBe(300)
+    vi.restoreAllMocks()
+  })
+
+  it('setSpreadsheetWidth clamps to valid number', () => {
+    useUIStore.getState().setSpreadsheetWidth(700)
+    expect(useUIStore.getState().spreadsheetWidth).toBe(700)
+  })
+})

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.module.css
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.module.css
@@ -1,0 +1,123 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border);
+  position: relative;
+}
+
+.rowCount {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.toolbarButton {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+}
+
+.toolbarButton:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.visibilityMenu {
+  position: absolute;
+  top: 100%;
+  right: 12px;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 8px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.visibilityItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.visibilityItem:hover {
+  background: var(--color-bg-hover);
+}
+
+.tableWrapper {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.table thead {
+  position: sticky;
+  top: 0;
+  background: var(--color-bg-elevated);
+  z-index: 1;
+}
+
+.table th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+.sortableHeader {
+  cursor: pointer;
+  user-select: none;
+}
+
+.sortableHeader:hover {
+  background: var(--color-bg-hover);
+}
+
+.table td {
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  color: var(--color-text-primary);
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.table tbody tr:hover {
+  background: var(--color-bg-hover);
+}
+
+.emptyState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.test.tsx
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.test.tsx
@@ -1,0 +1,175 @@
+import { cleanup, render, screen, fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpreadsheetViewer } from './spreadsheet-viewer'
+
+// CSS modules
+vi.mock('./spreadsheet-viewer.module.css', () => ({
+  default: new Proxy({}, { get: (_, prop) => String(prop) }),
+}))
+
+// @tanstack/react-virtual needs a scroll container with measurable height
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count, estimateSize }: { count: number; estimateSize: () => number }) => {
+    const size = estimateSize()
+    const items = Array.from({ length: count }, (_, i) => ({
+      index: i,
+      start: i * size,
+      end: (i + 1) * size,
+      size,
+      key: i,
+      lane: 0,
+    }))
+    return {
+      getVirtualItems: () => items,
+      getTotalSize: () => count * size,
+    }
+  },
+}))
+
+const SAMPLE_DATA = [
+  { id: 1, name: 'Alice', active: true, score: 3.14 },
+  { id: 2, name: 'Bob', active: false, score: 2.71 },
+  { id: 3, name: 'Carol', active: true, score: 1.41 },
+]
+
+describe('SpreadsheetViewer', () => {
+  afterEach(() => cleanup())
+
+  describe('empty / non-tabular data', () => {
+    it('shows "Not an array" for non-array data', () => {
+      render(<SpreadsheetViewer data={{ foo: 'bar' }} operatorId="/op" />)
+      expect(screen.getByText('Not an array')).toBeTruthy()
+    })
+
+    it('shows "Empty array" for empty array', () => {
+      render(<SpreadsheetViewer data={[]} operatorId="/op" />)
+      expect(screen.getByText('Empty array')).toBeTruthy()
+    })
+
+    it('shows "Not tabular" for array of primitives', () => {
+      render(<SpreadsheetViewer data={[1, 2, 3]} operatorId="/op" />)
+      expect(screen.getByText(/not tabular/i)).toBeTruthy()
+    })
+
+    it('shows null data as empty array message', () => {
+      render(<SpreadsheetViewer data={null} operatorId="/op" />)
+      expect(screen.getByText('Not an array')).toBeTruthy()
+    })
+  })
+
+  describe('table rendering', () => {
+    it('renders column headers from data keys', () => {
+      render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op" />)
+      expect(screen.getByText('id')).toBeTruthy()
+      expect(screen.getByText('name')).toBeTruthy()
+      expect(screen.getByText('active')).toBeTruthy()
+      expect(screen.getByText('score')).toBeTruthy()
+    })
+
+    it('renders row count in toolbar', () => {
+      render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op" />)
+      expect(screen.getByText('3 rows')).toBeTruthy()
+    })
+
+    it('renders string values correctly', () => {
+      render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op" />)
+      expect(screen.getByText('Alice')).toBeTruthy()
+      expect(screen.getByText('Bob')).toBeTruthy()
+    })
+
+    it('renders boolean true as ✓ and false as ✗', () => {
+      render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op" />)
+      const checks = screen.getAllByText('✓')
+      const crosses = screen.getAllByText('✗')
+      expect(checks.length).toBeGreaterThan(0)
+      expect(crosses.length).toBeGreaterThan(0)
+    })
+
+    it('renders float numbers with 2 decimal places', () => {
+      render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op" />)
+      expect(screen.getByText('3.14')).toBeTruthy()
+      expect(screen.getByText('2.71')).toBeTruthy()
+    })
+
+    it('renders integers without decimal places', () => {
+      render(<SpreadsheetViewer data={[{ count: 42 }]} operatorId="/op" />)
+      expect(screen.getByText('42')).toBeTruthy()
+      // No "42.00"
+      expect(screen.queryByText('42.00')).toBeNull()
+    })
+  })
+
+  describe('column visibility', () => {
+    it('shows filter button', () => {
+      render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op" />)
+      // The pi-filter button
+      const btn = screen.getByTitle('Toggle columns')
+      expect(btn).toBeTruthy()
+    })
+
+    it('opens column visibility menu on filter click', () => {
+      render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op" />)
+      fireEvent.click(screen.getByTitle('Toggle columns'))
+      // All column names should appear in the menu checkboxes
+      const checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes.length).toBe(4) // id, name, active, score
+    })
+
+    it('hides a column when its checkbox is unchecked', () => {
+      render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op" />)
+      fireEvent.click(screen.getByTitle('Toggle columns'))
+      const checkboxes = screen.getAllByRole('checkbox')
+      // Uncheck 'name' column (index 1)
+      fireEvent.click(checkboxes[1])
+      // 'Alice' etc. should no longer be in the table cells
+      expect(screen.queryByText('Alice')).toBeNull()
+    })
+  })
+
+  describe('operator switching', () => {
+    it('resets column visibility when operatorId changes', () => {
+      const { rerender } = render(<SpreadsheetViewer data={SAMPLE_DATA} operatorId="/op-a" />)
+      // Hide the 'name' column
+      fireEvent.click(screen.getByTitle('Toggle columns'))
+      const checkboxes = screen.getAllByRole('checkbox')
+      fireEvent.click(checkboxes[1]) // hide 'name'
+      expect(screen.queryByText('Alice')).toBeNull()
+      // Close the menu
+      fireEvent.click(screen.getByTitle('Toggle columns'))
+
+      // Switch operator
+      rerender(
+        <SpreadsheetViewer
+          data={[{ city: 'NYC', pop: 8000000 }]}
+          operatorId="/op-b"
+        />
+      )
+      // New columns visible — 'city' should appear in the header
+      expect(screen.getByRole('columnheader', { name: 'city' })).toBeTruthy()
+      expect(screen.getByText('NYC')).toBeTruthy()
+    })
+  })
+
+  describe('formatCellValue edge cases', () => {
+    it('renders null cells as empty string', () => {
+      render(
+        <SpreadsheetViewer
+          data={[{ value: null }, { value: 'hello' }]}
+          operatorId="/op"
+        />
+      )
+      // 'hello' should be there, no crash on null
+      expect(screen.getByText('hello')).toBeTruthy()
+    })
+
+    it('renders objects as JSON', () => {
+      render(
+        <SpreadsheetViewer
+          data={[{ meta: { x: 1 } }]}
+          operatorId="/op"
+        />
+      )
+      expect(screen.getByText('{"x":1}')).toBeTruthy()
+    })
+  })
+})

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.tsx
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.tsx
@@ -6,7 +6,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ColumnSchema } from '../../table-schema'
 import { inferSchema } from '../../table-schema'
 import s from './spreadsheet-viewer.module.css'
@@ -17,6 +17,7 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({})
   const [visibilityMenuOpen, setVisibilityMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
 
   // Validate data is array of objects
   const { rows, schema } = useMemo(() => {
@@ -65,6 +66,20 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
     getSortedRowModel: getSortedRowModel(),
   })
 
+  // Close visibility menu when clicking outside
+  useEffect(() => {
+    if (!visibilityMenuOpen) return
+
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setVisibilityMenuOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [visibilityMenuOpen])
+
   if (!schema || rows.length === 0) {
     return (
       <div className={s.emptyState}>
@@ -90,7 +105,7 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
           <i className="pi pi-filter" />
         </button>
         {visibilityMenuOpen && (
-          <div className={s.visibilityMenu}>
+          <div ref={menuRef} className={s.visibilityMenu}>
             {schema.columns.map(col => (
               <label key={col.name} className={s.visibilityItem}>
                 <input
@@ -156,7 +171,11 @@ function formatCellValue(value: unknown, column: ColumnSchema): string {
 
   switch (column.type) {
     case 'number':
-      return typeof value === 'number' ? value.toFixed(2) : String(value)
+      return typeof value === 'number'
+        ? Number.isInteger(value)
+          ? String(value)
+          : value.toFixed(2)
+        : String(value)
     case 'boolean':
       return value ? '✓' : ''
     case 'color':

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.tsx
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.tsx
@@ -6,6 +6,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ColumnSchema } from '../../table-schema'
 import { inferSchema } from '../../table-schema'
@@ -13,42 +14,41 @@ import s from './spreadsheet-viewer.module.css'
 
 const columnHelper = createColumnHelper<Record<string, unknown>>()
 
-export function SpreadsheetViewer({ data }: { data: unknown }) {
+export function SpreadsheetViewer({
+  data,
+  operatorId,
+}: {
+  data: unknown
+  operatorId: string
+}) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({})
   const [visibilityMenuOpen, setVisibilityMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  const tableContainerRef = useRef<HTMLDivElement>(null)
 
-  // Validate data is array of objects
+  // Reset sort/visibility when switching to a different operator
+  useEffect(() => {
+    setSorting([])
+    setColumnVisibility({})
+  }, [operatorId])
+
   const { rows, schema } = useMemo(() => {
-    if (!Array.isArray(data) || data.length === 0) {
-      return { rows: [], schema: null }
-    }
-
-    const firstRow = data[0]
-    if (typeof firstRow !== 'object' || firstRow === null) {
-      return { rows: [], schema: null }
-    }
-
+    if (!Array.isArray(data) || data.length === 0) return { rows: [], schema: null }
+    if (typeof data[0] !== 'object' || data[0] === null) return { rows: [], schema: null }
     try {
-      const inferredSchema = inferSchema(data)
-      return { rows: data, schema: inferredSchema }
+      return { rows: data as Record<string, unknown>[], schema: inferSchema(data) }
     } catch {
       return { rows: [], schema: null }
     }
   }, [data])
 
-  // Build columns from schema
   const columns = useMemo(() => {
     if (!schema) return []
-
     return schema.columns.map(col =>
       columnHelper.accessor(col.name, {
         header: col.name,
-        cell: info => {
-          const value = info.getValue()
-          return formatCellValue(value, col)
-        },
+        cell: info => formatCellValue(info.getValue(), col),
       })
     )
   }, [schema])
@@ -56,26 +56,38 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
   const table = useReactTable({
     data: rows,
     columns,
-    state: {
-      sorting,
-      columnVisibility,
-    },
+    state: { sorting, columnVisibility },
     onSortingChange: setSorting,
     onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   })
 
+  const tableRows = table.getRowModel().rows
+
+  const rowVirtualizer = useVirtualizer({
+    count: tableRows.length,
+    getScrollElement: () => tableContainerRef.current,
+    estimateSize: () => 30,
+    overscan: 10,
+  })
+
+  const virtualItems = rowVirtualizer.getVirtualItems()
+  const totalSize = rowVirtualizer.getTotalSize()
+  const paddingTop = virtualItems.length > 0 ? (virtualItems[0]?.start ?? 0) : 0
+  const paddingBottom =
+    virtualItems.length > 0
+      ? totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0)
+      : 0
+
   // Close visibility menu when clicking outside
   useEffect(() => {
     if (!visibilityMenuOpen) return
-
     function handleClickOutside(e: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setVisibilityMenuOpen(false)
       }
     }
-
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [visibilityMenuOpen])
@@ -95,7 +107,7 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
   return (
     <div className={s.container}>
       <div className={s.toolbar}>
-        <span className={s.rowCount}>{rows.length} rows</span>
+        <span className={s.rowCount}>{rows.length.toLocaleString()} rows</span>
         <button
           type="button"
           className={s.toolbarButton}
@@ -112,10 +124,7 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
                   type="checkbox"
                   checked={columnVisibility[col.name] !== false}
                   onChange={e =>
-                    setColumnVisibility(prev => ({
-                      ...prev,
-                      [col.name]: e.target.checked,
-                    }))
+                    setColumnVisibility(prev => ({ ...prev, [col.name]: e.target.checked }))
                   }
                 />
                 <span>{col.name}</span>
@@ -124,7 +133,7 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
           </div>
         )}
       </div>
-      <div className={s.tableWrapper}>
+      <div ref={tableContainerRef} className={s.tableWrapper}>
         <table className={s.table}>
           <thead>
             {table.getHeaderGroups().map(headerGroup => (
@@ -139,7 +148,9 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
                     {header.column.getIsSorted() && (
                       <i
                         className={
-                          header.column.getIsSorted() === 'asc' ? 'pi pi-sort-up' : 'pi pi-sort-down'
+                          header.column.getIsSorted() === 'asc'
+                            ? 'pi pi-sort-up'
+                            : 'pi pi-sort-down'
                         }
                         style={{ marginLeft: '4px', fontSize: '10px' }}
                       />
@@ -150,15 +161,28 @@ export function SpreadsheetViewer({ data }: { data: unknown }) {
             ))}
           </thead>
           <tbody>
-            {table.getRowModel().rows.map(row => (
-              <tr key={row.id}>
-                {row.getVisibleCells().map(cell => (
-                  <td key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
+            {paddingTop > 0 && (
+              <tr>
+                <td style={{ height: paddingTop }} />
               </tr>
-            ))}
+            )}
+            {virtualItems.map(virtualRow => {
+              const row = tableRows[virtualRow.index]
+              return (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map(cell => (
+                    <td key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              )
+            })}
+            {paddingBottom > 0 && (
+              <tr>
+                <td style={{ height: paddingBottom }} />
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
@@ -173,20 +197,17 @@ function formatCellValue(value: unknown, column: ColumnSchema): string {
     case 'number':
       return typeof value === 'number'
         ? Number.isInteger(value)
-          ? String(value)
+          ? value.toLocaleString()
           : value.toFixed(2)
         : String(value)
     case 'boolean':
-      return value ? '✓' : ''
+      return value ? '✓' : '✗'
     case 'color':
       return typeof value === 'string' ? value : JSON.stringify(value)
     case 'date':
     case 'dateTime':
       return String(value)
     default:
-      if (typeof value === 'object') {
-        return JSON.stringify(value)
-      }
-      return String(value)
+      return typeof value === 'object' ? JSON.stringify(value) : String(value)
   }
 }

--- a/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.tsx
+++ b/noodles-editor/src/noodles/components/spreadsheet-pane/spreadsheet-viewer.tsx
@@ -1,0 +1,173 @@
+import {
+  type SortingState,
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { useMemo, useState } from 'react'
+import type { ColumnSchema } from '../../table-schema'
+import { inferSchema } from '../../table-schema'
+import s from './spreadsheet-viewer.module.css'
+
+const columnHelper = createColumnHelper<Record<string, unknown>>()
+
+export function SpreadsheetViewer({ data }: { data: unknown }) {
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({})
+  const [visibilityMenuOpen, setVisibilityMenuOpen] = useState(false)
+
+  // Validate data is array of objects
+  const { rows, schema } = useMemo(() => {
+    if (!Array.isArray(data) || data.length === 0) {
+      return { rows: [], schema: null }
+    }
+
+    const firstRow = data[0]
+    if (typeof firstRow !== 'object' || firstRow === null) {
+      return { rows: [], schema: null }
+    }
+
+    try {
+      const inferredSchema = inferSchema(data)
+      return { rows: data, schema: inferredSchema }
+    } catch {
+      return { rows: [], schema: null }
+    }
+  }, [data])
+
+  // Build columns from schema
+  const columns = useMemo(() => {
+    if (!schema) return []
+
+    return schema.columns.map(col =>
+      columnHelper.accessor(col.name, {
+        header: col.name,
+        cell: info => {
+          const value = info.getValue()
+          return formatCellValue(value, col)
+        },
+      })
+    )
+  }, [schema])
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: {
+      sorting,
+      columnVisibility,
+    },
+    onSortingChange: setSorting,
+    onColumnVisibilityChange: setColumnVisibility,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  })
+
+  if (!schema || rows.length === 0) {
+    return (
+      <div className={s.emptyState}>
+        {!Array.isArray(data)
+          ? 'Not an array'
+          : data.length === 0
+            ? 'Empty array'
+            : 'Data is not tabular (must be array of objects)'}
+      </div>
+    )
+  }
+
+  return (
+    <div className={s.container}>
+      <div className={s.toolbar}>
+        <span className={s.rowCount}>{rows.length} rows</span>
+        <button
+          type="button"
+          className={s.toolbarButton}
+          onClick={() => setVisibilityMenuOpen(!visibilityMenuOpen)}
+          title="Toggle columns"
+        >
+          <i className="pi pi-filter" />
+        </button>
+        {visibilityMenuOpen && (
+          <div className={s.visibilityMenu}>
+            {schema.columns.map(col => (
+              <label key={col.name} className={s.visibilityItem}>
+                <input
+                  type="checkbox"
+                  checked={columnVisibility[col.name] !== false}
+                  onChange={e =>
+                    setColumnVisibility(prev => ({
+                      ...prev,
+                      [col.name]: e.target.checked,
+                    }))
+                  }
+                />
+                <span>{col.name}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className={s.tableWrapper}>
+        <table className={s.table}>
+          <thead>
+            {table.getHeaderGroups().map(headerGroup => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map(header => (
+                  <th
+                    key={header.id}
+                    className={header.column.getCanSort() ? s.sortableHeader : undefined}
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.column.getIsSorted() && (
+                      <i
+                        className={
+                          header.column.getIsSorted() === 'asc' ? 'pi pi-sort-up' : 'pi pi-sort-down'
+                        }
+                        style={{ marginLeft: '4px', fontSize: '10px' }}
+                      />
+                    )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map(row => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map(cell => (
+                  <td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function formatCellValue(value: unknown, column: ColumnSchema): string {
+  if (value == null) return ''
+
+  switch (column.type) {
+    case 'number':
+      return typeof value === 'number' ? value.toFixed(2) : String(value)
+    case 'boolean':
+      return value ? '✓' : ''
+    case 'color':
+      return typeof value === 'string' ? value : JSON.stringify(value)
+    case 'date':
+    case 'dateTime':
+      return String(value)
+    default:
+      if (typeof value === 'object') {
+        return JSON.stringify(value)
+      }
+      return String(value)
+  }
+}

--- a/noodles-editor/src/noodles/components/top-menu-bar.tsx
+++ b/noodles-editor/src/noodles/components/top-menu-bar.tsx
@@ -42,6 +42,8 @@ interface TopMenuBarProps {
   onChangeShowOverlay?: (show: boolean) => void
   showDebugInfo?: boolean
   onChangeShowDebugInfo?: (show: boolean) => void
+  spreadsheetVisible?: boolean
+  onChangeSpreadsheetVisible?: (show: boolean) => void
   layoutMode?: 'split' | 'noodles-on-top' | 'output-on-top'
   onChangeLayoutMode?: (mode: 'split' | 'noodles-on-top' | 'output-on-top') => void
   reactFlowRef?: RefObject<HTMLDivElement>
@@ -69,6 +71,8 @@ export function TopMenuBar({
   onChangeShowOverlay,
   showDebugInfo,
   onChangeShowDebugInfo,
+  spreadsheetVisible,
+  onChangeSpreadsheetVisible,
   layoutMode,
   onChangeLayoutMode,
   reactFlowRef,
@@ -436,6 +440,16 @@ export function TopMenuBar({
                           <i className="pi pi-check" style={{ fontSize: '12px' }} />
                         </DropdownMenu.ItemIndicator>
                         Show editor debug info
+                      </DropdownMenu.CheckboxItem>
+                      <DropdownMenu.CheckboxItem
+                        className={s.dropdownItem}
+                        checked={spreadsheetVisible}
+                        onCheckedChange={onChangeSpreadsheetVisible}
+                      >
+                        <DropdownMenu.ItemIndicator className={s.itemIndicator}>
+                          <i className="pi pi-check" style={{ fontSize: '12px' }} />
+                        </DropdownMenu.ItemIndicator>
+                        Show spreadsheet
                       </DropdownMenu.CheckboxItem>
 
                       <DropdownMenu.Separator className={s.dropdownSeparator} />

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -1739,7 +1739,7 @@ export function getNoodles(): Visualization {
     onChangeShowOverlay: setShowOverlay,
     showDebugInfo,
     onChangeShowDebugInfo: setShowDebugInfo,
-    spreadsheetVisible: useUIStore.getState().spreadsheetVisible,
+    spreadsheetVisible: useUIStore(state => state.spreadsheetVisible),
     onChangeSpreadsheetVisible: (visible: boolean) => {
       useUIStore.getState().setSpreadsheetVisible(visible)
       // Auto-switch to split mode when enabling spreadsheet

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -1727,6 +1727,7 @@ export function getNoodles(): Visualization {
 
   return {
     flowGraph,
+    selectedNodeIds: nodes.filter(n => n.selected).map(n => n.id),
     nodeSidebar: (
       <ErrorBoundary title="Node Tree Error">
         <NodeTreeSidebar updateOperatorId={updateOperatorId} />

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -1739,6 +1739,14 @@ export function getNoodles(): Visualization {
     onChangeShowOverlay: setShowOverlay,
     showDebugInfo,
     onChangeShowDebugInfo: setShowDebugInfo,
+    spreadsheetVisible: useUIStore.getState().spreadsheetVisible,
+    onChangeSpreadsheetVisible: (visible: boolean) => {
+      useUIStore.getState().setSpreadsheetVisible(visible)
+      // Auto-switch to split mode when enabling spreadsheet
+      if (visible && layoutMode !== 'split') {
+        setLayoutMode('split')
+      }
+    },
     // Render settings are now read from OutOp via useRenderSettings() hook
     // Export these so timeline-editor can create the menu with render actions
     projectName:

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -407,6 +407,9 @@ export function getNoodles(): Visualization {
     [setEdges]
   )
 
+  const spreadsheetVisible = useUIStore(state => state.spreadsheetVisible)
+  const setSpreadsheetVisible = useUIStore(state => state.setSpreadsheetVisible)
+
   // Track connection drag state for dimming unconnectable nodes
   const setConnectionDragState = useUIStore(state => state.setConnectionDragState)
   const connectionDragState = useUIStore(state => state.connectionDragState)
@@ -1740,14 +1743,14 @@ export function getNoodles(): Visualization {
     onChangeShowOverlay: setShowOverlay,
     showDebugInfo,
     onChangeShowDebugInfo: setShowDebugInfo,
-    spreadsheetVisible: useUIStore(state => state.spreadsheetVisible),
-    onChangeSpreadsheetVisible: (visible: boolean) => {
-      useUIStore.getState().setSpreadsheetVisible(visible)
-      // Auto-switch to split mode when enabling spreadsheet
-      if (visible && layoutMode !== 'split') {
-        setLayoutMode('split')
-      }
-    },
+    spreadsheetVisible,
+    onChangeSpreadsheetVisible: useCallback(
+      (visible: boolean) => {
+        setSpreadsheetVisible(visible)
+        if (visible && layoutMode !== 'split') setLayoutMode('split')
+      },
+      [setSpreadsheetVisible, layoutMode, setLayoutMode]
+    ),
     // Render settings are now read from OutOp via useRenderSettings() hook
     // Export these so timeline-editor can create the menu with render actions
     projectName:

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -1749,7 +1749,7 @@ export function getNoodles(): Visualization {
         setSpreadsheetVisible(visible)
         if (visible && layoutMode !== 'split') setLayoutMode('split')
       },
-      [setSpreadsheetVisible, layoutMode, setLayoutMode]
+      [setSpreadsheetVisible, layoutMode]
     ),
     // Render settings are now read from OutOp via useRenderSettings() hook
     // Export these so timeline-editor can create the menu with render actions

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -1,5 +1,5 @@
-import { Temporal } from 'temporal-polyfill'
 import * as turf from '@turf/turf'
+import { Temporal } from 'temporal-polyfill'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NumberField } from './fields'
 import {

--- a/noodles-editor/src/noodles/store.tsx
+++ b/noodles-editor/src/noodles/store.tsx
@@ -138,6 +138,12 @@ interface UIStoreState {
   setTimelineHeight: (height: number) => void
   quickStartModalOpen: boolean
   setQuickStartModalOpen: (open: boolean) => void
+  spreadsheetVisible: boolean
+  setSpreadsheetVisible: (visible: boolean) => void
+  pinnedSpreadsheetNodeId: string | null
+  setPinnedSpreadsheetNodeId: (id: string | null) => void
+  spreadsheetWidth: number
+  setSpreadsheetWidth: (width: number) => void
 }
 
 export const useUIStore = create<UIStoreState>(set => ({
@@ -162,6 +168,20 @@ export const useUIStore = create<UIStoreState>(set => ({
   setTimelineHeight: height => set({ timelineHeight: height }),
   quickStartModalOpen: false,
   setQuickStartModalOpen: open => set({ quickStartModalOpen: open }),
+  spreadsheetVisible: false,
+  setSpreadsheetVisible: visible => set({ spreadsheetVisible: visible }),
+  pinnedSpreadsheetNodeId: null,
+  setPinnedSpreadsheetNodeId: id => set({ pinnedSpreadsheetNodeId: id }),
+  spreadsheetWidth:
+    typeof window !== 'undefined'
+      ? Number(localStorage.getItem('noodles-spreadsheet-width')) || 400
+      : 400,
+  setSpreadsheetWidth: width => {
+    set({ spreadsheetWidth: width })
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('noodles-spreadsheet-width', String(width))
+    }
+  },
 }))
 
 // ============================================================================

--- a/noodles-editor/src/noodles/store.tsx
+++ b/noodles-editor/src/noodles/store.tsx
@@ -172,15 +172,12 @@ export const useUIStore = create<UIStoreState>(set => ({
   setSpreadsheetVisible: visible => set({ spreadsheetVisible: visible }),
   pinnedSpreadsheetNodeId: null,
   setPinnedSpreadsheetNodeId: id => set({ pinnedSpreadsheetNodeId: id }),
-  spreadsheetWidth:
-    typeof window !== 'undefined'
-      ? Number(localStorage.getItem('noodles-spreadsheet-width')) || 400
-      : 400,
+  spreadsheetWidth: 400,
   setSpreadsheetWidth: width => {
     set({ spreadsheetWidth: width })
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('noodles-spreadsheet-width', String(width))
-    }
+    try {
+      localStorage?.setItem('noodles-spreadsheet-width', String(width))
+    } catch {}
   },
 }))
 

--- a/noodles-editor/src/noodles/store.tsx
+++ b/noodles-editor/src/noodles/store.tsx
@@ -172,11 +172,18 @@ export const useUIStore = create<UIStoreState>(set => ({
   setSpreadsheetVisible: visible => set({ spreadsheetVisible: visible }),
   pinnedSpreadsheetNodeId: null,
   setPinnedSpreadsheetNodeId: id => set({ pinnedSpreadsheetNodeId: id }),
-  spreadsheetWidth: 400,
+  spreadsheetWidth: (() => {
+    try {
+      const stored = localStorage.getItem('noodles-spreadsheet-width')
+      return stored ? Number(stored) : 400
+    } catch {
+      return 400
+    }
+  })(),
   setSpreadsheetWidth: width => {
     set({ spreadsheetWidth: width })
     try {
-      localStorage?.setItem('noodles-spreadsheet-width', String(width))
+      localStorage.setItem('noodles-spreadsheet-width', String(width))
     } catch {}
   },
 }))

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -7,6 +7,7 @@ import { forwardRef, useCallback, useEffect, useRef, useState } from 'react'
 import ReactMapGL, { type MapProps, useControl } from 'react-map-gl/maplibre'
 import { Layout } from './layout'
 import { ErrorBoundary } from './noodles/components/error-boundary'
+import { SpreadsheetPane } from './noodles/components/spreadsheet-pane/spreadsheet-pane'
 import { TopMenuBar } from './noodles/components/top-menu-bar'
 import { ExportActionsProvider } from './noodles/contexts/export-actions-context'
 import { useActiveStorageType, useCurrentDirectory } from './noodles/filesystem-store'
@@ -89,6 +90,9 @@ export default function TimelineEditor() {
 
   const noodles = getNoodles()
   const { flowGraph, nodeSidebar, propertiesPanel, layoutMode, ...visualization } = noodles
+
+  // Get selected nodes for spreadsheet pane
+  const selectedNodeIds = noodles.nodes.filter(n => n.selected).map(n => n.id)
 
   // Render settings are now stored as OutOp inputs
   const renderSettings = useRenderSettings()
@@ -576,6 +580,8 @@ export default function TimelineEditor() {
       onChangeShowOverlay={noodles.onChangeShowOverlay}
       showDebugInfo={noodles.showDebugInfo}
       onChangeShowDebugInfo={noodles.onChangeShowDebugInfo}
+      spreadsheetVisible={noodles.spreadsheetVisible}
+      onChangeSpreadsheetVisible={noodles.onChangeSpreadsheetVisible}
       layoutMode={noodles.layoutMode}
       onChangeLayoutMode={noodles.onChangeLayoutMode}
     />
@@ -606,6 +612,7 @@ export default function TimelineEditor() {
             right={propertiesPanel}
             bottom={<CollapsibleTimelinePanel />}
             flowGraph={flowGraph}
+            spreadsheet={<SpreadsheetPane selectedNodeIds={selectedNodeIds} />}
             layoutMode={layoutMode}
           >
             {isFixedMode ? (

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -89,10 +89,8 @@ export default function TimelineEditor() {
   }, [])
 
   const noodles = getNoodles()
-  const { flowGraph, nodeSidebar, propertiesPanel, layoutMode, ...visualization } = noodles
-
-  // Get selected nodes for spreadsheet pane
-  const selectedNodeIds = noodles.nodes.filter(n => n.selected).map(n => n.id)
+  const { flowGraph, nodeSidebar, propertiesPanel, layoutMode, selectedNodeIds, ...visualization } =
+    noodles
 
   // Render settings are now stored as OutOp inputs
   const renderSettings = useRenderSettings()

--- a/noodles-editor/src/visualizations.ts
+++ b/noodles-editor/src/visualizations.ts
@@ -34,6 +34,9 @@ export type Visualization = {
   onChangeShowOverlay?: (show: boolean) => void
   showDebugInfo?: boolean
   onChangeShowDebugInfo?: (show: boolean) => void
+  spreadsheetVisible?: boolean
+  onChangeSpreadsheetVisible?: (visible: boolean) => void
+  selectedNodeIds?: string[]
   // Noodles props for creating menu in timeline-editor
   projectName?: string
   getTimelineJson?: () => Record<string, unknown>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8206,6 +8206,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
@@ -8214,6 +8231,16 @@
       "engines": {
         "node": ">=12"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -27309,6 +27336,7 @@
         "@radix-ui/react-menubar": "^1.1.16",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.14.5",
         "@tmcw/togeojson": "^7.1.2",
         "@turf/turf": "^7.3.4",
         "@types/rbush": "^4.0.0",


### PR DESCRIPTION
#### Background

Add a Blender/Houdini-style spreadsheet pane to inspect tabular data from operators, similar to Blender's Geometry Nodes spreadsheet and Houdini's Geometry Spreadsheet pane.

#### Change List
- Added Spreadsheet pane component with selection tracking and pin/unpin functionality
- Integrated TanStack Table for sorting and column visibility controls
- Added horizontal split layout (node graph left, spreadsheet right) with resizable width
- Added Zustand state management for visibility, pinned node, and width persistence
- Added "Show spreadsheet" toggle in Editor menu that auto-switches to split layout
- Created SpreadsheetPane and SpreadsheetViewer components with type-aware cell formatting
- Updated Layout component to support spreadsheet alongside node graph
- Handles edge cases: no selection, non-tabular data, empty arrays, deleted pinned operators

<img width="1241" height="546" alt="image" src="https://github.com/user-attachments/assets/bfad8855-6082-43f3-8fd4-4139cd529767" />
