### PR TITLE
fix: compute ReferenceEdges at graph transform time to fix op() resolution on load

### DIFF
--- a/noodles-editor/src/noodles/__tests__/graph-execution-e2e.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/graph-execution-e2e.test.tsx
@@ -51,7 +51,7 @@ describe('Graph Execution E2E', () => {
       },
     ]
 
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     // Verify all operators created
     expect(operators).toHaveLength(3)
@@ -174,7 +174,7 @@ describe('Graph Execution E2E', () => {
       },
     ]
 
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     expect(operators).toHaveLength(4)
 

--- a/noodles-editor/src/noodles/__tests__/noodles-graph-integration.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/noodles-graph-integration.test.tsx
@@ -49,7 +49,7 @@ describe('Noodles Graph Integration', () => {
       },
     ]
 
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     // Should create 3 operators
     expect(operators).toHaveLength(3)
@@ -129,7 +129,7 @@ describe('Noodles Graph Integration', () => {
 
     // Transform the graph again - this reuses existing operators
     // and cleans up operators that are no longer in the nodes list
-    const newOperators = transformGraph({
+    const { operators: newOperators } = transformGraph({
       nodes: nodesAfterDelete,
       edges: edgesAfterDelete,
     })
@@ -175,7 +175,7 @@ describe('Noodles Graph Integration', () => {
     ]
 
     // Transform again without clearing - operators are reused
-    const operators = transformGraph({ nodes: updatedNodes, edges: [] })
+    const { operators } = transformGraph({ nodes: updatedNodes, edges: [] })
 
     expect(operators).toHaveLength(2)
     expect(hasOp('/num2')).toBe(true)
@@ -290,7 +290,7 @@ describe('Noodles Graph Integration', () => {
       },
     ]
 
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     expect(operators).toHaveLength(4)
 

--- a/noodles-editor/src/noodles/components/__tests__/container-op-component.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/container-op-component.test.tsx
@@ -20,7 +20,7 @@ describe('ContainerOpComponent children count reactivity', () => {
 
   // Helper to setup a graph with operators
   const setupGraph = (nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[]) => {
-    return transformGraph({ nodes, edges: [] })
+    return transformGraph({ nodes, edges: [] }).operators
   }
 
   // Helper to render ContainerOpComponent within the required contexts

--- a/noodles-editor/src/noodles/components/__tests__/container-op-component.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/container-op-component.test.tsx
@@ -18,11 +18,6 @@ describe('ContainerOpComponent children count reactivity', () => {
     clearOps()
   })
 
-  // Helper to setup a graph with operators
-  const setupGraph = (nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[]) => {
-    return transformGraph({ nodes, edges: [] }).operators
-  }
-
   // Helper to render ContainerOpComponent within the required contexts
   const renderContainerOpComponent = (containerId: string) => {
     const containerOp = getOp(containerId) as ContainerOp
@@ -55,7 +50,7 @@ describe('ContainerOpComponent children count reactivity', () => {
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const { container } = renderContainerOpComponent('/my-container')
 
@@ -85,7 +80,7 @@ describe('ContainerOpComponent children count reactivity', () => {
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const { container } = renderContainerOpComponent('/my-container')
 
@@ -110,7 +105,7 @@ describe('ContainerOpComponent children count reactivity', () => {
       },
     ]
 
-    setupGraph(initialNodes)
+    transformGraph({ nodes: initialNodes, edges: [] })
 
     const { container, rerender } = renderContainerOpComponent('/my-container')
 
@@ -129,7 +124,7 @@ describe('ContainerOpComponent children count reactivity', () => {
     ]
 
     // Transform the updated graph to add the new operator to the store
-    setupGraph(updatedNodes)
+    transformGraph({ nodes: updatedNodes, edges: [] })
 
     // Re-render to trigger the component update with Zustand subscription
     const ContainerComponent = nodeComponents.ContainerOp
@@ -173,7 +168,7 @@ describe('ContainerOpComponent children count reactivity', () => {
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const { container, rerender } = renderContainerOpComponent('/my-container')
 
@@ -237,7 +232,7 @@ describe('ContainerOpComponent children count reactivity', () => {
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const { container } = renderContainerOpComponent('/my-container')
 
@@ -267,7 +262,7 @@ describe('ContainerOpComponent children count reactivity', () => {
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     // Outer container should have 1 child (the inner container)
     const { container: outerContainer } = renderContainerOpComponent('/outer-container')

--- a/noodles-editor/src/noodles/components/__tests__/field-components.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/field-components.test.tsx
@@ -65,11 +65,6 @@ describe('CodeFieldComponent edge management', () => {
     clearOps()
   })
 
-  // Helper to setup a graph with operators
-  const setupGraph = (nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[]) => {
-    return transformGraph({ nodes, edges: [] }).operators
-  }
-
   // Helper to render CodeFieldComponent within the required contexts
   const renderCodeFieldComponent = (field: CodeField, disabled = false) => {
     return render(
@@ -101,7 +96,7 @@ describe('CodeFieldComponent edge management', () => {
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const queryOp = getOp('/duckdb-query') as DuckDbOp
     expect(queryOp).toBeDefined()
@@ -152,7 +147,7 @@ WHERE
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const queryOp = getOp('/duckdb-query') as DuckDbOp
     const queryField = queryOp.inputs.query as CodeField
@@ -198,7 +193,7 @@ WHERE id = {{./source1.out.val}}
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const queryOp = getOp('/duckdb-query') as DuckDbOp
     const queryField = queryOp.inputs.query as CodeField
@@ -246,7 +241,7 @@ WHERE id = {{./source1.out.val}}
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const queryOp = getOp('/duckdb-query') as DuckDbOp
     const queryField = queryOp.inputs.query as CodeField
@@ -293,7 +288,7 @@ WHERE id = {{./source1.out.val}}
       },
     ]
 
-    setupGraph(nodes)
+    transformGraph({ nodes, edges: [] })
 
     const queryOp = getOp('/duckdb-query') as DuckDbOp
     const queryField = queryOp.inputs.query as CodeField

--- a/noodles-editor/src/noodles/components/__tests__/field-components.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/field-components.test.tsx
@@ -67,7 +67,7 @@ describe('CodeFieldComponent edge management', () => {
 
   // Helper to setup a graph with operators
   const setupGraph = (nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[]) => {
-    return transformGraph({ nodes, edges: [] })
+    return transformGraph({ nodes, edges: [] }).operators
   }
 
   // Helper to render CodeFieldComponent within the required contexts

--- a/noodles-editor/src/noodles/container-integration.test.ts
+++ b/noodles-editor/src/noodles/container-integration.test.ts
@@ -47,7 +47,7 @@ describe('Container Integration with Transform Graph', () => {
     const edges: Edge[] = []
 
     // Transform the graph
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     // Verify operators were created with correct IDs
     expect(operators).toHaveLength(4)
@@ -112,7 +112,7 @@ describe('Container Integration with Transform Graph', () => {
     const edges: Edge[] = []
 
     // Transform the graph
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     // Verify operators were created
     expect(operators).toHaveLength(4)

--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -929,6 +929,31 @@ describe('Field references', () => {
     expect(references.length).toEqual(1)
     expect(references[0].opId).toEqual('../../grandparent/sibling')
   })
+
+  it('supports double-quoted op() references', () => {
+    const src = 'op("/source").out.data'
+    const references = getFieldReferences(src)
+    expect(references.length).toEqual(1)
+    expect(references[0].opId).toEqual('/source')
+    expect(references[0].inOut).toEqual('out')
+    expect(references[0].fieldPath).toEqual('data')
+  })
+
+  it('supports double-quoted relative path op() references', () => {
+    const src = 'op("./sibling").out.val + op("../parent").par.threshold'
+    const references = getFieldReferences(src)
+    expect(references.length).toEqual(2)
+    expect(references[0].opId).toEqual('./sibling')
+    expect(references[1].opId).toEqual('../parent')
+  })
+
+  it('handles mixed single and double quoted op() references', () => {
+    const src = 'op(\'/a\').out.val + op("/b").out.val'
+    const references = getFieldReferences(src)
+    expect(references.length).toEqual(2)
+    expect(references[0].opId).toEqual('/a')
+    expect(references[1].opId).toEqual('/b')
+  })
 })
 
 describe('getFieldReferences self-parameter shorthand', () => {

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -337,9 +337,9 @@ export const mustacheRe = new RegExp(
   `{{(?<opId>${OPERATOR_ID_PATTERN})\\.(?<inOut>par|out)\\.(?<fieldPath>[\\w-.]+)}}`,
   'g'
 )
-// Function-style references: op('/path/to/operator').out.val
+// Function-style references: op('/path/to/operator').out.val or op("/path/to/operator").out.val
 export const fnRe = new RegExp(
-  `op\\('(?<opId>${OPERATOR_ID_PATTERN})'\\)\\.(?<inOut>par|out)\\.(?<fieldPath>[\\w-.]+)`,
+  `op\\(['"](?<opId>${OPERATOR_ID_PATTERN})['"]\\)\\.(?<inOut>par|out)\\.(?<fieldPath>[\\w-.]+)`,
   'g'
 )
 

--- a/noodles-editor/src/noodles/noodles.test.ts
+++ b/noodles-editor/src/noodles/noodles.test.ts
@@ -33,7 +33,7 @@ describe('nodes', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
     assert.equal(instances.length, 2)
 
     const [num, add] = instances
@@ -69,7 +69,7 @@ describe('nodes', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
 
     assert.equal(instances.length, 2)
 
@@ -151,7 +151,7 @@ describe('nodes', () => {
       ],
     }
 
-    const instances = transformGraph(complexGraph)
+    const { operators: instances } = transformGraph(complexGraph)
     assert.equal(instances.length, 5)
 
     // Verify all instances have qualified IDs
@@ -223,7 +223,7 @@ describe('nodes', () => {
     // prevents them from running — but they must be in the store to avoid "operator not found"
     // render errors. TODO: surface a cycle warning to the user.
     expect(() => transformGraph(graph)).not.toThrowError()
-    expect(transformGraph(graph).length).toEqual(2)
+    expect(transformGraph(graph).operators.length).toEqual(2)
   })
 
   it('fails gracefully on missing fields', () => {
@@ -254,6 +254,6 @@ describe('nodes', () => {
     }
 
     expect(() => transformGraph(graph)).not.toThrowError()
-    expect(transformGraph(graph).length).toEqual(2)
+    expect(transformGraph(graph).operators.length).toEqual(2)
   })
 })

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -336,8 +336,15 @@ export function getNoodles(): Visualization {
   useEffect(() => {
     // loadProjectFile already called transformGraph directly, so skip this triggered re-run
     if (isProjectLoadRef.current) return
-    const ops = transformGraph({ nodes, edges })
+    const { operators: ops, referenceEdges } = transformGraph({ nodes, edges })
     setOperators(ops)
+    if (referenceEdges.length > 0) {
+      setEdges(prev => {
+        const existing = new Set(prev.map(e => e.id))
+        const newEdges = referenceEdges.filter(e => !existing.has(e.id))
+        return newEdges.length > 0 ? [...prev, ...newEdges] : prev
+      })
+    }
   }, [graphStructureKey])
 
   // Reset isProjectLoadRef after every render so the flag never gets stuck when
@@ -746,12 +753,12 @@ export function getNoodles(): Visualization {
       }
 
       // Build the operator graph synchronously — operators are ready before any re-render
-      const ops = transformGraph({ nodes, edges })
+      const { operators: ops, referenceEdges } = transformGraph({ nodes, edges })
       setOperators(ops)
 
       // Update React Flow state (for rendering; graph is already set up above)
       setNodes(nodes)
-      setEdges(edges)
+      setEdges(referenceEdges.length > 0 ? [...edges, ...referenceEdges] : edges)
 
       // Load editor settings from project with defaults
       setLayoutMode(editorSettings?.layoutMode ?? 'noodles-on-top')

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -657,6 +657,14 @@ export abstract class Operator<OP extends IOperator> {
     this._downstreamDependents.delete(op)
   }
 
+  getUpstreamDependencies(): Set<Operator<IOperator>> {
+    return this._upstreamDependencies
+  }
+
+  getDownstreamDependents(): Set<Operator<IOperator>> {
+    return this._downstreamDependents
+  }
+
   // Get pull execution status
   get pullExecutionStatus(): PullExecutionStatus {
     return this._pullExecutionStatus

--- a/noodles-editor/src/noodles/qualified-paths-integration.test.ts
+++ b/noodles-editor/src/noodles/qualified-paths-integration.test.ts
@@ -70,7 +70,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created with correct qualified IDs
       expect(operators).toHaveLength(4)
@@ -190,7 +190,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created
       expect(operators).toHaveLength(6)
@@ -277,7 +277,7 @@ describe('Qualified Paths Integration Tests', () => {
       const edges: Edge[] = []
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created
       expect(operators).toHaveLength(6)
@@ -411,7 +411,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created with correct hierarchy
       expect(operators).toHaveLength(11)
@@ -526,7 +526,7 @@ describe('Qualified Paths Integration Tests', () => {
       const edges: Edge[] = []
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created
       expect(operators).toHaveLength(7)
@@ -605,7 +605,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify operators were created
       expect(operators).toHaveLength(3)
@@ -771,7 +771,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created
       expect(operators).toHaveLength(8)

--- a/noodles-editor/src/noodles/transform-graph.test.ts
+++ b/noodles-editor/src/noodles/transform-graph.test.ts
@@ -42,7 +42,7 @@ describe('transform-graph topological sort with missing upstream nodes', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const { operators: instances } = transformGraph({ nodes, edges })
 
     expect(instances).toHaveLength(1)
     expect(instances[0].id).toBe('/kml-to-geo-json')
@@ -74,7 +74,7 @@ describe('transform-graph topological sort with missing upstream nodes', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const { operators: instances } = transformGraph({ nodes, edges })
 
     expect(instances).toHaveLength(2)
     const { getOp } = getOpStore()
@@ -111,7 +111,7 @@ describe('transform-graph topological sort with missing upstream nodes', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const { operators: instances } = transformGraph({ nodes, edges })
 
     expect(instances).toHaveLength(3)
     // /source must come before /downstream in execution order
@@ -136,7 +136,7 @@ describe('transform-graph topological sort with missing upstream nodes', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const { operators: instances } = transformGraph({ nodes, edges })
 
     expect(instances).toHaveLength(2)
     const ids = instances.map(op => op.id)
@@ -375,7 +375,7 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
     expect(instances).toHaveLength(2)
 
     const [num, add] = instances
@@ -455,7 +455,7 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
     expect(instances).toHaveLength(2)
 
     const [num, add] = instances
@@ -494,7 +494,7 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
     const code = instances.find(op => op.id === '/code') as CodeOp
     expect(code.hasConnectionErrors()).toBe(false)
   })
@@ -525,7 +525,7 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
     const code = instances.find(op => op.id === '/code') as CodeOp
     expect(code.hasConnectionErrors()).toBe(true)
     const errorMessage = code.connectionErrors.value.get('/num.out.val->/code.par.code')
@@ -563,7 +563,7 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
     const add = instances.find(op => op.id === '/add') as MathOp
 
     // Connection should be established despite type mismatch
@@ -641,7 +641,7 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graphWithValidConnection)
+    const { operators: instances } = transformGraph(graphWithValidConnection)
     const add = instances.find(op => op.id === '/add') as MathOp
 
     // Valid connection should be established
@@ -707,7 +707,7 @@ describe('transform-graph', () => {
       edges: [], // No edges
     }
 
-    const instances = transformGraph(graphWithoutConnection)
+    const { operators: instances } = transformGraph(graphWithoutConnection)
     const add = instances.find(op => op.id === '/add') as MathOp
 
     // No subscriptions should exist
@@ -1041,7 +1041,7 @@ describe('connection error suppression for undefined source fields', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const { operators: instances } = transformGraph({ nodes, edges })
     const deck = instances.find(op => op.id === '/deck') as DeckRendererOp
 
     expect(deck.hasConnectionErrors()).toBe(false)
@@ -1075,7 +1075,7 @@ describe('connection error suppression for undefined source fields', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const { operators: instances } = transformGraph({ nodes, edges })
     const add = instances.find(op => op.id === '/add') as MathOp
 
     expect(add.hasConnectionErrors()).toBe(false)
@@ -1109,7 +1109,7 @@ describe('connection error suppression for undefined source fields', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const { operators: instances } = transformGraph({ nodes, edges })
     const add = instances.find(op => op.id === '/add') as MathOp
 
     expect(add.hasConnectionErrors()).toBe(true)
@@ -1160,5 +1160,243 @@ describe('connection error suppression for undefined source fields', () => {
 
     // Error should be cleared — source has no value, so we cannot confirm the mismatch
     expect(add.hasConnectionErrors()).toBe(false)
+  })
+})
+
+describe('ReferenceEdge synthesis from code fields', () => {
+  afterEach(() => {
+    clearOps()
+  })
+
+  it('creates upstream dependency for op() references in CodeOp', () => {
+    const nodes = [
+      {
+        id: '/source',
+        type: 'NumberOp',
+        data: { inputs: { val: 42 } },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: ["return op('/source').out.val * 2"] } },
+        position: { x: 200, y: 0 },
+      },
+    ]
+
+    const { operators, referenceEdges } = transformGraph({ nodes, edges: [] })
+
+    expect(referenceEdges).toHaveLength(1)
+    expect(referenceEdges[0].source).toBe('/source')
+    expect(referenceEdges[0].target).toBe('/code')
+    expect(referenceEdges[0].sourceHandle).toBe('out.val')
+    expect(referenceEdges[0].targetHandle).toBe('par.code')
+    expect(referenceEdges[0].type).toBe('ReferenceEdge')
+
+    const codeOp = operators.find(op => op.id === '/code')!
+    const sourceOp = operators.find(op => op.id === '/source')!
+    expect(codeOp.getUpstreamDependencies()).toContain(sourceOp)
+  })
+
+  it('creates upstream dependency for mustache references in DuckDbOp', () => {
+    const nodes = [
+      {
+        id: '/data',
+        type: 'NumberOp',
+        data: { inputs: { val: 10 } },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '/sql',
+        type: 'DuckDbOp',
+        data: { inputs: { query: ['SELECT * WHERE x > {{/data.par.val}}'] } },
+        position: { x: 200, y: 0 },
+      },
+    ]
+
+    const { referenceEdges } = transformGraph({ nodes, edges: [] })
+
+    expect(referenceEdges).toHaveLength(1)
+    expect(referenceEdges[0].source).toBe('/data')
+    expect(referenceEdges[0].target).toBe('/sql')
+    expect(referenceEdges[0].sourceHandle).toBe('par.val')
+    expect(referenceEdges[0].targetHandle).toBe('par.query')
+  })
+
+  it('creates upstream dependency for ExpressionOp references', () => {
+    const nodes = [
+      {
+        id: '/num',
+        type: 'NumberOp',
+        data: { inputs: { val: 5 } },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '/expr',
+        type: 'ExpressionOp',
+        data: { inputs: { expression: "op('/num').out.val * 2" } },
+        position: { x: 200, y: 0 },
+      },
+    ]
+
+    const { referenceEdges } = transformGraph({ nodes, edges: [] })
+
+    expect(referenceEdges).toHaveLength(1)
+    expect(referenceEdges[0].source).toBe('/num')
+    expect(referenceEdges[0].target).toBe('/expr')
+    expect(referenceEdges[0].sourceHandle).toBe('out.val')
+  })
+
+  it('resolves relative path references', () => {
+    const nodes = [
+      {
+        id: '/sibling',
+        type: 'NumberOp',
+        data: { inputs: { val: 7 } },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: ["return op('./sibling').out.val"] } },
+        position: { x: 200, y: 0 },
+      },
+    ]
+
+    const { referenceEdges } = transformGraph({ nodes, edges: [] })
+
+    expect(referenceEdges).toHaveLength(1)
+    expect(referenceEdges[0].source).toBe('/sibling')
+    expect(referenceEdges[0].target).toBe('/code')
+  })
+
+  it('handles self-parameter references without creating cycles', () => {
+    const nodes = [
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: ['return {{par.data}}'] } },
+        position: { x: 0, y: 0 },
+      },
+    ]
+
+    const { operators, referenceEdges } = transformGraph({ nodes, edges: [] })
+
+    // Self-parameter reference creates a reference edge
+    expect(referenceEdges).toHaveLength(1)
+    expect(referenceEdges[0].source).toBe('/code')
+    expect(referenceEdges[0].target).toBe('/code')
+
+    // But isSelfParameterReference check prevents adding as upstream dependency
+    const codeOp = operators.find(op => op.id === '/code')!
+    expect(codeOp.getUpstreamDependencies().size).toBe(0)
+  })
+
+  it('skips references to non-existent operators', () => {
+    const nodes = [
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: ["return op('/missing').out.data"] } },
+        position: { x: 0, y: 0 },
+      },
+    ]
+
+    const { referenceEdges } = transformGraph({ nodes, edges: [] })
+
+    expect(referenceEdges).toHaveLength(0)
+  })
+
+  it('creates multiple reference edges for multiple references', () => {
+    const nodes = [
+      {
+        id: '/a',
+        type: 'NumberOp',
+        data: { inputs: { val: 1 } },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '/b',
+        type: 'NumberOp',
+        data: { inputs: { val: 2 } },
+        position: { x: 0, y: 100 },
+      },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: ["return op('/a').out.val + op('/b').out.val"] } },
+        position: { x: 200, y: 0 },
+      },
+    ]
+
+    const { referenceEdges } = transformGraph({ nodes, edges: [] })
+
+    expect(referenceEdges).toHaveLength(2)
+    const sources = referenceEdges.map(e => e.source).sort()
+    expect(sources).toEqual(['/a', '/b'])
+  })
+
+  it('does not duplicate edges that already exist in the input', () => {
+    const nodes = [
+      {
+        id: '/source',
+        type: 'NumberOp',
+        data: { inputs: { val: 42 } },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: ["return op('/source').out.val * 2"] } },
+        position: { x: 200, y: 0 },
+      },
+    ]
+
+    // Simulate a case where the reference edge already exists in input
+    const existingRefEdge = {
+      id: edgeId({
+        source: '/source',
+        sourceHandle: 'out.val',
+        target: '/code',
+        targetHandle: 'par.code',
+      }),
+      type: 'ReferenceEdge',
+      source: '/source',
+      target: '/code',
+      sourceHandle: 'out.val',
+      targetHandle: 'par.code',
+    }
+
+    const { referenceEdges } = transformGraph({ nodes, edges: [existingRefEdge] as any })
+
+    // Should not produce duplicates
+    expect(referenceEdges).toHaveLength(0)
+  })
+
+  it('ensures referenced operators are pulled before the CodeOp', () => {
+    const nodes = [
+      {
+        id: '/source',
+        type: 'NumberOp',
+        data: { inputs: { val: 42 } },
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: ["return op('/source').out.val * 2"] } },
+        position: { x: 200, y: 0 },
+      },
+    ]
+
+    const { operators } = transformGraph({ nodes, edges: [] })
+
+    const codeOp = operators.find(op => op.id === '/code')!
+    const sourceOp = operators.find(op => op.id === '/source')!
+
+    // CodeOp should have /source as upstream dependency
+    expect(codeOp.getUpstreamDependencies()).toContain(sourceOp)
+    // /source should have /code as downstream dependent
+    expect(sourceOp.getDownstreamDependents()).toContain(codeOp)
   })
 })

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -1,11 +1,13 @@
 import { getIncomers, type Node as ReactFlowNode } from '@xyflow/react'
 import { debugExecutor } from '../utils/debug'
+import { CodeField, ExpressionField, getFieldReferences } from './fields'
 import { type Edge as ExecutorEdge, updateGraph } from './graph-executor'
 import type { Edge } from './noodles'
 import type { IOperator, Operator, OpType } from './operators'
 import { ContainerOp, ForLoopEndOp, GraphInputOp, opTypes, type SpecialNodeType } from './operators'
 import { getOpStore } from './store'
 import { validateConnection } from './utils/can-connect'
+import { edgeId } from './utils/id-utils'
 import { getParentPath, isDirectChild, parseHandleId } from './utils/path-utils'
 import { computeVisibilityHeuristic } from './utils/visibility-heuristic'
 
@@ -92,11 +94,60 @@ function topologicalSort<N extends Operator<IOperator>>(
   return sortedNodes.reverse()
 }
 
+// Compute ReferenceEdges by parsing CodeField/ExpressionField values for op() references.
+// These edges establish upstream dependencies so the pull-based executor knows to execute
+// referenced operators before operators that reference them in code.
+function computeReferenceEdges<OP extends Operator<IOperator>, E extends Edge<OP, OP>>(
+  instances: OP[],
+  nodeIds: Set<string>,
+  existingEdgeIds: Set<string>
+): E[] {
+  const referenceEdges: E[] = []
+  for (const op of instances) {
+    for (const [fieldName, field] of Object.entries(op.inputs)) {
+      if (!(field instanceof CodeField) && !(field instanceof ExpressionField)) continue
+      const codeValue = field.value
+      if (typeof codeValue !== 'string' || !codeValue.trim()) continue
+      const thisFieldId = `par.${fieldName}`
+      const refs = getFieldReferences(codeValue, op.id)
+      for (const { opId, handleId } of refs) {
+        if (!nodeIds.has(opId)) continue
+        const connection = {
+          source: opId,
+          sourceHandle: handleId,
+          target: op.id,
+          targetHandle: thisFieldId,
+        }
+        const id = edgeId(connection)
+        if (existingEdgeIds.has(id)) continue
+        referenceEdges.push({
+          id,
+          type: 'ReferenceEdge',
+          source: opId,
+          target: op.id,
+          sourceHandle: handleId,
+          targetHandle: thisFieldId,
+        } as unknown as E)
+      }
+    }
+  }
+  return referenceEdges
+}
+
 export function transformGraph<
   OP extends Operator<IOperator>,
   E extends Edge<OP, OP>,
   T extends OpType,
->({ nodes: _nodes, edges }: { nodes: NodeJSON<unknown>[]; edges: E[] }): OP[] {
+>({
+  nodes: _nodes,
+  edges,
+}: {
+  nodes: NodeJSON<unknown>[]
+  edges: E[]
+}): {
+  operators: OP[]
+  referenceEdges: E[]
+} {
   const nodes = _nodes.filter(n => opTypes[n.type as T] !== undefined) as NodeJSON<OpType>[]
   const store = getOpStore()
 
@@ -202,12 +253,18 @@ export function transformGraph<
     }) as OP[]
   })
 
+  // Compute ReferenceEdges from code field values so the executor knows the
+  // correct dependency order before any UI components mount.
+  const existingEdgeIds = new Set(edges.map(e => e.id))
+  const syntheticRefEdges = computeReferenceEdges<OP, E>(instances, nodeIds, existingEdgeIds)
+  const allEdges = syntheticRefEdges.length > 0 ? [...edges, ...syntheticRefEdges] : edges
+
   // Update dependency graph
-  updateGraph(edges as unknown as ExecutorEdge[])
+  updateGraph(allEdges as unknown as ExecutorEdge[])
 
   // Remove any connections that are not in the edges array.
   // Also clear connection errors for removed edges.
-  const currentEdgeIds = new Set(edges.map(e => e.id))
+  const currentEdgeIds = new Set(allEdges.map(e => e.id))
   for (const op of instances) {
     for (const [_key, field] of Object.entries(op.inputs)) {
       for (const [id] of field.subscriptions) {
@@ -226,7 +283,7 @@ export function transformGraph<
     }
   }
 
-  for (const edge of edges) {
+  for (const edge of allEdges) {
     const sourceOp = instances.find(n => n.id === edge.source)
     const targetOp = instances.find(n => n.id === edge.target)
     if (sourceOp && targetOp) {
@@ -361,5 +418,5 @@ export function transformGraph<
     }
   }
 
-  return instances
+  return { operators: instances, referenceEdges: syntheticRefEdges }
 }


### PR DESCRIPTION
#### Background

On project load, `op("/path")` references in CodeOps resolved to default/empty values because ReferenceEdges (which establish execution dependencies) were only created by UI components after mounting — but the executor starts immediately. This race condition meant CodeOps executed before their referenced operators had output values.

#### Change List
- Add `computeReferenceEdges` helper in `transform-graph.ts` that parses CodeField/ExpressionField values with `getFieldReferences()` at deserialization time
- `transformGraph` now returns `{ operators, referenceEdges }` and merges synthetic ReferenceEdges into the dependency graph before the executor starts
- Update `noodles.tsx` load path to include computed ReferenceEdges in ReactFlow edge state
- Add `getUpstreamDependencies()` / `getDownstreamDependents()` accessors to Operator class
- Add 9 new tests covering reference edge synthesis (CodeOp, DuckDbOp, ExpressionOp, relative paths, self-params, missing refs, duplicates, dependency correctness)
- Update all test files for the new `transformGraph` return type