### PR TITLE
fix: correct SF Bike Parking example ID

### DIFF
--- a/noodles-editor/src/components/examples-view.tsx
+++ b/noodles-editor/src/components/examples-view.tsx
@@ -86,7 +86,7 @@ export const CURATED_EXAMPLES = [
     icon: 'pi-car',
   },
   {
-    id: 'sf-bike-parking',
+    id: 'aggregation-example',
     title: 'SF Bike Parking',
     description: 'Bike parking facilities across San Francisco',
     icon: 'pi-map',


### PR DESCRIPTION
#### Background

The SF Bike Parking example in the quick start menu was using the ID 'sf-bike-parking' but the actual directory name is 'aggregation-example', causing the example to fail to load when selected.

#### Change List
- Updated example ID from 'sf-bike-parking' to 'aggregation-example' in examples-view.tsx