### PR TITLE
feat: detect geometry column in Point2D/3DField for NetworkOp compatibility

### DIFF
--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -1168,6 +1168,30 @@ describe('Point2DField', () => {
     field.setValue(geoJsonFeature)
     expect(field.value).toEqual([-118.4182302, 34.0576856])
   })
+
+  it('extracts coordinates from bare GeoJSON Point geometry', () => {
+    const field = new Point2DField()
+    field.setValue({ type: 'Point', coordinates: [-73.78, 40.64] })
+    expect(field.value).toEqual({ lng: -73.78, lat: 40.64 })
+  })
+
+  it('extracts coordinates from geometry column with [lng, lat] tuple', () => {
+    const field = new Point2DField()
+    field.setValue({ id: 1, geometry: [-73.78, 40.64] })
+    expect(field.value).toEqual({ lng: -73.78, lat: 40.64 })
+  })
+
+  it('extracts coordinates from geometry column with GeoJSON Point', () => {
+    const field = new Point2DField()
+    field.setValue({ id: 1, geometry: { type: 'Point', coordinates: [-73.78, 40.64] } })
+    expect(field.value).toEqual({ lng: -73.78, lat: 40.64 })
+  })
+
+  it('extracts coordinates from geometry column to tuple', () => {
+    const field = new Point2DField(undefined, { returnType: 'tuple' })
+    field.setValue({ id: 1, geometry: [-73.78, 40.64] })
+    expect(field.value).toEqual([-73.78, 40.64])
+  })
 })
 
 describe('Point3DField', () => {
@@ -1307,6 +1331,58 @@ describe('Point3DField', () => {
     }
     field.setValue(geoJsonFeature)
     expect(field.value).toEqual([-118.4182302, 34.0576856, 0])
+  })
+
+  it('extracts coordinates from bare GeoJSON Point geometry', () => {
+    const field = new Point3DField()
+    field.setValue({ type: 'Point', coordinates: [-73.78, 40.64, 100] })
+    expect(field.value).toEqual({ lng: -73.78, lat: 40.64, alt: 100 })
+  })
+
+  it('extracts 2D coordinates from bare GeoJSON Point geometry with alt=0', () => {
+    const field = new Point3DField()
+    field.setValue({ type: 'Point', coordinates: [-73.78, 40.64] })
+    expect(field.value).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+  })
+
+  it('extracts coordinates from geometry column with [lng, lat] tuple', () => {
+    const field = new Point3DField()
+    field.setValue({ id: 1, geometry: [-73.78, 40.64] })
+    expect(field.value).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+  })
+
+  it('extracts coordinates from geometry column with [lng, lat, alt] tuple', () => {
+    const field = new Point3DField()
+    field.setValue({ id: 1, geometry: [-73.78, 40.64, 100] })
+    expect(field.value).toEqual({ lng: -73.78, lat: 40.64, alt: 100 })
+  })
+
+  it('extracts coordinates from geometry column with GeoJSON Point', () => {
+    const field = new Point3DField()
+    field.setValue({ id: 1, geometry: { type: 'Point', coordinates: [-73.78, 40.64, 100] } })
+    expect(field.value).toEqual({ lng: -73.78, lat: 40.64, alt: 100 })
+  })
+
+  it('extracts coordinates from geometry column to tuple', () => {
+    const field = new Point3DField(undefined, { returnType: 'tuple' })
+    field.setValue({ id: 1, geometry: [-73.78, 40.64, 100] })
+    expect(field.value).toEqual([-73.78, 40.64, 100])
+  })
+
+  it('ignores geometry column with non-point data', () => {
+    const field = new Point3DField()
+    field.setValue({
+      id: 1,
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [0, 0],
+          [1, 1],
+        ],
+      },
+    })
+    // Should fall back to default since no valid point data
+    expect(field.value).toEqual({ lng: 0, lat: 0, alt: 0 })
   })
 })
 

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -756,7 +756,8 @@ function extractGeometryColumn(
     typeof geom[1] === 'number'
   ) {
     if (dimensions === 3) {
-      return { lng: geom[0], lat: geom[1], alt: geom.length >= 3 ? geom[2] : 0 }
+      const alt = geom.length >= 3 && typeof geom[2] === 'number' ? geom[2] : 0
+      return { lng: geom[0], lat: geom[1], alt }
     }
     return { lng: geom[0], lat: geom[1] }
   }
