### PR TITLE
Add timeline MCP tools and improve AI integration guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,86 @@ Any field can be keyframed via the native timeline system. Changes in timeline p
 9. **Document edge cases** - Users may not expect implementation-specific behavior
 10. **Keep PRs focused** - Split large changes into reviewable chunks when possible
 
+## Using Claude Code with Noodles.gl
+
+This section covers using Claude Code (the CLI tool) to work directly with projects, as opposed to the in-app Claude chat panel.
+
+### Setup
+
+```bash
+# Start the dev server
+cd noodles-editor && npm start
+
+# Projects are in noodles-editor/public/examples/
+# Each project directory contains a noodles.json and optional data files
+ls noodles-editor/public/examples/
+```
+
+### Editing Project Files Directly
+
+Project files (`noodles.json`) are plain JSON and can be read and written by Claude Code. See the **Project Files** section above for the full schema. Key points:
+
+- Node IDs are Unix-style paths: `/my-node`, `/container/child`
+- Edge handles: `out.fieldName` (source) → `par.fieldName` (target)
+- Only non-default input values need to be serialized
+- Version 6 is current; do not change the version field
+
+### Validating Changes
+
+After editing a project file, run the project's tests to catch schema issues:
+
+```bash
+cd noodles-editor && npm test src/noodles/storage.test.ts
+```
+
+Load it in the browser at `http://localhost:5173/examples/<project-name>` to visually verify.
+
+### Connecting Claude Code to a Running Browser Instance
+
+The MCP proxy bridges Claude Code to a running Noodles browser session, giving access to the same 18+ tools the in-app chat uses:
+
+```bash
+# 1. Start the app with external control enabled
+# Open: http://localhost:5173/examples/nyc-taxis?externalControl=true
+
+# 2. Start the MCP proxy (in a separate terminal)
+node noodles-editor/examples/external-control/mcp-proxy.js
+
+# 3. Add to Claude Desktop config (~/.claude/claude_desktop_config.json):
+{
+  "mcpServers": {
+    "noodles": {
+      "command": "node",
+      "args": ["/path/to/noodles-editor/examples/external-control/mcp-proxy.js"]
+    }
+  }
+}
+```
+
+The proxy exposes tools: `getCurrentProject`, `listNodes`, `createNode`, `connectNodes`, `captureVisualization`, and more — the same surface as the in-app chat.
+
+### Graph Design Guidelines for Claude Code
+
+When generating or modifying `noodles.json` programmatically:
+
+- **Keep graphs simple** — aim for 5–8 nodes. A human must be able to read and modify the result.
+- **Prefer CodeOp for data transformation** over chaining FilterOp → MapOp → SortOp. One CodeOp node with a few lines of JavaScript is more reliable and easier to inspect:
+  ```json
+  {
+    "id": "/transform",
+    "type": "CodeOp",
+    "data": { "inputs": { "code": "return data.filter(d => d.value > 0).sort((a,b) => b.value - a.value)" } }
+  }
+  ```
+- **Standard pipeline**: FileOp/DuckDbOp → CodeOp (transform) → AccessorOp (position) → LayerOp → DeckRendererOp
+- **Always include MaplibreBasemapOp** for geographic visualizations
+- **Verify handle names** using `get_operator_schema` or the operator registry before writing edges
+
+### Timeline / Animation
+
+The timeline is serialized inside `noodles.json` under the `"timeline"` key. The structure is complex — prefer using the in-app chat's `set_keyframe` / `get_timeline` tools rather than editing the timeline JSON directly.
+
 ---
 
-**Last Updated**: 2025-12-01
+**Last Updated**: 2026-06-02
 **Version**: Based on project version 6 schema

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -671,7 +671,9 @@ The MCP proxy bridges Claude Code to a running Noodles browser session, giving a
 # 2. Start the MCP proxy (in a separate terminal)
 node noodles-editor/examples/external-control/mcp-proxy.js
 
