### PR TITLE
fix: improve dirty state detection to reduce false warnings

### DIFF
--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -292,11 +292,9 @@ export function getNoodles(): Visualization {
 
   // Warn before leaving page with unsaved changes
   useEffect(() => {
-    const isExampleRoute = location.startsWith('/examples/')
-
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       // Don't warn for examples - they're read-only demos
-      if (isExampleRoute) {
+      if (isExamplesRoute) {
         return
       }
       if (hasUnsavedChanges || storageType === 'memory') {
@@ -310,12 +308,12 @@ export function getNoodles(): Visualization {
         ? memoryProjectStore.getDisplayName(projectName || '') || 'Untitled'
         : projectName
     // Don't show asterisk for examples - they're read-only
-    const showAsterisk = !isExampleRoute && (hasUnsavedChanges || storageType === 'memory')
+    const showAsterisk = !isExamplesRoute && (hasUnsavedChanges || storageType === 'memory')
     document.title = displayName ? `Noodles.gl - ${displayName}${showAsterisk ? ' *' : ''}` : 'Noodles.gl'
 
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [hasUnsavedChanges, projectName, storageType, location])
+  }, [hasUnsavedChanges, projectName, storageType, isExamplesRoute])
 
   // Only changes when graph structure changes (nodes added/removed/type changed, edges reconnected)
   // Intentionally excludes node position so dragging does NOT re-run transformGraph

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -292,9 +292,11 @@ export function getNoodles(): Visualization {
 
   // Warn before leaving page with unsaved changes
   useEffect(() => {
+    const isExampleRoute = location.startsWith('/examples/')
+
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       // Don't warn for examples - they're read-only demos
-      if (location.startsWith('/examples/')) {
+      if (isExampleRoute) {
         return
       }
       if (hasUnsavedChanges || storageType === 'memory') {
@@ -308,8 +310,7 @@ export function getNoodles(): Visualization {
         ? memoryProjectStore.getDisplayName(projectName || '') || 'Untitled'
         : projectName
     // Don't show asterisk for examples - they're read-only
-    const showAsterisk =
-      !location.startsWith('/examples/') && (hasUnsavedChanges || storageType === 'memory')
+    const showAsterisk = !isExampleRoute && (hasUnsavedChanges || storageType === 'memory')
     document.title = displayName ? `Noodles.gl - ${displayName}${showAsterisk ? ' *' : ''}` : 'Noodles.gl'
 
     window.addEventListener('beforeunload', handleBeforeUnload)

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -293,6 +293,10 @@ export function getNoodles(): Visualization {
   // Warn before leaving page with unsaved changes
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      // Don't warn for examples - they're read-only demos
+      if (location.startsWith('/examples/')) {
+        return
+      }
       if (hasUnsavedChanges || storageType === 'memory') {
         e.preventDefault()
         e.returnValue = ''
@@ -303,13 +307,14 @@ export function getNoodles(): Visualization {
       storageType === 'memory'
         ? memoryProjectStore.getDisplayName(projectName || '') || 'Untitled'
         : projectName
-    document.title = displayName
-      ? `Noodles.gl - ${displayName}${hasUnsavedChanges || storageType === 'memory' ? ' *' : ''}`
-      : 'Noodles.gl'
+    // Don't show asterisk for examples - they're read-only
+    const showAsterisk =
+      !location.startsWith('/examples/') && (hasUnsavedChanges || storageType === 'memory')
+    document.title = displayName ? `Noodles.gl - ${displayName}${showAsterisk ? ' *' : ''}` : 'Noodles.gl'
 
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [hasUnsavedChanges, projectName, storageType])
+  }, [hasUnsavedChanges, projectName, storageType, location])
 
   // Only changes when graph structure changes (nodes added/removed/type changed, edges reconnected)
   // Intentionally excludes node position so dragging does NOT re-run transformGraph


### PR DESCRIPTION
Fixes overly aggressive "unsaved changes" dialog showing false positives.

#### Background
The dialog was triggering in three scenarios where there weren't actual changes:
1. After undoing changes back to saved state  
2. During project load (React Flow initialization events)
3. During timeline playback (every animation frame)

#### Change List
- Add state-based comparison on undo/redo to clear dirty flag when returning to saved state
- Add loading guard (`isLoadingRef`) to prevent initialization events from marking project dirty  
- Add timeline playback guard to skip dirty detection during animation
- Add `checkIfStateMatchesSaved` callback invoked by UndoRedoHandler after undo/redo
- Smart beforeunload handler compares serialized state vs saved signature before showing dialog
- Zero overhead during normal editing (only checks on undo/redo and window unload)
- Add state comparison utilities with 18 unit tests (all passing)
- Add 3 E2E Playwright tests for load/playback/selection scenarios (all passing)
- Add manual test plan (`MANUAL_TEST.md`) for validation

**Performance:** <5ms check only on undo/redo and unload, zero cost during editing and playback.

**Testing:** 18 unit tests + 3 E2E tests passing. Two E2E drag tests skipped (need React Flow drag simulation investigation).