### PR TITLE
fix: add error handling to cancel-cf-build workflow

### DIFF
--- a/.github/workflows/cancel-cf-build.yml
+++ b/.github/workflows/cancel-cf-build.yml
@@ -26,9 +26,16 @@ jobs:
           fi
           page=1
           while true; do
-            response=$(curl -sf \
+            response=$(curl -sS \
               "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/pages/projects/$CF_PROJECT/deployments?per_page=25&page=$page" \
-              -H "Authorization: Bearer $CF_API_TOKEN")
+              -H "Authorization: Bearer $CF_API_TOKEN") || true
+
+            # Check if API call succeeded
+            if ! echo "$response" | jq -e '.success == true' > /dev/null 2>&1; then
+              echo "Warning: Cloudflare API error on page $page"
+              echo "$response" | jq -r '.errors[]?.message // "Unknown error"' 2>/dev/null || echo "Could not parse error response"
+              break
+            fi
 
             echo "$response" | jq -r \
               --arg branch "$BRANCH" \
@@ -41,10 +48,17 @@ jobs:
               ) | .id' \
             | while read -r id; do
                 echo "Cancelling deployment $id for branch $BRANCH"
-                curl -sf -X POST \
+                cancel_response=$(curl -sS -X POST \
                   "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/pages/projects/$CF_PROJECT/deployments/$id/cancel" \
                   -H "Authorization: Bearer $CF_API_TOKEN" \
-                  -H "Content-Type: application/json"
+                  -H "Content-Type: application/json") || true
+
+                if ! echo "$cancel_response" | jq -e '.success == true' > /dev/null 2>&1; then
+                  echo "Warning: Failed to cancel deployment $id"
+                  echo "$cancel_response" | jq -r '.errors[]?.message // "Unknown error"' 2>/dev/null || true
+                else
+                  echo "Successfully cancelled deployment $id"
+                fi
               done
 
             total=$(echo "$response" | jq '.result_info.total_count')


### PR DESCRIPTION
#### Background

The cancel-cf-build.yml workflow was failing with exit code 56 (curl network error) when the Cloudflare API returned HTTP errors (404, 401, 429, 500, etc.). This caused the entire job to fail, even though it's a non-critical cleanup operation.

Example failure: https://github.com/joby-aviation/noodles.gl/actions/runs/26819786690/job/79071014191

#### Change List
- Changed curl flags from `-sf` to `-sS` to prevent failure on HTTP errors
- Added validation of Cloudflare API response `.success` field before processing
- Added warning messages when API calls fail
- Wrapped cancellation requests with error handling to continue on individual failures
- Workflow now succeeds gracefully even when API errors occur