### PR TITLE
fix: Point field schema not transforming tuples to objects

### DIFF
--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -23,6 +23,8 @@ import {
   StringField,
   StringLiteralField,
   UnknownField,
+  Vec2Field,
+  Vec3Field,
 } from './fields'
 import { NumberOp } from './operators'
 import { clearOps, setOp } from './store'
@@ -1307,6 +1309,70 @@ describe('Point3DField', () => {
     }
     field.setValue(geoJsonFeature)
     expect(field.value).toEqual([-118.4182302, 34.0576856, 0])
+  })
+})
+
+describe('Vec2Field', () => {
+  it('transforms tuple to object by default (no options)', () => {
+    const field = new Vec2Field()
+    field.setValue([3, 7])
+    expect(field.value).toEqual({ x: 3, y: 7 })
+  })
+
+  it('transforms tuple to object with explicit option', () => {
+    const field = new Vec2Field(undefined, { returnType: 'object' })
+    field.setValue([3, 7])
+    expect(field.value).toEqual({ x: 3, y: 7 })
+  })
+
+  it('parses object to object', () => {
+    const field = new Vec2Field(undefined, { returnType: 'object' })
+    field.setValue({ x: 5, y: 9 })
+    expect(field.value).toEqual({ x: 5, y: 9 })
+  })
+
+  it('transforms object to tuple', () => {
+    const field = new Vec2Field(undefined, { returnType: 'tuple' })
+    field.setValue({ x: 5, y: 9 })
+    expect(field.value).toEqual([5, 9])
+  })
+
+  it('parses tuple to tuple', () => {
+    const field = new Vec2Field(undefined, { returnType: 'tuple' })
+    field.setValue([3, 7])
+    expect(field.value).toEqual([3, 7])
+  })
+})
+
+describe('Vec3Field', () => {
+  it('transforms tuple to object by default (no options)', () => {
+    const field = new Vec3Field()
+    field.setValue([1, 2, 3])
+    expect(field.value).toEqual({ x: 1, y: 2, z: 3 })
+  })
+
+  it('transforms tuple to object with explicit option', () => {
+    const field = new Vec3Field(undefined, { returnType: 'object' })
+    field.setValue([1, 2, 3])
+    expect(field.value).toEqual({ x: 1, y: 2, z: 3 })
+  })
+
+  it('parses object to object', () => {
+    const field = new Vec3Field(undefined, { returnType: 'object' })
+    field.setValue({ x: 4, y: 5, z: 6 })
+    expect(field.value).toEqual({ x: 4, y: 5, z: 6 })
+  })
+
+  it('transforms object to tuple', () => {
+    const field = new Vec3Field(undefined, { returnType: 'tuple' })
+    field.setValue({ x: 4, y: 5, z: 6 })
+    expect(field.value).toEqual([4, 5, 6])
+  })
+
+  it('parses tuple to tuple', () => {
+    const field = new Vec3Field(undefined, { returnType: 'tuple' })
+    field.setValue([1, 2, 3])
+    expect(field.value).toEqual([1, 2, 3])
   })
 })
 

--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -1031,6 +1031,12 @@ describe('LayerField', () => {
 })
 
 describe('Point2DField', () => {
+  it('transforms tuple to object by default (no options)', () => {
+    const field = new Point2DField()
+    field.setValue([1, 2])
+    expect(field.value).toEqual({ lng: 1, lat: 2 })
+  })
+
   it('parses object to object', () => {
     const field = new Point2DField(undefined, { returnType: 'object' })
     field.setValue({ lng: 1, lat: 2 })
@@ -1173,6 +1179,12 @@ describe('Point2DField', () => {
 })
 
 describe('Point3DField', () => {
+  it('transforms tuple to object by default (no options)', () => {
+    const field = new Point3DField()
+    field.setValue([1, 2, 3])
+    expect(field.value).toEqual({ lng: 1, lat: 2, alt: 3 })
+  })
+
   it('parses object to object', () => {
     const field = new Point3DField(undefined, { returnType: 'object' })
     field.setValue({ lng: 1, lat: 2, alt: 3 })

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -752,7 +752,7 @@ export class Point3DField extends Field<
     this.returnType = options?.returnType || 'object'
   }
 
-  createSchema({ returnType }: PointFieldOptions = { returnType: 'object' }) {
+  createSchema({ returnType = 'object' }: PointFieldOptions = {}) {
     const noop = (val: unknown) => val
     return z.union([
       z
@@ -911,7 +911,7 @@ export class Point2DField extends Field<
     this.returnType = options?.returnType || 'object'
   }
 
-  createSchema({ returnType }: PointFieldOptions = { returnType: 'object' }) {
+  createSchema({ returnType = 'object' }: PointFieldOptions = {}) {
     const noop = (val: unknown) => val
     return z.union([
       z

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -1000,7 +1000,7 @@ export class Vec2Field extends Field<
     super(override, options)
     this.returnType = options?.returnType || 'object'
   }
-  createSchema({ returnType }: Vec2FieldOptions = { returnType: 'object' }) {
+  createSchema({ returnType = 'object' }: Vec2FieldOptions = {}) {
     const noop = (val: unknown) => val
     return z.union([
       z
@@ -1036,7 +1036,7 @@ export class Vec3Field extends Field<
     super(override, options)
     this.returnType = options?.returnType || 'object'
   }
-  createSchema({ returnType }: Vec2FieldOptions = { returnType: 'object' }) {
+  createSchema({ returnType = 'object' }: Vec2FieldOptions = {}) {
     const noop = (val: unknown) => val
     return z.union([
       z


### PR DESCRIPTION
#### Background

Before
<img width="234" height="111" alt="Screenshot 2026-06-12 at 8 49 08 PM" src="https://github.com/user-attachments/assets/2721792b-5f14-4692-90ea-19cdce2c04d3" />

After
<img width="488" height="220" alt="Screenshot 2026-06-12 at 8 56 23 PM" src="https://github.com/user-attachments/assets/5e6e4762-116b-4ce9-ae9f-be205831e4c9" />


The PointOp's coordinates field displayed 0,0 even when valid coordinates were set (e.g. via Create Point). The root cause was a JS destructuring default bug: `createSchema({ returnType }: Opts = { returnType: 'object' })` only applied the default when called with no argument, but the Field constructor always passed `{}`, leaving `returnType` as `undefined` and skipping the tuple-to-object Zod transforms.

#### Change List
- Fix `Point2DField.createSchema` destructuring to use `{ returnType = 'object' }` so the default applies even when called with an empty options object
- Apply same fix to `Point3DField.createSchema`