### PR TITLE
Switch default edges to smooth-step routing

### DIFF
--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -5,7 +5,7 @@ import * as Tooltip from '@radix-ui/react-tooltip'
 import {
   BaseEdge,
   type EdgeProps,
-  getBezierPath,
+  getSmoothStepPath,
   getStraightPath,
   Handle,
   NodeResizer,
@@ -229,13 +229,14 @@ function DefaultEdgeComponent({
 }: EdgeProps) {
   const targetedEdge = useUIStore(s => s.targetedEdge)
   const nodeDragState = useUIStore(s => s.nodeDragState)
-  const [edgePath] = getBezierPath({
+  const [edgePath] = getSmoothStepPath({
     sourceX,
     sourceY,
     targetX,
     targetY,
     sourcePosition,
     targetPosition,
+    borderRadius: 8,
   })
 
   // Edge is targeted if either connection drag or node drag is targeting it


### PR DESCRIPTION
## Summary

- Replaces `getBezierPath` with `getSmoothStepPath` (`borderRadius: 8`) in `DefaultEdgeComponent`
- Edges now follow orthogonal (right-angle) paths with rounded corners instead of free-form bezier curves
- Matches the pattern from the [React Flow edge-routing example](https://reactflow.dev/examples/edges/edge-routing)
- `ReferenceEdge` (code reference edges, drawn with `getStraightPath`) is unchanged

## Test plan

- [ ] Open the editor and load any example project (e.g. `http://localhost:5173/examples/nyc-taxis`)
- [ ] Verify edges between nodes route with right-angle bends and rounded corners (~8px radius)
- [ ] Drag a node and confirm edges re-route correctly
- [ ] Create a new connection — confirm the new edge uses the smooth-step style
- [ ] Check code-reference edges (dashed lines between code operators) still render as straight lines

https://claude.ai/code/session_014Run6dXe7XB6wzQnWdoG3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_014Run6dXe7XB6wzQnWdoG3Z)_