### PR TITLE
feat: support undo/redo for TableEditorOp edits

### DIFF
--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -1733,11 +1733,15 @@ export function TableEditorOpComponent({
     firePropertyMutation(description, before)
   }
 
-  const handleSchemaChange = (newSchema: TableSchema) => {
+  const handleSchemaChange = (newSchema: TableSchema, newData?: unknown[]) => {
     const before = captureOperatorInputs()
     op.inputs.schema.setValue(newSchema)
     op.outputs.schema.setValue(newSchema)
     setSchema(newSchema)
+    if (newData) {
+      op.inputs.data.setValue(newData)
+      op.outputs.data.setValue(newData)
+    }
     firePropertyMutation('Edit table schema', before)
   }
 

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -1726,15 +1726,19 @@ export function TableEditorOpComponent({
     }
   }, [op])
 
-  const handleDataChange = (newData: unknown[]) => {
+  const handleDataChange = (newData: unknown[], description = 'Edit table data') => {
+    const before = captureOperatorInputs()
     op.inputs.data.setValue(newData)
     op.outputs.data.setValue(newData)
+    firePropertyMutation(description, before)
   }
 
   const handleSchemaChange = (newSchema: TableSchema) => {
+    const before = captureOperatorInputs()
     op.inputs.schema.setValue(newSchema)
     op.outputs.schema.setValue(newSchema)
     setSchema(newSchema)
+    firePropertyMutation('Edit table schema', before)
   }
 
   return (

--- a/noodles-editor/src/noodles/components/table-editor-edit-flow.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor-edit-flow.test.tsx
@@ -54,10 +54,13 @@ describe('TableEditor - Edit Flow', () => {
       fireEvent.blur(input)
 
       // Should call onDataChange with new value
-      expect(onDataChange).toHaveBeenCalledWith([
-        { name: 'Charlie', count: 10 },
-        { name: 'Bob', count: 20 },
-      ])
+      expect(onDataChange).toHaveBeenCalledWith(
+        [
+          { name: 'Charlie', count: 10 },
+          { name: 'Bob', count: 20 },
+        ],
+        'Edit cell name'
+      )
     })
 
     it('should allow number cell to be clicked and edited', () => {
@@ -88,10 +91,13 @@ describe('TableEditor - Edit Flow', () => {
       fireEvent.blur(input)
 
       // Should commit on first blur
-      expect(onDataChange).toHaveBeenCalledWith([
-        { name: 'Alice', count: 20 },
-        { name: 'Bob', count: 20 },
-      ])
+      expect(onDataChange).toHaveBeenCalledWith(
+        [
+          { name: 'Alice', count: 20 },
+          { name: 'Bob', count: 20 },
+        ],
+        'Edit cell count'
+      )
     })
   })
 
@@ -118,10 +124,13 @@ describe('TableEditor - Edit Flow', () => {
       fireEvent.change(input, { target: { value: 'Charlie' } })
       fireEvent.blur(input)
 
-      expect(onDataChange).toHaveBeenCalledWith([
-        { name: 'Charlie', count: 10 },
-        { name: 'Bob', count: 20 },
-      ])
+      expect(onDataChange).toHaveBeenCalledWith(
+        [
+          { name: 'Charlie', count: 10 },
+          { name: 'Bob', count: 20 },
+        ],
+        'Edit cell name'
+      )
 
       // Simulate parent updating with new data
       const updatedData = [
@@ -148,10 +157,13 @@ describe('TableEditor - Edit Flow', () => {
       fireEvent.change(input, { target: { value: 'David' } })
       fireEvent.blur(input)
 
-      expect(onDataChange).toHaveBeenCalledWith([
-        { name: 'David', count: 10 },
-        { name: 'Bob', count: 20 },
-      ])
+      expect(onDataChange).toHaveBeenCalledWith(
+        [
+          { name: 'David', count: 10 },
+          { name: 'Bob', count: 20 },
+        ],
+        'Edit cell name'
+      )
     })
   })
 
@@ -196,10 +208,13 @@ describe('TableEditor - Edit Flow', () => {
       fireEvent.blur(input)
 
       // Now it should commit
-      expect(onDataChange).toHaveBeenCalledWith([
-        { name: 'Alicia', count: 10 },
-        { name: 'Bob', count: 20 },
-      ])
+      expect(onDataChange).toHaveBeenCalledWith(
+        [
+          { name: 'Alicia', count: 10 },
+          { name: 'Bob', count: 20 },
+        ],
+        'Edit cell name'
+      )
     })
   })
 
@@ -318,7 +333,8 @@ describe('TableEditor - Edit Flow', () => {
 
       // Should parse to 400
       expect(onDataChange).toHaveBeenCalledWith(
-        expect.arrayContaining([{ amount: 400 }])
+        expect.arrayContaining([{ amount: 400 }]),
+        'Edit cell amount'
       )
     })
 
@@ -354,7 +370,7 @@ describe('TableEditor - Edit Flow', () => {
       let input = container.querySelector('input.p-inputtext') as HTMLInputElement
       fireEvent.change(input, { target: { value: 'abc' } })
       fireEvent.blur(input)
-      expect(onDataChange).toHaveBeenCalledWith([{ score: 0 }])
+      expect(onDataChange).toHaveBeenCalledWith([{ score: 0 }], 'Edit cell score')
 
       onDataChange.mockClear()
 
@@ -363,7 +379,7 @@ describe('TableEditor - Edit Flow', () => {
       input = container.querySelector('input.p-inputtext') as HTMLInputElement
       fireEvent.change(input, { target: { value: '150' } })
       fireEvent.blur(input)
-      expect(onDataChange).toHaveBeenCalledWith([{ score: 100 }])
+      expect(onDataChange).toHaveBeenCalledWith([{ score: 100 }], 'Edit cell score')
 
       onDataChange.mockClear()
 
@@ -372,7 +388,7 @@ describe('TableEditor - Edit Flow', () => {
       input = container.querySelector('input.p-inputtext') as HTMLInputElement
       fireEvent.change(input, { target: { value: '-10' } })
       fireEvent.blur(input)
-      expect(onDataChange).toHaveBeenCalledWith([{ score: 0 }])
+      expect(onDataChange).toHaveBeenCalledWith([{ score: 0 }], 'Edit cell score')
     })
 
     it('should handle escape key to cancel number edit', () => {

--- a/noodles-editor/src/noodles/components/table-editor.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.test.tsx
@@ -94,11 +94,14 @@ describe('TableEditor', () => {
     const addButton = getByRole('button', { name: /add row/i })
     fireEvent.click(addButton)
 
-    expect(onDataChange).toHaveBeenCalledWith([
-      { name: 'Alice', count: 10 },
-      { name: 'Bob', count: 20 },
-      { name: '', count: 0 }, // New row with defaults
-    ])
+    expect(onDataChange).toHaveBeenCalledWith(
+      [
+        { name: 'Alice', count: 10 },
+        { name: 'Bob', count: 20 },
+        { name: '', count: 0 }, // New row with defaults
+      ],
+      'Add table row'
+    )
   })
 
   it('should render different column types', () => {
@@ -186,7 +189,7 @@ describe('TableEditor', () => {
     const deleteButtons = container.querySelectorAll('.pi-trash')
     fireEvent.click(deleteButtons[0])
 
-    expect(onDataChange).toHaveBeenCalledWith([{ name: 'Bob', count: 20 }])
+    expect(onDataChange).toHaveBeenCalledWith([{ name: 'Bob', count: 20 }], 'Delete table row')
   })
 
   it('should call onSchemaChange when schema is updated', () => {
@@ -276,20 +279,23 @@ describe('TableEditor', () => {
     const addButton = getByRole('button', { name: /add row/i })
     fireEvent.click(addButton)
 
-    expect(onDataChange).toHaveBeenCalledWith([
-      {
-        str: 'default',
-        num: 42,
-        bool: true,
-        color: '#ffffff',
-        point2d: [1, 2],
-        point3d: [1, 2, 3],
-        vec2: [5, 6],
-        vec3: [7, 8, 9],
-        date: '2026-01-01',
-        literal: 'a',
-      },
-    ])
+    expect(onDataChange).toHaveBeenCalledWith(
+      [
+        {
+          str: 'default',
+          num: 42,
+          bool: true,
+          color: '#ffffff',
+          point2d: [1, 2],
+          point3d: [1, 2, 3],
+          vec2: [5, 6],
+          vec3: [7, 8, 9],
+          date: '2026-01-01',
+          literal: 'a',
+        },
+      ],
+      'Add table row'
+    )
   })
 
   it('should convert existing values when column type changes', () => {

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -640,7 +640,7 @@ interface TableEditorProps {
   op: TableEditorOp
   data: unknown[]
   schema: TableSchema
-  onDataChange: (data: unknown[]) => void
+  onDataChange: (data: unknown[], description?: string) => void
   onSchemaChange: (schema: TableSchema) => void
 }
 
@@ -658,7 +658,7 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
     }
     const newData = [...tableData, newRow]
     setTableData(newData)
-    onDataChange(newData)
+    onDataChange(newData, 'Add table row')
   }
 
   const handleSchemaChange = (newSchema: TableSchema) => {
@@ -679,7 +679,7 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
 
     onSchemaChange(newSchema)
     setTableData(newData)
-    onDataChange(newData)
+    onDataChange(newData, 'Edit table schema')
   }
 
   const columnHelper = createColumnHelper<Record<string, unknown>>()
@@ -730,12 +730,12 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
           [columnId]: value,
         }
         setTableData(newData)
-        onDataChange(newData)
+        onDataChange(newData, `Edit cell ${columnId}`)
       },
       deleteRow: (rowIndex: number) => {
         const newData = tableData.filter((_, index) => index !== rowIndex)
         setTableData(newData)
-        onDataChange(newData)
+        onDataChange(newData, 'Delete table row')
       },
       schema,
     },

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -641,7 +641,7 @@ interface TableEditorProps {
   data: unknown[]
   schema: TableSchema
   onDataChange: (data: unknown[], description?: string) => void
-  onSchemaChange: (schema: TableSchema) => void
+  onSchemaChange: (schema: TableSchema, data?: unknown[]) => void
 }
 
 export function TableEditor({ data, schema, onDataChange, onSchemaChange }: TableEditorProps) {
@@ -677,9 +677,8 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
       return newRow
     })
 
-    onSchemaChange(newSchema)
+    onSchemaChange(newSchema, newData)
     setTableData(newData)
-    onDataChange(newData, 'Edit table schema')
   }
 
   const columnHelper = createColumnHelper<Record<string, unknown>>()


### PR DESCRIPTION
#### Background

https://github.com/user-attachments/assets/272800ae-ab0c-4d6c-88c0-8e3099b226f9

TableEditorOp cell edits, row additions, row deletions, and schema changes were not registered in the undo/redo history, so Cmd+Z had no effect after editing table data.

#### Change List
- Wrap `handleDataChange` and `handleSchemaChange` in `TableEditorOpComponent` with `captureOperatorInputs`/`firePropertyMutation` to record mutations in the undo/redo history stack
- Pass descriptive action labels (e.g. "Edit cell name", "Add table row", "Delete table row") from `TableEditor` through the `onDataChange` callback
- Update existing tests to assert the new description parameter