### PR TITLE
fix: skip connected fields in property history to prevent stringify overflow

### DIFF
--- a/noodles-editor/src/noodles/utils/property-history.test.ts
+++ b/noodles-editor/src/noodles/utils/property-history.test.ts
@@ -291,6 +291,111 @@ describe('registerPropertyMutationCallback and firePropertyMutation', () => {
   })
 })
 
+describe('captureOperatorInputs skips connected fields', () => {
+  it('excludes fields that have active subscriptions (connected inputs)', () => {
+    const connectedField = {
+      serialize: vi.fn(() => Array.from({ length: 50000 }, (_, i) => ({ id: i }))),
+      setValue: vi.fn(),
+      subscriptions: new Map([['edge-1', {}]]),
+    }
+    const localField = mockField(20)
+    const op = mockOp('/scatter', { data: connectedField, getRadius: localField })
+    mockedGetAllOps.mockReturnValue([op as never])
+
+    const result = captureOperatorInputs()
+    const parsed = JSON.parse(result)
+
+    expect(parsed['/scatter'].getRadius).toBe(20)
+    expect(parsed['/scatter'].data).toBeUndefined()
+    expect(connectedField.serialize).not.toHaveBeenCalled()
+  })
+
+  it('includes fields with empty subscriptions (no connections)', () => {
+    const field = {
+      serialize: vi.fn(() => 'test-value'),
+      setValue: vi.fn(),
+      subscriptions: new Map(),
+    }
+    const op = mockOp('/op', { name: field })
+    mockedGetAllOps.mockReturnValue([op as never])
+
+    const result = captureOperatorInputs()
+    const parsed = JSON.parse(result)
+
+    expect(parsed['/op'].name).toBe('test-value')
+  })
+
+  it('includes fields without subscriptions property (legacy/interface fields)', () => {
+    const field = mockField('hello')
+    const op = mockOp('/op', { text: field })
+    mockedGetAllOps.mockReturnValue([op as never])
+
+    const result = captureOperatorInputs()
+    const parsed = JSON.parse(result)
+
+    expect(parsed['/op'].text).toBe('hello')
+  })
+})
+
+describe('captureOperatorInputs performance', () => {
+  it('completes in under 50ms even with many operators and large connected data', () => {
+    const ops = Array.from({ length: 50 }, (_, i) => {
+      const connectedDataField = {
+        serialize: vi.fn(() => Array.from({ length: 100000 }, () => ({ x: 1, y: 2 }))),
+        setValue: vi.fn(),
+        subscriptions: new Map([['edge', {}]]),
+      }
+      const localField = mockField(i)
+      return mockOp(`/op-${i}`, { data: connectedDataField, value: localField })
+    })
+    mockedGetAllOps.mockReturnValue(ops as never[])
+
+    const start = performance.now()
+    const result = captureOperatorInputs()
+    const elapsed = performance.now() - start
+
+    expect(elapsed).toBeLessThan(50)
+    const parsed = JSON.parse(result)
+    expect(Object.keys(parsed)).toHaveLength(50)
+    expect(parsed['/op-0'].value).toBe(0)
+    expect(parsed['/op-0'].data).toBeUndefined()
+  })
+
+  it('does not call serialize() on connected fields', () => {
+    const expensiveSerialize = vi.fn(() => {
+      throw new Error('Should not be called')
+    })
+    const connectedField = {
+      serialize: expensiveSerialize,
+      setValue: vi.fn(),
+      subscriptions: new Map([['edge-1', {}]]),
+    }
+    const op = mockOp('/op', { bigData: connectedField, radius: mockField(5) })
+    mockedGetAllOps.mockReturnValue([op as never])
+
+    const result = captureOperatorInputs()
+    const parsed = JSON.parse(result)
+
+    expect(expensiveSerialize).not.toHaveBeenCalled()
+    expect(parsed['/op'].radius).toBe(5)
+  })
+
+  it('returns empty JSON object when stringify would throw', () => {
+    const circular: any = {}
+    circular.self = circular
+    const field = {
+      serialize: vi.fn(() => circular),
+      setValue: vi.fn(),
+      subscriptions: new Map(),
+    }
+    const op = mockOp('/op', { bad: field })
+    mockedGetAllOps.mockReturnValue([op as never])
+
+    const result = captureOperatorInputs()
+    expect(result).toBe('{}')
+  })
+})
+
 describe('captureOperatorInputs + applyOperatorInputs round-trip', () => {
   it('restores field values to their captured state', () => {
     const field = mockField(42)

--- a/noodles-editor/src/noodles/utils/property-history.test.ts
+++ b/noodles-editor/src/noodles/utils/property-history.test.ts
@@ -380,7 +380,7 @@ describe('captureOperatorInputs performance', () => {
     expect(parsed['/op'].radius).toBe(5)
   })
 
-  it('returns empty JSON object when stringify would throw', () => {
+  it('returns null when stringify would throw', () => {
     const circular: any = {}
     circular.self = circular
     const field = {
@@ -392,7 +392,37 @@ describe('captureOperatorInputs performance', () => {
     mockedGetAllOps.mockReturnValue([op as never])
 
     const result = captureOperatorInputs()
-    expect(result).toBe('{}')
+    expect(result).toBeNull()
+  })
+
+  it('firePropertyMutation skips recording when before is null', () => {
+    const callback = vi.fn()
+    registerPropertyMutationCallback(callback)
+
+    mockedGetAllOps.mockReturnValue([
+      { id: '/op', inputs: { x: { serialize: () => 10, subscriptions: new Map() } } } as never,
+    ])
+
+    firePropertyMutation('Change value', null)
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('firePropertyMutation skips recording when after capture returns null', () => {
+    const callback = vi.fn()
+    registerPropertyMutationCallback(callback)
+
+    const circular: any = {}
+    circular.self = circular
+    const field = {
+      serialize: vi.fn(() => circular),
+      setValue: vi.fn(),
+      subscriptions: new Map(),
+    }
+    const op = mockOp('/op', { bad: field })
+    mockedGetAllOps.mockReturnValue([op as never])
+
+    firePropertyMutation('Change value', JSON.stringify({ '/op': { bad: 'old' } }))
+    expect(callback).not.toHaveBeenCalled()
   })
 })
 

--- a/noodles-editor/src/noodles/utils/property-history.ts
+++ b/noodles-editor/src/noodles/utils/property-history.ts
@@ -31,7 +31,7 @@ export function captureOperatorInputs(): string | null {
   try {
     return JSON.stringify(state)
   } catch {
-    debugHistory('State too large to serialize for property history')
+    debugHistory('Failed to serialize state for property history')
     return null
   }
 }

--- a/noodles-editor/src/noodles/utils/property-history.ts
+++ b/noodles-editor/src/noodles/utils/property-history.ts
@@ -16,13 +16,13 @@ export function registerPropertyMutationCallback(cb: PropertyMutationCallback | 
 // Serializes all operator field values using each field's serialize() method.
 // This mirrors captureTimelineState() in timeline-store.ts.
 // Skips connected fields (they receive values from upstream and can hold large datasets).
-export function captureOperatorInputs(): string {
+export function captureOperatorInputs(): string | null {
   const ops = getAllOps()
   const state: Record<string, Record<string, unknown>> = {}
   for (const op of ops) {
     const inputs: Record<string, unknown> = {}
     for (const [name, field] of Object.entries(op.inputs as Record<string, IField>)) {
-      if ((field as any).subscriptions?.size > 0) continue
+      if ('subscriptions' in field && (field as { subscriptions: Map<unknown, unknown> }).subscriptions.size > 0) continue
       inputs[name] = field.serialize()
     }
     state[op.id] = inputs
@@ -32,7 +32,7 @@ export function captureOperatorInputs(): string {
     return JSON.stringify(state)
   } catch {
     debugHistory('State too large to serialize for property history')
-    return '{}'
+    return null
   }
 }
 
@@ -64,10 +64,10 @@ export function applyOperatorInputs(snapshot: string): void {
 // Records a property mutation to the undo/redo history. Captures the "after" state
 // and calls the registered callback with both before and after. Skips if state is unchanged.
 // Mirrors fireTimelineMutation() in timeline-store.ts.
-export function firePropertyMutation(description: string, before: string): void {
-  if (!_propertyMutationCallback) return
+export function firePropertyMutation(description: string, before: string | null): void {
+  if (!_propertyMutationCallback || before === null) return
   const after = captureOperatorInputs()
-  if (before === after) return
+  if (after === null || before === after) return
   _lastCommittedBeforeState = before
   debugHistorySnapshot('Firing property mutation: %s', description)
   _propertyMutationCallback(description, before, after)
@@ -88,7 +88,7 @@ export function usePropertyHistory() {
   }, [])
 
   const commitChange = useCallback((description: string) => {
-    if (beforeRef.current !== null) {
+    if (beforeRef.current) {
       firePropertyMutation(description, beforeRef.current)
       beforeRef.current = null
     }

--- a/noodles-editor/src/noodles/utils/property-history.ts
+++ b/noodles-editor/src/noodles/utils/property-history.ts
@@ -15,18 +15,25 @@ export function registerPropertyMutationCallback(cb: PropertyMutationCallback | 
 
 // Serializes all operator field values using each field's serialize() method.
 // This mirrors captureTimelineState() in timeline-store.ts.
+// Skips connected fields (they receive values from upstream and can hold large datasets).
 export function captureOperatorInputs(): string {
   const ops = getAllOps()
   const state: Record<string, Record<string, unknown>> = {}
   for (const op of ops) {
     const inputs: Record<string, unknown> = {}
     for (const [name, field] of Object.entries(op.inputs as Record<string, IField>)) {
+      if ((field as any).subscriptions?.size > 0) continue
       inputs[name] = field.serialize()
     }
     state[op.id] = inputs
   }
   debugHistorySnapshot('Captured operator inputs for %d ops', ops.length)
-  return JSON.stringify(state)
+  try {
+    return JSON.stringify(state)
+  } catch {
+    debugHistory('State too large to serialize for property history')
+    return '{}'
+  }
 }
 
 // Restores operator field values from a snapshot.


### PR DESCRIPTION
#### Background

`captureOperatorInputs()` (introduced in #362) serializes all operator field values on every focus event for undo/redo history. In projects with large datasets (e.g. CSV files with thousands of rows), connected input fields hold the full upstream data array. Attempting to `JSON.stringify` all of this caused either a `RangeError: Invalid string length` crash or a 10+ second UI freeze.

#### Change List
- Skip fields with active subscriptions (connected inputs) in `captureOperatorInputs()` — these receive values from upstream operators and don't need to be in the property history snapshot
- Add try/catch fallback around `JSON.stringify` so the app never crashes even if the state is unexpectedly large
- Add tests verifying connected fields are excluded, unconnected fields are still captured, and performance stays under 50ms even with 50 operators and large mock datasets