### PR TITLE
feat: improve op() error messages in CodeOp/ExpressionOp/AccessorOp

### DIFF
--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -39,7 +39,7 @@ import {
   Tile3DLayerOp,
   TimeSeriesOp,
 } from './operators'
-import { setOp } from './store'
+import { deleteOp, getOpStore, setOp } from './store'
 import { isAccessor } from './utils/accessor-helpers'
 
 describe('basic Operators', () => {
@@ -289,6 +289,65 @@ describe('CodeOp', () => {
   })
 })
 
+describe('CodeOp op() error handling', () => {
+  beforeEach(() => {
+    getOpStore().batch(() => {
+      const numOp = new NumberOp('/num')
+      numOp.inputs.val.setValue(42)
+      setOp('/num', numOp)
+    })
+  })
+
+  afterEach(() => {
+    deleteOp('/num')
+  })
+
+  it('should throw clear error when operator not found with absolute path', async () => {
+    const codeOp = new CodeOp('/code')
+    await expect(
+      codeOp.execute({
+        data: [],
+        code: 'return op("/missing").par.value',
+      })
+    ).rejects.toThrow("Operator '/missing' not found")
+  })
+
+  it('should throw clear error when operator not found with relative path', async () => {
+    const codeOp = new CodeOp('/code')
+    setOp('/code', codeOp)
+
+    try {
+      await expect(
+        codeOp.execute({
+          data: [],
+          code: 'return op("./missing").out.data',
+        })
+      ).rejects.toThrow("Operator './missing' not found")
+    } finally {
+      deleteOp('/code')
+    }
+  })
+
+  it('should throw clear error when operator not found in mustache syntax', async () => {
+    const codeOp = new CodeOp('/code')
+    await expect(
+      codeOp.execute({
+        data: [],
+        code: 'return {{/missing.par.value}}',
+      })
+    ).rejects.toThrow("Operator '/missing' not found")
+  })
+
+  it('should still work with valid operator references', async () => {
+    const codeOp = new CodeOp('/code')
+    const result = await codeOp.execute({
+      data: [],
+      code: 'return op("/num").par.val',
+    })
+    expect(result.data).toBe(42)
+  })
+})
+
 describe('CodeOp self-parameter references', () => {
   it('should allow CodeOp to reference its own custom parameter with shorthand syntax', async () => {
     const codeOp = new CodeOp('/code-self')
@@ -526,6 +585,47 @@ describe('ExpressionOp', () => {
   })
 })
 
+describe('ExpressionOp op() error handling', () => {
+  beforeEach(() => {
+    const numOp = new NumberOp('/num')
+    numOp.inputs.val.setValue(100)
+    setOp('/num', numOp)
+  })
+
+  afterEach(() => {
+    deleteOp('/num')
+  })
+
+  it('should throw clear error when operator not found', () => {
+    const exprOp = new ExpressionOp('/expr')
+    expect(() =>
+      exprOp.execute({
+        data: [],
+        expression: 'op("/nonexistent").par.value',
+      })
+    ).toThrow("Operator '/nonexistent' not found")
+  })
+
+  it('should throw clear error accessing out field of missing operator', () => {
+    const exprOp = new ExpressionOp('/expr')
+    expect(() =>
+      exprOp.execute({
+        data: [],
+        expression: 'op("/missing").out.result',
+      })
+    ).toThrow("Operator '/missing' not found")
+  })
+
+  it('should still work with valid operator references', () => {
+    const exprOp = new ExpressionOp('/expr')
+    const result = exprOp.execute({
+      data: [1],
+      expression: 'd + op("/num").par.val',
+    })
+    expect(result.data).toBe(101)
+  })
+})
+
 describe('AccessorOp', () => {
   it('executes an AccessorOp', () => {
     const operator = new AccessorOp('/expression-0')
@@ -546,6 +646,38 @@ describe('AccessorOp', () => {
       expression: '',
     })
     expect(val.accessor).toEqual(expect.any(Function))
+  })
+})
+
+describe('AccessorOp op() error handling', () => {
+  beforeEach(() => {
+    const numOp = new NumberOp('/num')
+    numOp.inputs.val.setValue(5)
+    setOp('/num', numOp)
+  })
+
+  afterEach(() => {
+    deleteOp('/num')
+  })
+
+  it('should return undefined when operator not found (errors swallowed)', () => {
+    const accessorOp = new AccessorOp('/accessor')
+    const { accessor } = accessorOp.execute({
+      expression: 'op("/missing").par.value',
+    })
+    // AccessorOp has try-catch that swallows errors and returns undefined
+    // to prevent GPU crashes in deck.gl
+    const result = accessor({ value: 10 }, { index: 0, data: [] })
+    expect(result).toBeUndefined()
+  })
+
+  it('should still work with valid operator references', () => {
+    const accessorOp = new AccessorOp('/accessor')
+    const { accessor } = accessorOp.execute({
+      expression: 'd.value * op("/num").par.val',
+    })
+    const result = accessor({ value: 10 }, { index: 0, data: [] })
+    expect(result).toBe(50)
   })
 })
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -6408,6 +6408,17 @@ export function fnWithSource(args: string[], body: string, id: string): Function
   }
 }
 
+// Creates a safe wrapper around getOp that throws a clear error when operator not found.
+function safeOpGetter(contextOpId: string): (path: string) => Operator<IOperator> {
+  return (path: string) => {
+    const op = getOp(path, contextOpId)
+    if (!op) {
+      throw new Error(`Operator '${path}' not found`)
+    }
+    return op
+  }
+}
+
 // An Accessor is an ExpressionOp that returns a function instead of executing it
 export class AccessorOp extends Operator<AccessorOp> {
   static displayName = 'Accessor'
@@ -6445,7 +6456,7 @@ export class AccessorOp extends Operator<AccessorOp> {
 
     // https://deck.gl/docs/developer-guide/using-layers#accessors
     const accessor = (d: unknown, dInfo: { index: number; data: unknown; target: number[] }) => {
-      const contextualGetOp = (path: string) => getOp(path, this.id)
+      const contextualGetOp = safeOpGetter(this.id)
       // Get fresh timeline values for each accessor call
       const timelineContext = getTimelineContext()
       try {
@@ -6511,7 +6522,7 @@ export class CodeOp extends Operator<CodeOp> {
     subscribeOpToTimeline(this)
 
     // Create a context-aware getOp function for the code execution
-    const contextualGetOp = (path: string) => getOp(path, this.id)
+    const contextualGetOp = safeOpGetter(this.id)
     const fn = fnWithSource(
       [
         'data',
@@ -6610,7 +6621,7 @@ export class ExpressionOp extends Operator<ExpressionOp> {
       this.id
     )
     // Create a context-aware getOp function for the expression execution
-    const contextualGetOp = (path: string) => getOp(path, this.id)
+    const contextualGetOp = safeOpGetter(this.id)
 
     // Check if any data items are accessor functions
     const hasAccessors = data.some(isAccessor)


### PR DESCRIPTION
#### Background

When developers use `op()` in CodeOp, ExpressionOp, or AccessorOp to reference non-existent operators, the error message was confusing: `TypeError: Cannot read properties of undefined` without indicating which operator path failed.

#### Change List
- Add `createSafeOpGetter()` helper that wraps `getOp()` and throws clear error: `Operator '/path' not found`
- Update AccessorOp, CodeOp, and ExpressionOp to use the safe wrapper
- Add comprehensive test coverage (9 new tests) for all three operators covering absolute paths, relative paths, mustache syntax, and success cases
- Follow existing pattern from `enable-expression-evaluator.ts`