-# 3. Add to Claude Desktop config (~/.claude/claude_desktop_config.json):
+# 3. Add to Claude Desktop config:
+#    macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json
+#    Windows: %APPDATA%\Claude\claude_desktop_config.json
 {
   "mcpServers": {
     "noodles": {

--- a/noodles-editor/src/ai-chat/claude-client.ts
+++ b/noodles-editor/src/ai-chat/claude-client.ts
@@ -502,6 +502,66 @@ export class ClaudeClient {
           required: ['nodeId'],
         },
       },
+      // Timeline tools
+      {
+        name: 'get_timeline',
+        description:
+          'Get the current animation timeline state: sequence length, FPS, playback position, and all animated tracks with their keyframes. Use this before adding keyframes to understand the current animation.',
+        input_schema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'set_keyframe',
+        description:
+          'Add or update a keyframe on an animated field. Track IDs follow the pattern "operator-name / fieldName" (e.g. "my-layer / opacity"). Position is in seconds. Interpolation is "bezier" (smooth) or "hold" (step). If a keyframe already exists within 1 frame of the position, it will be updated.',
+        input_schema: {
+          type: 'object',
+          properties: {
+            trackId: {
+              type: 'string',
+              description: 'Track identifier in format "operator-name / fieldName"',
+            },
+            position: { type: 'number', description: 'Time position in seconds' },
+            value: { description: 'The value at this keyframe (number, boolean, or string)' },
+            interpolation: {
+              type: 'string',
+              enum: ['bezier', 'hold'],
+              description: 'Interpolation type (default: bezier)',
+            },
+          },
+          required: ['trackId', 'position', 'value'],
+        },
+      },
+      {
+        name: 'delete_keyframe',
+        description: 'Delete a specific keyframe by its ID. Use get_timeline to find keyframe IDs.',
+        input_schema: {
+          type: 'object',
+          properties: {
+            trackId: { type: 'string', description: 'The track containing the keyframe' },
+            keyframeId: { type: 'string', description: 'The keyframe ID to delete' },
+          },
+          required: ['trackId', 'keyframeId'],
+        },
+      },
+      {
+        name: 'set_playback_position',
+        description:
+          'Scrub the timeline to a specific time position (in seconds) for inspection. Optionally start or stop playback.',
+        input_schema: {
+          type: 'object',
+          properties: {
+            position: { type: 'number', description: 'Time in seconds to seek to' },
+            play: {
+              type: 'boolean',
+              description: 'true to start playback, false to pause, omit to leave unchanged',
+            },
+          },
+          required: ['position'],
+        },
+      },
     ]
   }
 
@@ -528,6 +588,10 @@ export class ClaudeClient {
       list_nodes: () => this.tools.listNodes(),
       get_node_info: p => this.tools.getNodeInfo(p),
       get_node_output: p => this.tools.getNodeOutput(p),
+      get_timeline: () => this.tools.getTimeline(),
+      set_keyframe: p => this.tools.setKeyframe(p),
+      delete_keyframe: p => this.tools.deleteKeyframe(p),
+      set_playback_position: p => this.tools.setPlaybackPosition(p),
     }
 
     const method = methodMap[name]

--- a/noodles-editor/src/ai-chat/mcp-tools.ts
+++ b/noodles-editor/src/ai-chat/mcp-tools.ts
@@ -2,7 +2,11 @@
 
 import type { Operator } from '../noodles/operators'
 import { getOpStore } from '../noodles/store'
-import { captureTimelineState, fireTimelineMutation, getTimelineStore } from '../timeline/timeline-store'
+import {
+  captureTimelineState,
+  fireTimelineMutation,
+  getTimelineStore,
+} from '../timeline/timeline-store'
 import type { Keyframe } from '../timeline/types'
 import { safeStringify } from '../noodles/utils/serialization'
 import type { ContextLoader } from './context-loader'
