### PR TITLE
feat: show executing indicator for ops taking longer than 200ms

### DIFF
--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -496,6 +496,10 @@ export abstract class Operator<OP extends IOperator> {
 
     let executionTime = 0
     let startTime = 0
+    // Show executing indicator only for ops taking longer than 200ms
+    const executingTimer = setTimeout(() => {
+      this.executionState.next({ status: 'executing' })
+    }, 200)
 
     try {
       // Pull upstream dependencies first
@@ -522,6 +526,8 @@ export abstract class Operator<OP extends IOperator> {
       if (finalResult === null) {
         throw new Error(`Operator ${this.id} returned null`)
       }
+
+      clearTimeout(executingTimer)
 
       // Cache result and mark clean
       this._cachedOutput = finalResult
@@ -556,6 +562,7 @@ export abstract class Operator<OP extends IOperator> {
 
       return finalResult
     } catch (err) {
+      clearTimeout(executingTimer)
       const error = err instanceof Error ? err : new Error(String(err))
 
       // Calculate actual elapsed time even on error

--- a/noodles-editor/src/noodles/pull-benchmark.test.ts
+++ b/noodles-editor/src/noodles/pull-benchmark.test.ts
@@ -1,6 +1,6 @@
 // Performance benchmark tests for pull-based execution model
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DataField, NumberField } from './fields'
 import { GraphExecutor, topologicalSort } from './graph-executor'
 import { Operator, PullExecutionStatus } from './operators'
@@ -397,5 +397,98 @@ describe('Dependency graph (via topologicalSort)', () => {
     // Check that sink nodes have no downstream
     expect(executor.getDownstream('/sink1').size).toBe(0)
     expect(executor.getDownstream('/sink2').size).toBe(0)
+  })
+})
+
+// Operator that takes a configurable amount of time to execute
+class SlowOp extends Operator<SlowOp> {
+  static displayName = 'Slow'
+  delayMs = 0
+
+  createInputs() {
+    return { value: new NumberField(0) }
+  }
+
+  createOutputs() {
+    return { result: new NumberField() }
+  }
+
+  async execute({ value }: ExtractProps<typeof this.inputs>) {
+    if (this.delayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, this.delayMs))
+    }
+    return { result: value * 2 }
+  }
+}
+
+describe('Execution indicator timing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should not show executing indicator for fast ops (<200ms)', async () => {
+    const op = new SlowOp('/fast-op')
+    op.delayMs = 50
+
+    const states: string[] = []
+    const sub = op.executionState.subscribe(s => states.push(s.status))
+
+    const pullPromise = op.pull()
+    // Advance past the op's 50ms delay but not past the 200ms indicator threshold
+    await vi.advanceTimersByTimeAsync(100)
+    await pullPromise
+
+    sub.unsubscribe()
+
+    expect(states).not.toContain('executing')
+    expect(states).toContain('success')
+  })
+
+  it('should show executing indicator for slow ops (>200ms)', async () => {
+    const op = new SlowOp('/slow-op')
+    op.delayMs = 300
+
+    const states: string[] = []
+    const sub = op.executionState.subscribe(s => states.push(s.status))
+
+    const pullPromise = op.pull()
+    // Advance past the 200ms indicator threshold
+    await vi.advanceTimersByTimeAsync(250)
+    expect(states).toContain('executing')
+
+    // Finish execution
+    await vi.advanceTimersByTimeAsync(100)
+    await pullPromise
+
+    sub.unsubscribe()
+
+    expect(states).toContain('success')
+  })
+
+  it('should clear executing indicator on error', async () => {
+    const op = new SlowOp('/error-op')
+    op.delayMs = 300
+    vi.spyOn(op, 'execute').mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 300))
+      throw new Error('test error')
+    })
+
+    const states: string[] = []
+    const sub = op.executionState.subscribe(s => states.push(s.status))
+
+    const pullPromise = op.pull().catch(() => {})
+    await vi.advanceTimersByTimeAsync(250)
+    expect(states).toContain('executing')
+
+    await vi.advanceTimersByTimeAsync(100)
+    await pullPromise
+
+    sub.unsubscribe()
+
+    expect(states).toContain('error')
   })
 })


### PR DESCRIPTION
#### Background

Operators that take a long time to execute had no visual feedback during execution in pull-based mode. The existing spinner indicator and blue border glow were wired up but never triggered.

#### Change List
- Add a 200ms delayed timer in `_pullExecution()` that sets execution state to `'executing'`, activating the existing spinner and border glow
- Clear the timer on both success and error paths so fast ops (<200ms) never flash the indicator