### PR TITLE
test: ensure example projects are migrated to latest schema version

### DIFF
--- a/.github/workflows/migrate-project-files.yml
+++ b/.github/workflows/migrate-project-files.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'animations/timeline-editor/src/visualizations/noodles/__migrations__/*.ts'
+      - 'noodles-editor/src/noodles/__migrations__/*.ts'
   workflow_dispatch:
 
 permissions:
@@ -25,7 +25,7 @@ jobs:
       - name: Check for new migration files
         id: check-migrations
         run: |
-          if git diff HEAD~1 HEAD --name-only | grep -q "animations/timeline-editor/src/visualizations/noodles/__migrations__/.*\.ts$"; then
+          if git diff HEAD~1 HEAD --name-only | grep -q "noodles-editor/src/noodles/__migrations__/.*\.ts$"; then
             echo "has-new-migrations=true" >> $GITHUB_OUTPUT
             echo "New migration files detected"
           else
@@ -81,7 +81,7 @@ jobs:
           body: |
             ## Automated Project File Migration
 
-            This PR contains automated migrations of project files in `noodles-editor/public/examples/` after detecting new migration files in the codebase.
+            This PR contains automated migrations of project files in `noodles-editor/src/examples/` and `noodles-editor/public/noodles/` after detecting new migration files in the codebase.
 
             ### Changes
             - Applied latest schema migrations to project files