@@ -889,7 +893,12 @@ export class MCPTools {
   async getTimeline(): Promise<ToolResult> {
     try {
       const store = getTimelineStore()
-      const tracks: Record<string, { keyframes: Array<{ id: string; position: number; value: unknown; interpolation: string }> }> = {}
+      const tracks: Record<
+        string,
+        {
+          keyframes: Array<{ id: string; position: number; value: unknown; interpolation: string }>
+        }
+      > = {}
 
       for (const [trackId, track] of store.tracks) {
         tracks[trackId] = {
@@ -946,12 +955,20 @@ export class MCPTools {
       // Check for existing keyframe near this position (within 1 frame)
       const fps = store.sequence.fps
       const frameDuration = 1 / fps
-      const existing = track.keyframes.find((kf: Keyframe) => Math.abs(kf.position - position) < frameDuration)
+      const existing = track.keyframes.find(
+        (kf: Keyframe) => Math.abs(kf.position - position) < frameDuration
+      )
 
       if (existing) {
-        store.updateKeyframe(trackId, existing.id, { value: value as number | boolean | string, interpolation })
+        store.updateKeyframe(trackId, existing.id, {
+          value: value as number | boolean | string,
+          interpolation,
+        })
         fireTimelineMutation('Update keyframe via AI', before)
-        return { success: true, data: { keyframeId: existing.id, action: 'updated', trackId, position, value } }
+        return {
+          success: true,
+          data: { keyframeId: existing.id, action: 'updated', trackId, position, value },
+        }
       }
 
       const keyframeId = store.addKeyframe(trackId, {

--- a/noodles-editor/src/ai-chat/mcp-tools.ts
+++ b/noodles-editor/src/ai-chat/mcp-tools.ts
@@ -890,7 +890,7 @@ export class MCPTools {
   }
 
   // Get the current timeline state
-  async getTimeline(): Promise<ToolResult> {
+  getTimeline(): ToolResult {
     try {
       const store = getTimelineStore()
       const tracks: Record<
@@ -935,12 +935,12 @@ export class MCPTools {
   }
 
   // Add or update a keyframe on an animated field
-  async setKeyframe(params: {
+  setKeyframe(params: {
     trackId: string
     position: number
     value: unknown
     interpolation?: 'bezier' | 'hold'
-  }): Promise<ToolResult> {
+  }): ToolResult {
     try {
       const { trackId, position, value, interpolation = 'bezier' } = params
       const store = getTimelineStore()
@@ -987,7 +987,7 @@ export class MCPTools {
   }
 
   // Delete a keyframe by ID
-  async deleteKeyframe(params: { trackId: string; keyframeId: string }): Promise<ToolResult> {
+  deleteKeyframe(params: { trackId: string; keyframeId: string }): ToolResult {
     try {
       const { trackId, keyframeId } = params
       const store = getTimelineStore()
@@ -1013,7 +1013,7 @@ export class MCPTools {
   }
 
   // Set the current playback position (scrub to a time)
-  async setPlaybackPosition(params: { position: number; play?: boolean }): Promise<ToolResult> {
+  setPlaybackPosition(params: { position: number; play?: boolean }): ToolResult {
     try {
       const store = getTimelineStore()
       const clamped = Math.max(0, Math.min(params.position, store.sequence.length))

--- a/noodles-editor/src/ai-chat/mcp-tools.ts
+++ b/noodles-editor/src/ai-chat/mcp-tools.ts
@@ -6,8 +6,9 @@ import {
   captureTimelineState,
   fireTimelineMutation,
   getTimelineStore,
+  useTimelineStore,
 } from '../timeline/timeline-store'
-import type { Keyframe } from '../timeline/types'
+import type { Keyframe, KeyframeValue, Track } from '../timeline/types'
 import { safeStringify } from '../noodles/utils/serialization'
 import type { ContextLoader } from './context-loader'
 import type {
@@ -934,7 +935,11 @@ export class MCPTools {
     }
   }
 
-  // Add or update a keyframe on an animated field
+  // Add or update a keyframe on an animated field.
+  // Writes directly to useTimelineStore.setState so that both track creation
+  // and keyframe insertion land in a single undo entry (addKeyframe() fires
+  // its own internal history entry after track creation, leaving a ghost track
+  // on undo — bypassing it here fixes that).
   setKeyframe(params: {
     trackId: string
     position: number
@@ -943,40 +948,53 @@ export class MCPTools {
   }): ToolResult {
     try {
       const { trackId, position, value, interpolation = 'bezier' } = params
+      const kfValue = value as KeyframeValue
       const store = getTimelineStore()
+      const frameDuration = 1 / store.sequence.fps
 
+      // Capture before ANY mutation so undo covers the full operation
       const before = captureTimelineState()
 
-      let track = store.tracks.get(trackId)
-      if (!track) {
-        track = store.getOrCreateTrack(trackId, value as number | boolean | string)
-      }
-
-      // Check for existing keyframe near this position (within 1 frame)
-      const fps = store.sequence.fps
-      const frameDuration = 1 / fps
-      const existing = track.keyframes.find(
+      const existingTrack = store.tracks.get(trackId)
+      const nearbyKf = existingTrack?.keyframes.find(
         (kf: Keyframe) => Math.abs(kf.position - position) < frameDuration
       )
 
-      if (existing) {
-        store.updateKeyframe(trackId, existing.id, {
-          value: value as number | boolean | string,
-          interpolation,
-        })
+      if (nearbyKf) {
+        // Update in place — updateKeyframe has no internal history, so we fire it
+        store.updateKeyframe(trackId, nearbyKf.id, { value: kfValue, interpolation })
         fireTimelineMutation('Update keyframe via AI', before)
         return {
           success: true,
-          data: { keyframeId: existing.id, action: 'updated', trackId, position, value },
+          data: { keyframeId: nearbyKf.id, action: 'updated', trackId, position, value },
         }
       }
 
-      const keyframeId = store.addKeyframe(trackId, {
-        position,
-        value: value as number | boolean | string,
-        interpolation,
+      // Add new keyframe — write directly so track creation + insertion share one undo entry
+      const keyframeId = `kf_${Math.random().toString(36).slice(2, 10)}`
+      const newKf: Keyframe = { id: keyframeId, position, value: kfValue, interpolation }
+
+      useTimelineStore.setState(state => {
+        const newTracks = new Map(state.tracks)
+        const track = newTracks.get(trackId)
+        if (track) {
+          const keyframes = [...track.keyframes, newKf].sort(
+            (a: Keyframe, b: Keyframe) => a.position - b.position
+          )
+          newTracks.set(trackId, { ...track, keyframes })
+        } else {
+          const newTrack: Track = {
+            id: trackId,
+            fieldPath: trackId,
+            keyframes: [newKf],
+            defaultValue: kfValue,
+          }
+          newTracks.set(trackId, newTrack)
+        }
+        return { tracks: newTracks }
       })
 
+      fireTimelineMutation('Add keyframe via AI', before)
       return { success: true, data: { keyframeId, action: 'added', trackId, position, value } }
     } catch (error) {
       return {
@@ -1020,7 +1038,8 @@ export class MCPTools {
       store.setPosition(clamped)
       if (params.play === true) store.play()
       else if (params.play === false) store.pause()
-      return { success: true, data: { position: clamped, playing: store.playing } }
+      // Re-read store after mutations — the snapshot in `store` is stale
+      return { success: true, data: { position: clamped, playing: getTimelineStore().playing } }
     } catch (error) {
       return {
         success: false,

--- a/noodles-editor/src/ai-chat/mcp-tools.ts
+++ b/noodles-editor/src/ai-chat/mcp-tools.ts
@@ -2,6 +2,8 @@
 
 import type { Operator } from '../noodles/operators'
 import { getOpStore } from '../noodles/store'
+import { captureTimelineState, fireTimelineMutation, getTimelineStore } from '../timeline/timeline-store'
+import type { Keyframe } from '../timeline/types'
 import { safeStringify } from '../noodles/utils/serialization'
 import type { ContextLoader } from './context-loader'
 import type {
@@ -879,6 +881,133 @@ export class MCPTools {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to get node info',
+      }
+    }
+  }
+
+  // Get the current timeline state
+  async getTimeline(): Promise<ToolResult> {
+    try {
+      const store = getTimelineStore()
+      const tracks: Record<string, { keyframes: Array<{ id: string; position: number; value: unknown; interpolation: string }> }> = {}
+
+      for (const [trackId, track] of store.tracks) {
+        tracks[trackId] = {
+          keyframes: track.keyframes.map((kf: Keyframe) => ({
+            id: kf.id,
+            position: kf.position,
+            value: kf.value,
+            interpolation: kf.interpolation,
+          })),
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          sequence: {
+            length: store.sequence.length,
+            fps: store.sequence.fps,
+            inPoint: store.sequence.inPoint,
+            outPoint: store.sequence.outPoint,
+          },
+          position: store.position,
+          playing: store.playing,
+          trackCount: store.tracks.size,
+          tracks,
+        },
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get timeline state',
+      }
+    }
+  }
+
+  // Add or update a keyframe on an animated field
+  async setKeyframe(params: {
+    trackId: string
+    position: number
+    value: unknown
+    interpolation?: 'bezier' | 'hold'
+  }): Promise<ToolResult> {
+    try {
+      const { trackId, position, value, interpolation = 'bezier' } = params
+      const store = getTimelineStore()
+
+      const before = captureTimelineState()
+
+      let track = store.tracks.get(trackId)
+      if (!track) {
+        track = store.getOrCreateTrack(trackId, value as number | boolean | string)
+      }
+
+      // Check for existing keyframe near this position (within 1 frame)
+      const fps = store.sequence.fps
+      const frameDuration = 1 / fps
+      const existing = track.keyframes.find((kf: Keyframe) => Math.abs(kf.position - position) < frameDuration)
+
+      if (existing) {
+        store.updateKeyframe(trackId, existing.id, { value: value as number | boolean | string, interpolation })
+        fireTimelineMutation('Update keyframe via AI', before)
+        return { success: true, data: { keyframeId: existing.id, action: 'updated', trackId, position, value } }
+      }
+
+      const keyframeId = store.addKeyframe(trackId, {
+        position,
+        value: value as number | boolean | string,
+        interpolation,
+      })
+
+      return { success: true, data: { keyframeId, action: 'added', trackId, position, value } }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to set keyframe',
+      }
+    }
+  }
+
+  // Delete a keyframe by ID
+  async deleteKeyframe(params: { trackId: string; keyframeId: string }): Promise<ToolResult> {
+    try {
+      const { trackId, keyframeId } = params
+      const store = getTimelineStore()
+      const track = store.tracks.get(trackId)
+
+      if (!track) {
+        return { success: false, error: `Track not found: ${trackId}` }
+      }
+
+      const exists = track.keyframes.some((kf: Keyframe) => kf.id === keyframeId)
+      if (!exists) {
+        return { success: false, error: `Keyframe not found: ${keyframeId}` }
+      }
+
+      store.deleteKeyframe(trackId, keyframeId)
+      return { success: true, data: { deleted: keyframeId, trackId } }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to delete keyframe',
+      }
+    }
+  }
+
+  // Set the current playback position (scrub to a time)
+  async setPlaybackPosition(params: { position: number; play?: boolean }): Promise<ToolResult> {
+    try {
+      const store = getTimelineStore()
+      const clamped = Math.max(0, Math.min(params.position, store.sequence.length))
+      store.setPosition(clamped)
+      if (params.play === true) store.play()
+      else if (params.play === false) store.pause()
+      return { success: true, data: { position: clamped, playing: store.playing } }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to set playback position',
       }
     }
   }

--- a/noodles-editor/src/ai-chat/system-prompt.md
+++ b/noodles-editor/src/ai-chat/system-prompt.md
@@ -16,6 +16,7 @@ You are an AI assistant for Noodles.gl, a node-based geospatial visualization ed
    - Choose layer type based on data: ScatterplotLayerOp (points), ArcLayerOp (routes), GeoJsonLayerOp (polygons)
    - Use AccessorOp for extracting coordinates: `[d.longitude, d.latitude]` or `[d.lng, d.lat]` depending on field names
    - Use `capture_visualization` tool ONLY when user explicitly asks to see the visualization
+   - **VERIFY after adding data nodes**: call `get_node_output` on the data source before building any visualization layers
 
 2. **Updating Visualizations**:
    - Use `list_nodes` to see current nodes and find targets
@@ -42,15 +43,37 @@ You are an AI assistant for Noodles.gl, a node-based geospatial visualization ed
    - Example: `SELECT * FROM data WHERE magnitude > 5`
    - Always verify data transformations with `get_node_output`
 
+5. **Timeline Animation**:
+   - Use `get_timeline` to read the current animation state (tracks, keyframes, sequence length/FPS)
+   - Use `set_keyframe` to add or update a keyframe on any animatable field
+   - Track IDs follow the pattern: `"operator-name / fieldName"` (e.g., `"my-layer / opacity"`)
+   - Position is in seconds; use the sequence length and FPS from `get_timeline` to orient keyframes
+   - Interpolation types: `"bezier"` (smooth, default) or `"hold"` (step/snap)
+   - Use `set_playback_position` to scrub the timeline to a specific time for inspection
+   - Example: animate opacity from 0→1 over 2 seconds → add keyframe at t=0 with value=0, then at t=2 with value=1
+
 **Node Graph Layout**:
 - Arrange LEFT → RIGHT: Data sources → Transforms/Accessors → Layers → Renderer → Output
 - Increment X position by ~300-400 for each step
 - Use consistent Y positions for related nodes
 
+**Graph Design Principles**:
+
+- **Keep graphs simple.** Prefer fewer, more expressive nodes over long chains of single-purpose nodes. A human needs to understand and modify the graph you create.
+- **Use CodeOp for data transformation logic.** Chaining FilterOp → MapOp → SortOp → SliceOp is fragile (many edge opportunities for errors). A single CodeOp with 5 lines of JS is more readable and reliable:
+  ```javascript
+  return data
+    .filter(d => d.status === 'active')
+    .sort((a, b) => b.value - a.value)
+    .slice(0, 100)
+  ```
+- **Use the node graph for data flow architecture**: FileOp → CodeOp → LayerOp → DeckRendererOp. Use CodeOp for the *logic* within that architecture.
+- **Limit nodes per task.** For any single visualization request, aim for 5-8 nodes total. If you're adding more, use CodeOp to consolidate transformation logic.
+
 **Common Operators & Properties**:
 - Data: FileOp, JSONOp, DuckDbOp
 - Layers: ScatterplotLayerOp, ArcLayerOp, GeoJsonLayerOp, HexagonLayerOp, PathLayerOp
-- Utilities: AccessorOp, ColorOp, ColorRampOp, MapRangeOp
+- Utilities: AccessorOp, CodeOp, ColorOp, ColorRampOp, MapRangeOp
 - Output: MaplibreBasemapOp, DeckRendererOp, OutOp
 
 **CRITICAL: Handle Naming Format**:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Timeline MCP tools**: adds `get_timeline`, `set_keyframe`, `delete_keyframe`, and `set_playback_position` to the in-app Claude chat — closing the biggest capability gap where AI could read and modify any node property but had no access to animation keyframes at all
- **System prompt improvements**: mandatory `get_node_output` verification step after adding data nodes; explicit guidance to prefer `CodeOp` for multi-step data transformation over chaining many single-purpose operators; new "Graph Design Principles" section
- **AGENTS.md Claude Code section**: documents the direct project file editing workflow, how to validate changes, and how to connect Claude Code to a running browser instance via the MCP proxy

## Why

From a strategic review of the AI integration: the node graph's core value in the age of LLMs is live data inspection, timeline animation, and human+AI co-editing — not avoiding code. These changes lean into that:

1. **Timeline was completely inaccessible to AI** — "animate the arc height over 10 seconds" was an unanswerable request
2. **The system prompt was generating fragile chains** (FilterOp → MapOp → SortOp) when one CodeOp is more reliable; AI writes JS well, so let it
3. **Claude Code had no documented path** for working with Noodles projects without the browser UI

## Test plan

- [ ] In-app chat: ask "animate the layer opacity from 0 to 1 over 3 seconds" — should call `get_timeline`, then `set_keyframe` twice
- [ ] In-app chat: ask "show me the current animation state" — should return sequence length, FPS, and any existing tracks
- [ ] In-app chat with a data task: verify Claude calls `get_node_output` before building the visualization layer
- [ ] In-app chat with a multi-step transformation: verify Claude uses one `CodeOp` rather than chaining `FilterOp → MapOp → SortOp`
- [ ] AGENTS.md: confirms Claude Code workflow section is present and accurate

https://claude.ai/code/session_01Tk96oWf2u22YbVJmp4oXQY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk96oWf2u22YbVJmp4oXQY)_