### PR TITLE
fix: use npm instead of yarn in conductor.json

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "setup": "(cd noodles-editor && yarn)",
-        "run": "(cd noodles-editor && yarn start)"
+        "setup": "(cd noodles-editor && npm install)",
+        "run": "(cd noodles-editor && npm start)"
     }
 }


### PR DESCRIPTION
#### Background

The project specifies `npm@11.6.1` in `package.json`'s `packageManager` field, which causes yarn to refuse to run. The Conductor setup script was failing because of this mismatch.

#### Change List
- Switch `conductor.json` setup and run scripts from `yarn` to `npm` to match the project's configured package manager