--- a/noodles-editor/public/noodles/table-editor-demo.json
+++ b/noodles-editor/public/noodles/table-editor-demo.json
@@ -1,123 +1,5 @@
 {
-  "version": 6,
-  "nodes": [
-    {
-      "id": "/cities-table",
-      "type": "TableEditorOp",
-      "position": { "x": 100, "y": 100 },
-      "data": {
-        "inputs": {
-          "schema": {
-            "columns": [
-              { "name": "city", "type": "string", "defaultValue": "" },
-              {
-                "name": "position",
-                "type": "point2d",
-                "defaultValue": [0, 0],
-                "options": { "geocoder": true }
-              },
-              {
-                "name": "population",
-                "type": "number",
-                "defaultValue": 0,
-                "options": { "min": 0, "step": 1 }
-              },
-              { "name": "color", "type": "color", "defaultValue": "#3b82f6" },
-              { "name": "active", "type": "boolean", "defaultValue": true }
-            ]
-          },
-          "data": [
-            {
-              "city": "New York City",
-              "position": [-74.006, 40.7128],
-              "population": 8336817,
-              "color": "#ff5733",
-              "active": true
-            },
-            {
-              "city": "San Francisco",
-              "position": [-122.4194, 37.7749],
-              "population": 873965,
-              "color": "#33ff57",
-              "active": true
-            },
-            {
-              "city": "Los Angeles",
-              "position": [-118.2437, 34.0522],
-              "population": 3979576,
-              "color": "#3357ff",
-              "active": true
-            },
-            {
-              "city": "Chicago",
-              "position": [-87.6298, 41.8781],
-              "population": 2693976,
-              "color": "#ff33f5",
-              "active": false
-            },
-            {
-              "city": "Seattle",
-              "position": [-122.3321, 47.6062],
-              "population": 753675,
-              "color": "#f5ff33",
-              "active": true
-            }
-          ]
-        }
-      }
-    },
-    {
-      "id": "/scatter",
-      "type": "ScatterplotLayerOp",
-      "position": { "x": 400, "y": 100 },
-      "data": {
-        "inputs": {
-          "data": null,
-          "getPosition": "d => d.position",
-          "getRadius": "d => Math.sqrt(d.population) * 5",
-          "getFillColor": "d => hexToColor(d.color)",
-          "radiusMinPixels": 5,
-          "radiusMaxPixels": 50,
-          "pickable": true
-        }
-      }
-    },
-    {
-      "id": "/text-layer",
-      "type": "TextLayerOp",
-      "position": { "x": 400, "y": 300 },
-      "data": {
-        "inputs": {
-          "data": null,
-          "getPosition": "d => d.position",
-          "getText": "d => d.city",
-          "getSize": 14,
-          "getColor": "[255, 255, 255, 255]",
-          "getPixelOffset": "[0, -20]",
-          "fontWeight": 600,
-          "pickable": true
-        }
-      }
-    },
-    {
-      "id": "/viewer",
-      "type": "ViewerOp",
-      "position": { "x": 700, "y": 200 },
-      "data": {
-        "inputs": {
-          "layers": null
-        }
-      }
-    },
-    {
-      "id": "/merge-layers",
-      "type": "MergeOp",
-      "position": { "x": 550, "y": 200 },
-      "data": {
-        "inputs": {}
-      }
-    }
-  ],
+  "version": 14,
   "edges": [
     {
       "id": "/cities-table.out.data->/scatter.par.data",
@@ -155,5 +37,190 @@
       "targetHandle": "par.layers"
     }
   ],
-  "viewport": { "x": 0, "y": 0, "zoom": 1 }
+  "viewport": {
+    "x": 0,
+    "y": 0,
+    "zoom": 1
+  },
+  "editorSettings": {
+    "layoutMode": "noodles-on-top",
+    "showOverlay": true
+  },
+  "nodes": [
+    {
+      "id": "/cities-table",
+      "type": "TableEditorOp",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "data": {
+        "inputs": {
+          "schema": {
+            "columns": [
+              {
+                "name": "city",
+                "type": "string",
+                "defaultValue": ""
+              },
+              {
+                "name": "position",
+                "type": "point2d",
+                "defaultValue": [
+                  0,
+                  0
+                ],
+                "options": {
+                  "geocoder": true
+                }
+              },
+              {
+                "name": "population",
+                "type": "number",
+                "defaultValue": 0,
+                "options": {
+                  "min": 0,
+                  "step": 1
+                }
+              },
+              {
+                "name": "color",
+                "type": "color",
+                "defaultValue": "#3b82f6"
+              },
+              {
+                "name": "active",
+                "type": "boolean",
+                "defaultValue": true
+              }
+            ]
+          },
+          "data": [
+            {
+              "city": "New York City",
+              "position": [
+                -74.006,
+                40.7128
+              ],
+              "population": 8336817,
+              "color": "#ff5733",
+              "active": true
+            },
+            {
+              "city": "San Francisco",
+              "position": [
+                -122.4194,
+                37.7749
+              ],
+              "population": 873965,
+              "color": "#33ff57",
+              "active": true
+            },
+            {
+              "city": "Los Angeles",
+              "position": [
+                -118.2437,
+                34.0522
+              ],
+              "population": 3979576,
+              "color": "#3357ff",
+              "active": true
+            },
+            {
+              "city": "Chicago",
+              "position": [
+                -87.6298,
+                41.8781
+              ],
+              "population": 2693976,
+              "color": "#ff33f5",
+              "active": false
+            },
+            {
+              "city": "Seattle",
+              "position": [
+                -122.3321,
+                47.6062
+              ],
+              "population": 753675,
+              "color": "#f5ff33",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "/scatter",
+      "type": "ScatterplotLayerOp",
+      "position": {
+        "x": 400,
+        "y": 100
+      },
+      "data": {
+        "inputs": {
+          "data": null,
+          "getPosition": "d => d.position",
+          "getRadius": "d => Math.sqrt(d.population) * 5",
+          "getFillColor": "d => hexToColor(d.color)",
+          "radiusMinPixels": 5,
+          "radiusMaxPixels": 50,
+          "pickable": true
+        }
+      }
+    },
+    {
+      "id": "/text-layer",
+      "type": "TextLayerOp",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "data": {
+        "inputs": {
+          "data": null,
+          "getPosition": "d => d.position",
+          "getText": "d => d.city",
+          "getSize": 14,
+          "getColor": "[255, 255, 255, 255]",
+          "getPixelOffset": "[0, -20]",
+          "fontWeight": 600,
+          "pickable": true
+        }
+      }
+    },
+    {
+      "id": "/viewer",
+      "type": "ViewerOp",
+      "position": {
+        "x": 700,
+        "y": 200
+      },
+      "data": {
+        "inputs": {
+          "layers": null
+        }
+      }
+    },
+    {
+      "id": "/merge-layers",
+      "type": "ConcatOp",
+      "position": {
+        "x": 550,
+        "y": 200
+      },
+      "data": {
+        "inputs": {}
+      }
+    }
+  ],
+  "timeline": {
+    "sheetsById": {
+      "Noodles": {
+        "staticOverrides": {
+          "byObject": {}
+        }
+      }
+    }
+  }
 }

--- a/noodles-editor/scripts/migrate-project-files.ts
+++ b/noodles-editor/scripts/migrate-project-files.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { migrateProject } from '../src/noodles/utils/migrate-schema.js'
 
 const EXAMPLES_DIR = './src/examples'
+const PUBLIC_DIR = './public/noodles'
 
 async function getAllFiles(dir: string, extension = '.json'): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true })
@@ -21,7 +22,9 @@ async function getAllFiles(dir: string, extension = '.json'): Promise<string[]> 
 
 async function migrateFiles() {
   try {
-    const files = await getAllFiles(EXAMPLES_DIR)
+    const exampleFiles = await getAllFiles(EXAMPLES_DIR)
+    const publicFiles = await getAllFiles(PUBLIC_DIR)
+    const files = [...exampleFiles, ...publicFiles]
     let migratedCount = 0
     let skippedCount = 0
 

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -309,7 +309,9 @@ export function getNoodles(): Visualization {
         : projectName
     // Don't show asterisk for examples - they're read-only
     const showAsterisk = !isExamplesRoute && (hasUnsavedChanges || storageType === 'memory')
-    document.title = displayName ? `Noodles.gl - ${displayName}${showAsterisk ? ' *' : ''}` : 'Noodles.gl'
+    document.title = displayName
+      ? `Noodles.gl - ${displayName}${showAsterisk ? ' *' : ''}`
+      : 'Noodles.gl'
 
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)

--- a/noodles-editor/src/noodles/utils/examples-version.test.ts
+++ b/noodles-editor/src/noodles/utils/examples-version.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { NOODLES_VERSION } from './migrate-schema'
+import type { NoodlesProjectJSON } from './serialization'
+
+// Import all example project files
+const exampleProjects = import.meta.glob('../../examples/**/noodles.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, NoodlesProjectJSON>
+
+// Import public demo projects
+const publicProjects = import.meta.glob('../../public/noodles/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, NoodlesProjectJSON>
+
+const allProjects = { ...exampleProjects, ...publicProjects }
+
+describe('Example projects version', () => {
+  it('should have at least one example project', () => {
+    expect(Object.keys(allProjects).length).toBeGreaterThan(0)
+  })
+
+  it('all example projects should be at the latest schema version', () => {
+    const outdatedProjects: string[] = []
+
+    for (const [path, project] of Object.entries(allProjects)) {
+      if (project.version !== NOODLES_VERSION) {
+        outdatedProjects.push(
+          `${path}: version ${project.version} (expected ${NOODLES_VERSION})`
+        )
+      }
+    }
+
+    if (outdatedProjects.length > 0) {
+      throw new Error(
+        `The following example projects need to be migrated to version ${NOODLES_VERSION}:\n\n${outdatedProjects.join('\n')}\n\nRun the migration script or manually update each project file.`
+      )
+    }
+  })
+
+  it('all example projects should have a valid version number', () => {
+    for (const [path, project] of Object.entries(allProjects)) {
+      expect(
+        project.version,
+        `${path} should have a version field`
+      ).toBeDefined()
+      expect(
+        typeof project.version,
+        `${path} version should be a number`
+      ).toBe('number')
+      expect(
+        project.version,
+        `${path} version should be positive`
+      ).toBeGreaterThanOrEqual(0)
+    }
+  })
+})

--- a/noodles-editor/src/noodles/utils/examples-version.test.ts
+++ b/noodles-editor/src/noodles/utils/examples-version.test.ts
@@ -9,7 +9,7 @@ const exampleProjects = import.meta.glob('../../examples/**/noodles.json', {
 }) as Record<string, NoodlesProjectJSON>
 
 // Import public demo projects
-const publicProjects = import.meta.glob('../../public/noodles/*.json', {
+const publicProjects = import.meta.glob('../../../public/noodles/*.json', {
   eager: true,
   import: 'default',
 }) as Record<string, NoodlesProjectJSON>


### PR DESCRIPTION
#### Background

When adding a new migration to bump the schema version, example projects need to be migrated to the latest version. Previously, this could be missed until someone tried to load an example and noticed it was outdated.

#### Change List
- Add CI test that verifies all 18 example projects (src/examples/**/noodles.json and public/noodles/*.json) are at the latest schema version (NOODLES_VERSION)
- Test dynamically imports all example files and compares versions, failing with a clear list of outdated projects when a new migration is added
- Fix migrate-project-files.yml workflow path bug (was watching old animations/ directory instead of noodles-editor/)
- Update workflow to correctly detect new migrations and auto-create PR with migrated examples
- Fix code formatting in noodles.tsx (split long ternary across multiple lines per Biome requirements)