### PR TITLE
fix: support double-quoted op() references in fnRe regex

### DIFF
--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -954,6 +954,12 @@ describe('Field references', () => {
     expect(references[0].opId).toEqual('/a')
     expect(references[1].opId).toEqual('/b')
   })
+
+  it('does not match mismatched quotes', () => {
+    const src = 'op(\'/path").out.val + op("/other\').par.value'
+    const references = getFieldReferences(src)
+    expect(references.length).toEqual(0)
+  })
 })
 
 describe('getFieldReferences self-parameter shorthand', () => {

--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -929,6 +929,31 @@ describe('Field references', () => {
     expect(references.length).toEqual(1)
     expect(references[0].opId).toEqual('../../grandparent/sibling')
   })
+
+  it('supports double-quoted op() references', () => {
+    const src = 'op("/source").out.data'
+    const references = getFieldReferences(src)
+    expect(references.length).toEqual(1)
+    expect(references[0].opId).toEqual('/source')
+    expect(references[0].inOut).toEqual('out')
+    expect(references[0].fieldPath).toEqual('data')
+  })
+
+  it('supports double-quoted relative path op() references', () => {
+    const src = 'op("./sibling").out.val + op("../parent").par.threshold'
+    const references = getFieldReferences(src)
+    expect(references.length).toEqual(2)
+    expect(references[0].opId).toEqual('./sibling')
+    expect(references[1].opId).toEqual('../parent')
+  })
+
+  it('handles mixed single and double quoted op() references', () => {
+    const src = 'op(\'/a\').out.val + op("/b").out.val'
+    const references = getFieldReferences(src)
+    expect(references.length).toEqual(2)
+    expect(references[0].opId).toEqual('/a')
+    expect(references[1].opId).toEqual('/b')
+  })
 })
 
 describe('getFieldReferences self-parameter shorthand', () => {

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -337,9 +337,9 @@ export const mustacheRe = new RegExp(
   `{{(?<opId>${OPERATOR_ID_PATTERN})\\.(?<inOut>par|out)\\.(?<fieldPath>[\\w-.]+)}}`,
   'g'
 )
-// Function-style references: op('/path/to/operator').out.val
+// Function-style references: op('/path/to/operator').out.val or op("/path/to/operator").out.val
 export const fnRe = new RegExp(
-  `op\\('(?<opId>${OPERATOR_ID_PATTERN})'\\)\\.(?<inOut>par|out)\\.(?<fieldPath>[\\w-.]+)`,
+  `op\\(['"](?<opId>${OPERATOR_ID_PATTERN})['"]\\)\\.(?<inOut>par|out)\\.(?<fieldPath>[\\w-.]+)`,
   'g'
 )
 

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -339,7 +339,7 @@ export const mustacheRe = new RegExp(
 )
 // Function-style references: op('/path/to/operator').out.val or op("/path/to/operator").out.val
 export const fnRe = new RegExp(
-  `op\\(['"](?<opId>${OPERATOR_ID_PATTERN})['"]\\)\\.(?<inOut>par|out)\\.(?<fieldPath>[\\w-.]+)`,
+  `op\\((?<q>['"])(?<opId>${OPERATOR_ID_PATTERN})\\k<q>\\)\\.(?<inOut>par|out)\\.(?<fieldPath>[\\w-.]+)`,
   'g'
 )
 


### PR DESCRIPTION
#### Background

The `fnRe` regex pattern only matched single-quoted `op('/path')` references in CodeField and ExpressionField values. Projects using double-quoted strings like `op("/path")` would silently fail to parse operator references during load, causing CodeOps to break.

#### Change List
- Updated `fnRe` regex in `fields.ts` to accept both single and double quotes: `op(['"']...['"'])`
- Added 3 tests validating double-quoted op() references (absolute paths, relative paths, and mixed quotes)