@@ -877,16 +878,9 @@ export class Point3DField extends Field<
         .unknown()
         .transform(val => {
           // Normalize column names for 2D variant (no altitude)
-          // Note: GeoJSON Point geometries/Features are handled by the first union arm
+          // Note: GeoJSON Point geometries/Features and geometry columns are handled by the first union arm
           if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
             const obj = val as Record<string, unknown>
-
-            // Check for a "geometry" column containing point data
-            const geomCoords = extractGeometryColumn(obj, 2)
-            if (geomCoords) {
-              return geomCoords
-            }
-
             const normalized: Record<string, unknown> = {}
             let hasLng = false
             let hasLat = false

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -687,8 +687,8 @@ export class GeoJsonField<D extends Field = Field, TElement = unknown> extends F
   }
 }
 
-// Helper to extract coordinates from GeoJSON Point Features
-// Used by Point2DField and Point3DField to accept PointOp outputs directly
+// Helper to extract coordinates from GeoJSON Point geometries or Features
+// Used by Point2DField and Point3DField to accept PointOp outputs and geometry columns
 function extractGeoJsonPointCoordinates(
   val: unknown,
   dimensions: 2 | 3 = 3
@@ -699,16 +699,9 @@ function extractGeoJsonPointCoordinates(
 
   const obj = val as Record<string, unknown>
 
-  // Check if it's a GeoJSON Point Feature
-  if (obj.type !== 'Feature' || typeof obj.geometry !== 'object' || obj.geometry === null) {
-    return null
-  }
-
-  const geom = obj.geometry as Record<string, unknown>
-
-  // Extract coordinates from Point geometry
-  if (geom.type === 'Point' && Array.isArray(geom.coordinates) && geom.coordinates.length >= 2) {
-    const coords = geom.coordinates as number[]
+  // Check if it's a bare GeoJSON Point geometry
+  if (obj.type === 'Point' && Array.isArray(obj.coordinates) && obj.coordinates.length >= 2) {
+    const coords = obj.coordinates as number[]
     if (dimensions === 3) {
       return {
         lng: coords[0],
@@ -720,6 +713,58 @@ function extractGeoJsonPointCoordinates(
       lng: coords[0],
       lat: coords[1],
     }
+  }
+
+  // Check if it's a GeoJSON Point Feature
+  if (obj.type === 'Feature' && typeof obj.geometry === 'object' && obj.geometry !== null) {
+    const geom = obj.geometry as Record<string, unknown>
+    if (geom.type === 'Point' && Array.isArray(geom.coordinates) && geom.coordinates.length >= 2) {
+      const coords = geom.coordinates as number[]
+      if (dimensions === 3) {
+        return {
+          lng: coords[0],
+          lat: coords[1],
+          alt: coords.length >= 3 ? coords[2] : 0,
+        }
+      }
+      return {
+        lng: coords[0],
+        lat: coords[1],
+      }
+    }
+  }
+
+  return null
+}
+
+// Extract point coordinates from a row object's "geometry" column.
+// Handles: [lng, lat], [lng, lat, alt], {type: "Point", coordinates: [...]}, and GeoJSON Features.
+function extractGeometryColumn(
+  obj: Record<string, unknown>,
+  dimensions: 2 | 3 = 3
+): { lng: number; lat: number; alt: number } | { lng: number; lat: number } | null {
+  const geom = obj.geometry
+  if (geom === undefined || geom === null) {
+    return null
+  }
+
+  // geometry is a [lng, lat] or [lng, lat, alt] tuple
+  if (
+    Array.isArray(geom) &&
+    geom.length >= 2 &&
+    typeof geom[0] === 'number' &&
+    typeof geom[1] === 'number'
+  ) {
+    if (dimensions === 3) {
+      return { lng: geom[0], lat: geom[1], alt: geom.length >= 3 ? geom[2] : 0 }
+    }
+    return { lng: geom[0], lat: geom[1] }
+  }
+
+  // geometry is a GeoJSON Point geometry or Feature
+  const geoJsonCoords = extractGeoJsonPointCoordinates(geom, dimensions)
+  if (geoJsonCoords) {
+    return geoJsonCoords
   }
 
   return null
@@ -758,7 +803,7 @@ export class Point3DField extends Field<
       z
         .unknown()
         .transform(val => {
-          // Try to extract GeoJSON Point Feature coordinates (3D)
+          // Try to extract GeoJSON Point geometry or Feature coordinates (3D)
           const geoJsonCoords = extractGeoJsonPointCoordinates(val, 3)
           if (geoJsonCoords) {
             return geoJsonCoords
@@ -767,6 +812,13 @@ export class Point3DField extends Field<
           // Normalize column names: support Longitude/Latitude, longitude/latitude, lon/lat
           if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
             const obj = val as Record<string, unknown>
+
+            // Check for a "geometry" column containing point data
+            const geomCoords = extractGeometryColumn(obj, 3)
+            if (geomCoords) {
+              return geomCoords
+            }
+
             const normalized: Record<string, unknown> = {}
             let hasLng = false
             let hasLat = false
@@ -825,9 +877,16 @@ export class Point3DField extends Field<
         .unknown()
         .transform(val => {
           // Normalize column names for 2D variant (no altitude)
-          // Note: GeoJSON Features are handled by the first union arm
+          // Note: GeoJSON Point geometries/Features are handled by the first union arm
           if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
             const obj = val as Record<string, unknown>
+
+            // Check for a "geometry" column containing point data
+            const geomCoords = extractGeometryColumn(obj, 2)
+            if (geomCoords) {
+              return geomCoords
+            }
+
             const normalized: Record<string, unknown> = {}
             let hasLng = false
             let hasLat = false
@@ -917,7 +976,7 @@ export class Point2DField extends Field<
       z
         .unknown()
         .transform(val => {
-          // Try to extract GeoJSON Point Feature coordinates (2D)
+          // Try to extract GeoJSON Point geometry or Feature coordinates (2D)
           const geoJsonCoords = extractGeoJsonPointCoordinates(val, 2)
           if (geoJsonCoords) {
             return geoJsonCoords
@@ -926,6 +985,13 @@ export class Point2DField extends Field<
           // Normalize column names: support Longitude/Latitude, longitude/latitude, lon/lat
           if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
             const obj = val as Record<string, unknown>
+
+            // Check for a "geometry" column containing point data
+            const geomCoords = extractGeometryColumn(obj, 2)
+            if (geomCoords) {
+              return geomCoords
+            }
+
             const normalized: Record<string, unknown> = {}
             let hasLng = false
             let hasLat = false

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -26,6 +26,7 @@ import {
   MapViewOp,
   MathOp,
   MergeOp,
+  NetworkOp,
   NumberOp,
   Operator,
   PointOp,
@@ -3586,5 +3587,121 @@ describe('DirectionsOp', () => {
     // Verify DirectionsOp correctly parses the GeoJSON Features
     expect(directionsOp.inputs.origin.value).toEqual({ lng: -74.006, lat: 40.7128 })
     expect(directionsOp.inputs.destination.value).toEqual({ lng: -73.935242, lat: 40.73061 })
+  })
+})
+
+describe('NetworkOp with geometry column', () => {
+  it('still accepts direct {lng, lat, alt} objects (backward compat)', () => {
+    const networkOp = new NetworkOp('/network')
+    const points = [
+      { lng: -73.78, lat: 40.64, alt: 0 },
+      { lng: -122.37, lat: 37.62, alt: 0 },
+    ]
+
+    networkOp.inputs.skyports.setValue(points)
+    const result = networkOp.execute({ skyports: networkOp.inputs.skyports.value, hub: false })
+    expect(result.routes).toHaveLength(1)
+    expect(result.routes[0].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+    expect(result.routes[0].destination).toEqual({ lng: -122.37, lat: 37.62, alt: 0 })
+  })
+
+  it('still accepts {lng, lat} objects without alt (backward compat)', () => {
+    const networkOp = new NetworkOp('/network')
+    const points = [
+      { lng: -73.78, lat: 40.64 },
+      { lng: -122.37, lat: 37.62 },
+    ]
+
+    networkOp.inputs.skyports.setValue(points)
+    const result = networkOp.execute({ skyports: networkOp.inputs.skyports.value, hub: false })
+    expect(result.routes).toHaveLength(1)
+    expect(result.routes[0].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+    expect(result.routes[0].destination).toEqual({ lng: -122.37, lat: 37.62, alt: 0 })
+  })
+
+  it('accepts rows with geometry column as [lng, lat] tuple', () => {
+    const networkOp = new NetworkOp('/network')
+    const tableData = [
+      { name: 'JFK', geometry: [-73.78, 40.64] },
+      { name: 'SFO', geometry: [-122.37, 37.62] },
+      { name: 'LAX', geometry: [-118.41, 33.94] },
+    ]
+
+    networkOp.inputs.skyports.setValue(tableData)
+    const result = networkOp.execute({ skyports: networkOp.inputs.skyports.value, hub: false })
+    expect(result.routes).toHaveLength(3)
+    expect(result.routes[0].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+    expect(result.routes[0].destination).toEqual({ lng: -122.37, lat: 37.62, alt: 0 })
+  })
+
+  it('accepts rows with geometry column as GeoJSON Point', () => {
+    const networkOp = new NetworkOp('/network')
+    const tableData = [
+      { name: 'JFK', geometry: { type: 'Point', coordinates: [-73.78, 40.64] } },
+      { name: 'SFO', geometry: { type: 'Point', coordinates: [-122.37, 37.62] } },
+    ]
+
+    networkOp.inputs.skyports.setValue(tableData)
+    const result = networkOp.execute({ skyports: networkOp.inputs.skyports.value, hub: false })
+    expect(result.routes).toHaveLength(1)
+    expect(result.routes[0].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+    expect(result.routes[0].destination).toEqual({ lng: -122.37, lat: 37.62, alt: 0 })
+  })
+
+  it('accepts rows with geometry column as [lng, lat, alt] tuple', () => {
+    const networkOp = new NetworkOp('/network')
+    const tableData = [
+      { name: 'JFK', geometry: [-73.78, 40.64, 100] },
+      { name: 'SFO', geometry: [-122.37, 37.62, 200] },
+    ]
+
+    networkOp.inputs.skyports.setValue(tableData)
+    const result = networkOp.execute({ skyports: networkOp.inputs.skyports.value, hub: false })
+    expect(result.routes).toHaveLength(1)
+    expect(result.routes[0].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 100 })
+    expect(result.routes[0].destination).toEqual({ lng: -122.37, lat: 37.62, alt: 200 })
+  })
+
+  it('accepts rows with geometry column as GeoJSON Point with altitude', () => {
+    const networkOp = new NetworkOp('/network')
+    const tableData = [
+      { name: 'JFK', geometry: { type: 'Point', coordinates: [-73.78, 40.64, 100] } },
+      { name: 'SFO', geometry: { type: 'Point', coordinates: [-122.37, 37.62, 200] } },
+    ]
+
+    networkOp.inputs.skyports.setValue(tableData)
+    const result = networkOp.execute({ skyports: networkOp.inputs.skyports.value, hub: false })
+    expect(result.routes).toHaveLength(1)
+    expect(result.routes[0].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 100 })
+    expect(result.routes[0].destination).toEqual({ lng: -122.37, lat: 37.62, alt: 200 })
+  })
+
+  it('works in hub mode with geometry column', () => {
+    const networkOp = new NetworkOp('/network')
+    const tableData = [
+      { name: 'HUB', geometry: [-73.78, 40.64] },
+      { name: 'SFO', geometry: [-122.37, 37.62] },
+      { name: 'LAX', geometry: [-118.41, 33.94] },
+    ]
+
+    networkOp.inputs.skyports.setValue(tableData)
+    const result = networkOp.execute({ skyports: networkOp.inputs.skyports.value, hub: true })
+    expect(result.routes).toHaveLength(2)
+    expect(result.routes[0].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+    expect(result.routes[1].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+  })
+
+  it('accepts bare GeoJSON Point geometry at top level via Point3DField', () => {
+    const networkOp = new NetworkOp('/network')
+    const tableData = [
+      { type: 'Point', coordinates: [-73.78, 40.64] },
+      { type: 'Point', coordinates: [-122.37, 37.62] },
+    ]
+
+    networkOp.inputs.skyports.setValue(tableData)
+    const result = networkOp.execute({ skyports: networkOp.inputs.skyports.value, hub: false })
+    expect(result.routes).toHaveLength(1)
+    expect(result.routes[0].origin).toEqual({ lng: -73.78, lat: 40.64, alt: 0 })
+    expect(result.routes[0].destination).toEqual({ lng: -122.37, lat: 37.62, alt: 0 })
   })
 })


### PR DESCRIPTION
#### Background

<img width="902" height="353" alt="Screenshot 2026-06-12 at 10 10 41 PM" src="https://github.com/user-attachments/assets/6fe90a9f-b7e7-4396-9761-d8877b74bb02" />

When connecting a TableEditorOp with a point2D column to a NetworkOp, the geometry data wasn't being detected because Point2D/3DField only looked for top-level `lng`/`lat` keys or GeoJSON Features — not a `geometry` column containing point data.

The `geometry` column name is the standard convention across the geospatial ecosystem:
- **DuckDB Spatial** — default column name when loading spatial data
- **GeoJSON (RFC 7946)** — every Feature has a `"geometry"` property
- **GeoParquet** — specifies `"geometry"` as the default column name
- **GeoPandas** — `.geometry` is the default column accessor

#### Change List
- Extend `extractGeoJsonPointCoordinates` to handle bare GeoJSON Point geometry objects (`{type: "Point", coordinates: [...]}`) in addition to Features
- Add `extractGeometryColumn` helper that detects a `geometry` property on row objects and extracts point coordinates from tuples or GeoJSON Point geometries
- Wire geometry column detection into Point3DField (both 3D and 2D arms) and Point2DField normalization
- Add 12 field-level tests for bare GeoJSON Point and geometry column extraction
- Add 8 NetworkOp integration tests covering geometry column formats and backward compatibility