### PR TITLE
Add WebMCP support for external control from Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -662,7 +662,39 @@ Load it in the browser at `http://localhost:5173/examples/<project-name>` to vis
 
 ### Connecting Claude Code to a Running Browser Instance
 
-The MCP proxy bridges Claude Code to a running Noodles browser session, giving access to the same 18+ tools the in-app chat uses:
+#### WebMCP (recommended)
+
+With `?externalControl=true`, the app registers its full AI tool surface (~22 tools) on `navigator.modelContext` (the W3C WebMCP API, polyfilled via `@mcp-b/global`). External MCP clients reach those tools through the `@mcp-b/webmcp-local-relay` stdio bridge — no proxy code to run:
+
+```bash
+# 1. Start the app with external control enabled
+# Open: http://localhost:5173/examples/nyc-taxis?externalControl=true
+
+# 2. Register the relay with Claude Code (once)
+claude mcp add webmcp -- npx -y @mcp-b/webmcp-local-relay@4
+
+# For Claude Desktop / Cursor, use the equivalent config:
+{
+  "mcpServers": {
+    "webmcp": {
+      "command": "npx",
+      "args": ["-y", "@mcp-b/webmcp-local-relay@4"]
+    }
+  }
+}
+```
+
+Tool names match the in-app chat (snake_case): `get_current_project`, `list_nodes`, `get_node_info`, `get_node_output`, `apply_modifications`, `capture_visualization`, `get_timeline`, `set_keyframe`, `get_operator_schema`, `search_code`, and more. `apply_modifications` mutates the live editor graph, so changes appear immediately in the browser.
+
+Notes:
+
+- The relay embed script is only injected on localhost. Alternatives that need no relay: the WebMCP browser extension, or native Chrome WebMCP (origin trial).
+- If multiple Noodles tabs are open, the relay suffixes tool names with a tab ID.
+- Code search/docs tools download their context bundles on page load when external control is enabled.
+
+#### Legacy WebSocket proxy
+
+The older MCP proxy bridges Claude Code to the browser over a WebSocket. It exposes a smaller camelCase tool surface (`getCurrentProject`, `listNodes`, `createNode`, `connectNodes`, `captureVisualization`, …):
 
 ```bash
 # 1. Start the app with external control enabled
@@ -683,8 +715,6 @@ node noodles-editor/examples/external-control/mcp-proxy.js
   }
 }
 ```
-
-The proxy exposes tools: `getCurrentProject`, `listNodes`, `createNode`, `connectNodes`, `captureVisualization`, and more — the same surface as the in-app chat.
 
 ### Graph Design Guidelines for Claude Code
 
@@ -709,5 +739,5 @@ The timeline is serialized inside `noodles.json` under the `"timeline"` key. The
 
 ---
 
-**Last Updated**: 2026-06-02
+**Last Updated**: 2026-07-04
 **Version**: Based on project version 6 schema

--- a/noodles-editor/package.json
+++ b/noodles-editor/package.json
@@ -15,6 +15,7 @@
     "@mapbox/mapbox-gl-geocoder": "^5.1.2",
     "@mapbox/polyline": "^1.2.1",
     "@math.gl/web-mercator": "^4.1.0",
+    "@mcp-b/global": "^3.0.0",
     "@microlink/react-json-view": "^1.31.15",
     "@observablehq/plot": "^0.6.17",
     "@radix-ui/colors": "^3.0.0",
@@ -60,7 +61,8 @@
     "validator": "^13.15.26",
     "web-vitals": "^5.2.0",
     "wouter": "^3.9.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zod-to-json-schema": "^3.25.0"
   },
   "overrides": {
     "d3-scale-chromatic": "3.1.x"
@@ -94,6 +96,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
+    "@mcp-b/webmcp-types": "^3.0.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/noodles-editor/public/404.html
+++ b/noodles-editor/public/404.html
@@ -18,9 +18,11 @@
       const appRoot = window.location.hostname === 'localhost' ? '/' : '/app/'
 
       if (path && path !== '/') {
-        // Redirect to index.html with the path as a query parameter
+        // Redirect to index.html with the path as a query parameter.
+        // Original query params are hoisted to the top level (not folded into
+        // redirect) so module-init reads like ?externalControl=true still work
         window.location.replace(
-          appRoot + '?redirect=' + encodeURIComponent(path + query)
+          appRoot + '?redirect=' + encodeURIComponent(path) + (query ? '&' + query.slice(1) : '')
         )
       } else {
         // Already at root, redirect

--- a/noodles-editor/src/ai-chat/claude-client.ts
+++ b/noodles-editor/src/ai-chat/claude-client.ts
@@ -6,6 +6,7 @@ import {
 } from './conversation-compaction'
 import type { MCPTools } from './mcp-tools'
 import systemPromptTemplate from './system-prompt.md?raw'
+import { getToolDefinition, toolDefinitions } from './tool-definitions'
 import type {
   ClaudeResponse,
   Message,
@@ -381,225 +382,27 @@ export class ClaudeClient {
   }
 
   private getTools(): Anthropic.Tool[] {
-    // Essential tools for visualization, debugging, and project state manipulation
-    return [
-      // Visual debugging tools
-      {
-        name: 'capture_visualization',
-        description:
-          'Capture a screenshot of the current visualization. The screenshot will be attached to your next message so you can see it.',
-        input_schema: {
-          type: 'object',
-          properties: {
-            includeUI: { type: 'boolean' },
-            format: { type: 'string', enum: ['png', 'jpeg'] },
-            quality: { type: 'number', description: 'JPEG quality 0-1, default 0.7' },
-          },
-        },
-      },
-      {
-        name: 'get_console_errors',
-        description: 'Get recent browser console errors and warnings',
-        input_schema: {
-          type: 'object',
-          properties: {
-            since: { type: 'number' },
-            level: { type: 'string', enum: ['error', 'warn', 'all'] },
-            maxResults: { type: 'number' },
-          },
-        },
-      },
-      {
-        name: 'get_render_stats',
-        description: 'Get deck.gl rendering statistics',
-        input_schema: {
-          type: 'object',
-          properties: {},
-        },
-      },
-      {
-        name: 'inspect_layer',
-        description: 'Get layer information',
-        input_schema: {
-          type: 'object',
-          properties: {
-            layerId: { type: 'string' },
-          },
-          required: ['layerId'],
-        },
-      },
-      // Project state tools
-      {
-        name: 'apply_modifications',
-        description:
-          'Apply modifications to the project (add/update/delete nodes or edges). Use this instead of returning JSON in text.',
-        input_schema: {
-          type: 'object',
-          properties: {
-            modifications: {
-              type: 'array',
-              description: 'Array of modifications to apply',
-              items: {
-                type: 'object',
-                properties: {
-                  type: {
-                    type: 'string',
-                    enum: ['add_node', 'update_node', 'delete_node', 'add_edge', 'delete_edge'],
-                  },
-                  data: {
-                    type: 'object',
-                    description: 'The node or edge data',
-                  },
-                },
-                required: ['type', 'data'],
-              },
-            },
-          },
-          required: ['modifications'],
-        },
-      },
-      {
-        name: 'get_current_project',
-        description: 'Get the current project state including all nodes and edges',
-        input_schema: {
-          type: 'object',
-          properties: {},
-        },
-      },
-      {
-        name: 'list_nodes',
-        description: 'List all nodes in the project with their current state and execution status',
-        input_schema: {
-          type: 'object',
-          properties: {},
-        },
-      },
-      {
-        name: 'get_node_info',
-        description:
-          'Get detailed information about a specific node including connections and schema',
-        input_schema: {
-          type: 'object',
-          properties: {
-            nodeId: { type: 'string', description: 'The ID of the node to inspect' },
-          },
-          required: ['nodeId'],
-        },
-      },
-      {
-        name: 'get_node_output',
-        description:
-          'Read the output data from a specific operator/node. Useful for inspecting data at any point in the pipeline.',
-        input_schema: {
-          type: 'object',
-          properties: {
-            nodeId: { type: 'string', description: 'The ID of the node to read output from' },
-            maxRows: {
-              type: 'number',
-              description: 'Maximum number of rows to return (default: 10)',
-            },
-          },
-          required: ['nodeId'],
-        },
-      },
-      // Timeline tools
-      {
-        name: 'get_timeline',
-        description:
-          'Get the current animation timeline state: sequence length, FPS, playback position, and all animated tracks with their keyframes. Use this before adding keyframes to understand the current animation.',
-        input_schema: {
-          type: 'object',
-          properties: {},
-        },
-      },
-      {
-        name: 'set_keyframe',
-        description:
-          'Add or update a keyframe on an animated field. Track IDs follow the pattern "operator-name / fieldName" (e.g. "my-layer / opacity"). Position is in seconds. Interpolation is "bezier" (smooth) or "hold" (step). If a keyframe already exists within 1 frame of the position, it will be updated.',
-        input_schema: {
-          type: 'object',
-          properties: {
-            trackId: {
-              type: 'string',
-              description: 'Track identifier in format "operator-name / fieldName"',
-            },
-            position: { type: 'number', description: 'Time position in seconds' },
-            value: { description: 'The value at this keyframe (number, boolean, or string)' },
-            interpolation: {
-              type: 'string',
-              enum: ['bezier', 'hold'],
-              description: 'Interpolation type (default: bezier)',
-            },
-          },
-          required: ['trackId', 'position', 'value'],
-        },
-      },
-      {
-        name: 'delete_keyframe',
-        description: 'Delete a specific keyframe by its ID. Use get_timeline to find keyframe IDs.',
-        input_schema: {
-          type: 'object',
-          properties: {
-            trackId: { type: 'string', description: 'The track containing the keyframe' },
-            keyframeId: { type: 'string', description: 'The keyframe ID to delete' },
-          },
-          required: ['trackId', 'keyframeId'],
-        },
-      },
-      {
-        name: 'set_playback_position',
-        description:
-          'Scrub the timeline to a specific time position (in seconds) for inspection. Optionally start or stop playback.',
-        input_schema: {
-          type: 'object',
-          properties: {
-            position: { type: 'number', description: 'Time in seconds to seek to' },
-            play: {
-              type: 'boolean',
-              description: 'true to start playback, false to pause, omit to leave unchanged',
-            },
-          },
-          required: ['position'],
-        },
-      },
-    ]
+    // Essential tools for visualization, debugging, and project state manipulation;
+    // definitions with exposeToChat: false stay executable but aren't offered here
+    return toolDefinitions
+      .filter(def => def.exposeToChat !== false)
+      .map(def => ({
+        name: def.name,
+        description: def.description,
+        input_schema: def.inputSchema as Anthropic.Tool['input_schema'],
+      }))
   }
 
   private async executeTool(name: string, params: unknown): Promise<ToolResult> {
-    // params comes from Claude's tool_use with validated schema
-    // Using any here since we're dispatching to properly typed methods
-    // biome-ignore lint/suspicious/noExplicitAny: params validated by Anthropic SDK schema
-    const methodMap: Record<string, (params: any) => Promise<ToolResult>> = {
-      search_code: p => this.tools.searchCode(p),
-      get_source_code: p => this.tools.getSourceCode(p),
-      get_operator_schema: p => this.tools.getOperatorSchema(p),
-      list_operators: p => this.tools.listOperators(p),
-      get_documentation: p => this.tools.getDocumentation(p),
-      get_example: p => this.tools.getExample(p),
-      list_examples: p => this.tools.listExamples(p),
-      find_symbol: p => this.tools.findSymbol(p),
-      analyze_project: p => this.tools.analyzeProject(p),
-      capture_visualization: p => this.tools.captureVisualization(p),
-      get_console_errors: p => this.tools.getConsoleErrors(p),
-      get_render_stats: () => this.tools.getRenderStats(),
-      inspect_layer: p => this.tools.inspectLayer(p),
-      apply_modifications: p => this.tools.applyModifications(p),
-      get_current_project: () => this.tools.getCurrentProject(),
-      list_nodes: () => this.tools.listNodes(),
-      get_node_info: p => this.tools.getNodeInfo(p),
-      get_node_output: p => this.tools.getNodeOutput(p),
-      get_timeline: () => this.tools.getTimeline(),
-      set_keyframe: p => this.tools.setKeyframe(p),
-      delete_keyframe: p => this.tools.deleteKeyframe(p),
-      set_playback_position: p => this.tools.setPlaybackPosition(p),
-    }
-
-    const method = methodMap[name]
-    if (!method) {
+    const definition = getToolDefinition(name)
+    if (!definition) {
       return { success: false, error: `Unknown tool: ${name}` }
     }
 
-    return method(params)
+    // params comes from Claude's tool_use with validated schema
+    return definition.execute(this.tools, (params ?? {}) as Record<string, unknown>, () =>
+      this.tools.getProject()
+    )
   }
 
   private extractProjectModifications(text: string): ProjectModification[] {

--- a/noodles-editor/src/ai-chat/mcp-tools.ts
+++ b/noodles-editor/src/ai-chat/mcp-tools.ts
@@ -33,6 +33,10 @@ export class MCPTools {
     this.project = project
   }
 
+  getProject(): NoodlesProject | null {
+    return this.project
+  }
+
   // Extract common operator properties to avoid duplication
   private mapOperatorProperties(op: {
     type: string

--- a/noodles-editor/src/ai-chat/tool-definitions.test.ts
+++ b/noodles-editor/src/ai-chat/tool-definitions.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MCPTools } from './mcp-tools'
+import { getToolDefinition, toolDefinitions } from './tool-definitions'
+
+// The tool surface the in-app chat offered before definitions were shared —
+// guards against accidentally changing the chat's token budget or tool names
+const CHAT_TOOL_NAMES = [
+  'capture_visualization',
+  'get_console_errors',
+  'get_render_stats',
+  'inspect_layer',
+  'apply_modifications',
+  'get_current_project',
+  'list_nodes',
+  'get_node_info',
+  'get_node_output',
+  'get_timeline',
+  'set_keyframe',
+  'delete_keyframe',
+  'set_playback_position',
+]
+
+const CONTEXT_TOOL_NAMES = [
+  'search_code',
+  'get_source_code',
+  'get_operator_schema',
+  'list_operators',
+  'get_documentation',
+  'get_example',
+  'list_examples',
+  'find_symbol',
+  'analyze_project',
+]
+
+describe('toolDefinitions', () => {
+  it('exposes exactly the original chat tools to the chat', () => {
+    const chatExposed = toolDefinitions.filter(d => d.exposeToChat !== false).map(d => d.name)
+    expect(chatExposed.sort()).toEqual([...CHAT_TOOL_NAMES].sort())
+  })
+
+  it('includes the context tools as non-chat definitions', () => {
+    const hidden = toolDefinitions.filter(d => d.exposeToChat === false).map(d => d.name)
+    expect(hidden.sort()).toEqual([...CONTEXT_TOOL_NAMES].sort())
+  })
+
+  it('has unique snake_case names', () => {
+    const names = toolDefinitions.map(d => d.name)
+    expect(new Set(names).size).toBe(names.length)
+    for (const name of names) {
+      expect(name).toMatch(/^[a-z][a-z0-9_]*$/)
+    }
+  })
+
+  it('has a description and object input schema on every definition', () => {
+    for (const def of toolDefinitions) {
+      expect(def.description.length, def.name).toBeGreaterThan(0)
+      expect(def.inputSchema.type, def.name).toBe('object')
+      expect(typeof def.inputSchema.properties, def.name).toBe('object')
+    }
+  })
+
+  it('only requires properties that exist in the schema', () => {
+    for (const def of toolDefinitions) {
+      for (const required of def.inputSchema.required ?? []) {
+        expect(def.inputSchema.properties, `${def.name}.${required}`).toHaveProperty(required)
+      }
+    }
+  })
+
+  it('looks up definitions by name', () => {
+    expect(getToolDefinition('list_nodes')?.name).toBe('list_nodes')
+    expect(getToolDefinition('nonexistent_tool')).toBeUndefined()
+  })
+
+  it('injects the current project into analyze_project', async () => {
+    const analyzeProject = vi.fn(async () => ({ success: true }))
+    const tools = { analyzeProject } as unknown as MCPTools
+    const definition = getToolDefinition('analyze_project')
+    if (!definition) throw new Error('analyze_project not defined')
+
+    const project = { nodes: [], edges: [] }
+    await definition.execute(tools, { analysisType: 'validation' }, () => project)
+    expect(analyzeProject).toHaveBeenCalledWith({ project, analysisType: 'validation' })
+
+    const noProject = await definition.execute(tools, { analysisType: 'validation' }, () => null)
+    expect(noProject.success).toBe(false)
+    expect(noProject.error).toContain('No project loaded')
+  })
+})

--- a/noodles-editor/src/ai-chat/tool-definitions.test.ts
+++ b/noodles-editor/src/ai-chat/tool-definitions.test.ts
@@ -59,6 +59,24 @@ describe('toolDefinitions', () => {
     }
   })
 
+  it('marks exactly the mutating tools as non-read-only', () => {
+    const writeTools = toolDefinitions
+      .filter(d => d.annotations.readOnlyHint === false)
+      .map(d => d.name)
+    expect(writeTools.sort()).toEqual([
+      'apply_modifications',
+      'delete_keyframe',
+      'set_keyframe',
+      'set_playback_position',
+    ])
+  })
+
+  it('declares annotations on every definition', () => {
+    for (const def of toolDefinitions) {
+      expect(typeof def.annotations.readOnlyHint, def.name).toBe('boolean')
+    }
+  })
+
   it('only requires properties that exist in the schema', () => {
     for (const def of toolDefinitions) {
       for (const required of def.inputSchema.required ?? []) {

--- a/noodles-editor/src/ai-chat/tool-definitions.ts
+++ b/noodles-editor/src/ai-chat/tool-definitions.ts
@@ -1,0 +1,395 @@
+// Canonical tool definitions shared by the in-app Claude chat (claude-client.ts)
+// and the WebMCP registration (src/webmcp/). Single source of truth so the
+// Anthropic input_schema and the navigator.modelContext inputSchema can't drift.
+
+import type { MCPTools } from './mcp-tools'
+import type { NoodlesProject, SearchCodeParams, ToolResult } from './types'
+
+// JSON Schema subset accepted by both Anthropic tools and WebMCP registerTool
+export interface ToolInputSchema {
+  type: 'object'
+  properties: Record<string, unknown>
+  required?: string[]
+}
+
+export interface ToolDefinition {
+  // snake_case, matches the in-app chat tool names
+  name: string
+  description: string
+  inputSchema: ToolInputSchema
+  // false = executable but not offered to the in-app chat (keeps chat token budget unchanged)
+  exposeToChat?: boolean
+  // getProject supplies the live project for tools that need it injected (analyze_project)
+  execute: (
+    tools: MCPTools,
+    params: Record<string, unknown>,
+    getProject: () => NoodlesProject | null
+  ) => Promise<ToolResult> | ToolResult
+}
+
+export const toolDefinitions: ToolDefinition[] = [
+  // Visual debugging tools
+  {
+    name: 'capture_visualization',
+    description:
+      'Capture a screenshot of the current visualization. The screenshot will be attached to your next message so you can see it.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        includeUI: { type: 'boolean' },
+        format: { type: 'string', enum: ['png', 'jpeg'] },
+        quality: { type: 'number', description: 'JPEG quality 0-1, default 0.7' },
+      },
+    },
+    execute: (tools, params) =>
+      tools.captureVisualization(
+        params as { includeUI?: boolean; format?: 'png' | 'jpeg'; quality?: number }
+      ),
+  },
+  {
+    name: 'get_console_errors',
+    description: 'Get recent browser console errors and warnings',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        since: { type: 'number' },
+        level: { type: 'string', enum: ['error', 'warn', 'all'] },
+        maxResults: { type: 'number' },
+      },
+    },
+    execute: (tools, params) =>
+      tools.getConsoleErrors(
+        params as { since?: number; level?: 'error' | 'warn' | 'all'; maxResults?: number }
+      ),
+  },
+  {
+    name: 'get_render_stats',
+    description: 'Get deck.gl rendering statistics',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    execute: tools => tools.getRenderStats(),
+  },
+  {
+    name: 'inspect_layer',
+    description: 'Get layer information',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        layerId: { type: 'string' },
+      },
+      required: ['layerId'],
+    },
+    execute: (tools, params) => tools.inspectLayer(params as { layerId: string }),
+  },
+  // Project state tools
+  {
+    name: 'apply_modifications',
+    description:
+      'Apply modifications to the project (add/update/delete nodes or edges). Use this instead of returning JSON in text.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        modifications: {
+          type: 'array',
+          description: 'Array of modifications to apply',
+          items: {
+            type: 'object',
+            properties: {
+              type: {
+                type: 'string',
+                enum: ['add_node', 'update_node', 'delete_node', 'add_edge', 'delete_edge'],
+              },
+              data: {
+                type: 'object',
+                description: 'The node or edge data',
+              },
+            },
+            required: ['type', 'data'],
+          },
+        },
+      },
+      required: ['modifications'],
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic modification structure from Claude
+    execute: (tools, params) => tools.applyModifications(params as { modifications: any[] }),
+  },
+  {
+    name: 'get_current_project',
+    description: 'Get the current project state including all nodes and edges',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    execute: tools => tools.getCurrentProject(),
+  },
+  {
+    name: 'list_nodes',
+    description: 'List all nodes in the project with their current state and execution status',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    execute: tools => tools.listNodes(),
+  },
+  {
+    name: 'get_node_info',
+    description: 'Get detailed information about a specific node including connections and schema',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        nodeId: { type: 'string', description: 'The ID of the node to inspect' },
+      },
+      required: ['nodeId'],
+    },
+    execute: (tools, params) => tools.getNodeInfo(params as { nodeId: string }),
+  },
+  {
+    name: 'get_node_output',
+    description:
+      'Read the output data from a specific operator/node. Useful for inspecting data at any point in the pipeline.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        nodeId: { type: 'string', description: 'The ID of the node to read output from' },
+        maxRows: {
+          type: 'number',
+          description: 'Maximum number of rows to return (default: 10)',
+        },
+      },
+      required: ['nodeId'],
+    },
+    execute: (tools, params) => tools.getNodeOutput(params as { nodeId: string; maxRows?: number }),
+  },
+  // Timeline tools
+  {
+    name: 'get_timeline',
+    description:
+      'Get the current animation timeline state: sequence length, FPS, playback position, and all animated tracks with their keyframes. Use this before adding keyframes to understand the current animation.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    execute: tools => tools.getTimeline(),
+  },
+  {
+    name: 'set_keyframe',
+    description:
+      'Add or update a keyframe on an animated field. Track IDs follow the pattern "operator-name / fieldName" (e.g. "my-layer / opacity"). Position is in seconds. Interpolation is "bezier" (smooth) or "hold" (step). If a keyframe already exists within 1 frame of the position, it will be updated.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        trackId: {
+          type: 'string',
+          description: 'Track identifier in format "operator-name / fieldName"',
+        },
+        position: { type: 'number', description: 'Time position in seconds' },
+        value: { description: 'The value at this keyframe (number, boolean, or string)' },
+        interpolation: {
+          type: 'string',
+          enum: ['bezier', 'hold'],
+          description: 'Interpolation type (default: bezier)',
+        },
+      },
+      required: ['trackId', 'position', 'value'],
+    },
+    execute: (tools, params) =>
+      tools.setKeyframe(
+        params as {
+          trackId: string
+          position: number
+          value: number | boolean | string
+          interpolation?: 'bezier' | 'hold'
+        }
+      ),
+  },
+  {
+    name: 'delete_keyframe',
+    description: 'Delete a specific keyframe by its ID. Use get_timeline to find keyframe IDs.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        trackId: { type: 'string', description: 'The track containing the keyframe' },
+        keyframeId: { type: 'string', description: 'The keyframe ID to delete' },
+      },
+      required: ['trackId', 'keyframeId'],
+    },
+    execute: (tools, params) =>
+      tools.deleteKeyframe(params as { trackId: string; keyframeId: string }),
+  },
+  {
+    name: 'set_playback_position',
+    description:
+      'Scrub the timeline to a specific time position (in seconds) for inspection. Optionally start or stop playback.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        position: { type: 'number', description: 'Time in seconds to seek to' },
+        play: {
+          type: 'boolean',
+          description: 'true to start playback, false to pause, omit to leave unchanged',
+        },
+      },
+      required: ['position'],
+    },
+    execute: (tools, params) =>
+      tools.setPlaybackPosition(params as { position: number; play?: boolean }),
+  },
+  // Context tools (code search, docs, examples) — executable by the chat's tool
+  // loop and WebMCP, but not offered in the chat's tool list to save tokens
+  {
+    name: 'search_code',
+    description:
+      'Search the Noodles.gl source code with a regex pattern. Returns matching lines with surrounding context.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Regex pattern to search for' },
+        path: { type: 'string', description: 'Only search files whose path contains this string' },
+        contextLines: {
+          type: 'number',
+          description: 'Lines of context around each match (default: 3)',
+        },
+        maxResults: { type: 'number', description: 'Maximum matches to return (default: 20)' },
+      },
+      required: ['pattern'],
+    },
+    exposeToChat: false,
+    execute: (tools, params) => tools.searchCode(params as unknown as SearchCodeParams),
+  },
+  {
+    name: 'get_source_code',
+    description: 'Get source code for a specific file, optionally limited to a line range',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', description: 'File path within the code index' },
+        startLine: { type: 'number', description: '1-indexed first line (default: 1)' },
+        endLine: { type: 'number', description: '1-indexed last line (default: end of file)' },
+      },
+      required: ['file'],
+    },
+    exposeToChat: false,
+    execute: (tools, params) =>
+      tools.getSourceCode(params as { file: string; startLine?: number; endLine?: number }),
+  },
+  {
+    name: 'get_operator_schema',
+    description:
+      'Get the input/output field schema for an operator type (e.g. FileOp, ScatterplotLayerOp)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        type: { type: 'string', description: 'Operator type name' },
+      },
+      required: ['type'],
+    },
+    exposeToChat: false,
+    execute: (tools, params) => tools.getOperatorSchema(params as { type: string }),
+  },
+  {
+    name: 'list_operators',
+    description: 'List all available operator types, optionally filtered by category',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        category: { type: 'string', description: 'Filter by operator category' },
+      },
+    },
+    exposeToChat: false,
+    execute: (tools, params) => tools.listOperators(params as { category?: string }),
+  },
+  {
+    name: 'get_documentation',
+    description: 'Search the Noodles.gl documentation',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query' },
+        section: {
+          type: 'string',
+          enum: ['users', 'developers', 'ai-assistant', 'examples'],
+          description: 'Limit search to a docs section',
+        },
+      },
+      required: ['query'],
+    },
+    exposeToChat: false,
+    execute: (tools, params) =>
+      tools.getDocumentation(
+        params as { query: string; section?: 'users' | 'developers' | 'ai-assistant' | 'examples' }
+      ),
+  },
+  {
+    name: 'get_example',
+    description: 'Get an example project by ID, including its full node graph',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Example project ID' },
+      },
+      required: ['id'],
+    },
+    exposeToChat: false,
+    execute: (tools, params) => tools.getExample(params as { id: string }),
+  },
+  {
+    name: 'list_examples',
+    description: 'List all example projects, optionally filtered by category or tag',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        category: { type: 'string', description: 'Filter by category' },
+        tag: { type: 'string', description: 'Filter by tag' },
+      },
+    },
+    exposeToChat: false,
+    execute: (tools, params) => tools.listExamples(params as { category?: string; tag?: string }),
+  },
+  {
+    name: 'find_symbol',
+    description: 'Find a symbol (class, function, type) by name in the Noodles.gl source code',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Symbol name to find' },
+      },
+      required: ['name'],
+    },
+    exposeToChat: false,
+    execute: (tools, params) => tools.findSymbol(params as { name: string }),
+  },
+  {
+    name: 'analyze_project',
+    description: 'Analyze the current project for validation issues or performance problems',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        analysisType: {
+          type: 'string',
+          enum: ['validation', 'performance', 'suggestions'],
+          description: 'Type of analysis to run',
+        },
+      },
+      required: ['analysisType'],
+    },
+    exposeToChat: false,
+    execute: (tools, params, getProject) => {
+      const project = getProject()
+      if (!project) {
+        return { success: false, error: 'No project loaded' }
+      }
+      return tools.analyzeProject({
+        project,
+        analysisType: params.analysisType as 'validation' | 'performance' | 'suggestions',
+      })
+    },
+  },
+]
+
+const definitionsByName = new Map(toolDefinitions.map(d => [d.name, d]))
+
+export function getToolDefinition(name: string): ToolDefinition | undefined {
+  return definitionsByName.get(name)
+}

--- a/noodles-editor/src/ai-chat/tool-definitions.ts
+++ b/noodles-editor/src/ai-chat/tool-definitions.ts
@@ -12,10 +12,21 @@ export interface ToolInputSchema {
   required?: string[]
 }
 
+// Behavior hints per the MCP/WebMCP ToolAnnotations spec. MCP clients use
+// these to decide which calls to auto-approve vs surface to the user, so
+// every definition must declare them — a new mutating tool can't silently
+// pass for read-only
+export interface ToolAnnotations {
+  readOnlyHint: boolean
+  destructiveHint?: boolean
+  idempotentHint?: boolean
+}
+
 export interface ToolDefinition {
   // snake_case, matches the in-app chat tool names
   name: string
   description: string
+  annotations: ToolAnnotations
   inputSchema: ToolInputSchema
   // false = executable but not offered to the in-app chat (keeps chat token budget unchanged)
   exposeToChat?: boolean
@@ -31,6 +42,7 @@ export const toolDefinitions: ToolDefinition[] = [
   // Visual debugging tools
   {
     name: 'capture_visualization',
+    annotations: { readOnlyHint: true },
     description:
       'Capture a screenshot of the current visualization. The screenshot will be attached to your next message so you can see it.',
     inputSchema: {
@@ -48,6 +60,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_console_errors',
+    annotations: { readOnlyHint: true },
     description: 'Get recent browser console errors and warnings',
     inputSchema: {
       type: 'object',
@@ -64,6 +77,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_render_stats',
+    annotations: { readOnlyHint: true },
     description: 'Get deck.gl rendering statistics',
     inputSchema: {
       type: 'object',
@@ -73,6 +87,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'inspect_layer',
+    annotations: { readOnlyHint: true },
     description: 'Get layer information',
     inputSchema: {
       type: 'object',
@@ -86,6 +101,7 @@ export const toolDefinitions: ToolDefinition[] = [
   // Project state tools
   {
     name: 'apply_modifications',
+    annotations: { readOnlyHint: false, destructiveHint: true },
     description:
       'Apply modifications to the project (add/update/delete nodes or edges). Use this instead of returning JSON in text.',
     inputSchema: {
@@ -117,6 +133,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_current_project',
+    annotations: { readOnlyHint: true },
     description: 'Get the current project state including all nodes and edges',
     inputSchema: {
       type: 'object',
@@ -126,6 +143,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'list_nodes',
+    annotations: { readOnlyHint: true },
     description: 'List all nodes in the project with their current state and execution status',
     inputSchema: {
       type: 'object',
@@ -135,6 +153,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_node_info',
+    annotations: { readOnlyHint: true },
     description: 'Get detailed information about a specific node including connections and schema',
     inputSchema: {
       type: 'object',
@@ -147,6 +166,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_node_output',
+    annotations: { readOnlyHint: true },
     description:
       'Read the output data from a specific operator/node. Useful for inspecting data at any point in the pipeline.',
     inputSchema: {
@@ -165,6 +185,7 @@ export const toolDefinitions: ToolDefinition[] = [
   // Timeline tools
   {
     name: 'get_timeline',
+    annotations: { readOnlyHint: true },
     description:
       'Get the current animation timeline state: sequence length, FPS, playback position, and all animated tracks with their keyframes. Use this before adding keyframes to understand the current animation.',
     inputSchema: {
@@ -175,6 +196,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'set_keyframe',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     description:
       'Add or update a keyframe on an animated field. Track IDs follow the pattern "operator-name / fieldName" (e.g. "my-layer / opacity"). Position is in seconds. Interpolation is "bezier" (smooth) or "hold" (step). If a keyframe already exists within 1 frame of the position, it will be updated.',
     inputSchema: {
@@ -206,6 +228,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'delete_keyframe',
+    annotations: { readOnlyHint: false, destructiveHint: true },
     description: 'Delete a specific keyframe by its ID. Use get_timeline to find keyframe IDs.',
     inputSchema: {
       type: 'object',
@@ -220,6 +243,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'set_playback_position',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     description:
       'Scrub the timeline to a specific time position (in seconds) for inspection. Optionally start or stop playback.',
     inputSchema: {
@@ -240,6 +264,7 @@ export const toolDefinitions: ToolDefinition[] = [
   // loop and WebMCP, but not offered in the chat's tool list to save tokens
   {
     name: 'search_code',
+    annotations: { readOnlyHint: true },
     description:
       'Search the Noodles.gl source code with a regex pattern. Returns matching lines with surrounding context.',
     inputSchema: {
@@ -260,6 +285,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_source_code',
+    annotations: { readOnlyHint: true },
     description: 'Get source code for a specific file, optionally limited to a line range',
     inputSchema: {
       type: 'object',
@@ -276,6 +302,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_operator_schema',
+    annotations: { readOnlyHint: true },
     description:
       'Get the input/output field schema for an operator type (e.g. FileOp, ScatterplotLayerOp)',
     inputSchema: {
@@ -290,6 +317,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'list_operators',
+    annotations: { readOnlyHint: true },
     description: 'List all available operator types, optionally filtered by category',
     inputSchema: {
       type: 'object',
@@ -302,6 +330,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_documentation',
+    annotations: { readOnlyHint: true },
     description: 'Search the Noodles.gl documentation',
     inputSchema: {
       type: 'object',
@@ -323,6 +352,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_example',
+    annotations: { readOnlyHint: true },
     description: 'Get an example project by ID, including its full node graph',
     inputSchema: {
       type: 'object',
@@ -336,6 +366,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'list_examples',
+    annotations: { readOnlyHint: true },
     description: 'List all example projects, optionally filtered by category or tag',
     inputSchema: {
       type: 'object',
@@ -349,6 +380,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'find_symbol',
+    annotations: { readOnlyHint: true },
     description: 'Find a symbol (class, function, type) by name in the Noodles.gl source code',
     inputSchema: {
       type: 'object',
@@ -362,6 +394,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'analyze_project',
+    annotations: { readOnlyHint: true },
     description: 'Analyze the current project for validation issues or performance problems',
     inputSchema: {
       type: 'object',

--- a/noodles-editor/src/app.tsx
+++ b/noodles-editor/src/app.tsx
@@ -2,6 +2,7 @@ import { Component, lazy, type ReactNode, Suspense, useEffect } from 'react'
 import { Redirect, Route, Router, Switch, useRoute, useSearchParams } from 'wouter'
 import { AnalyticsConsentBanner } from './components/analytics-consent-banner'
 import { type ModalView, QuickStartModal } from './components/quick-start-modal'
+import { externalControl } from './noodles/globals'
 import { useUIStore } from './noodles/store'
 import TimelineEditor from './timeline-editor'
 import { debugApp } from './utils/debug'
@@ -9,6 +10,8 @@ import { debugApp } from './utils/debug'
 const ExternalControlProvider = lazy(() =>
   import('./external-control').then(m => ({ default: m.ExternalControlProvider }))
 )
+
+const WebMCPProvider = lazy(() => import('./webmcp').then(m => ({ default: m.WebMCPProvider })))
 
 // Error boundary to catch analytics failures
 class AnalyticsErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
@@ -41,14 +44,16 @@ function App() {
 
   // Check if external control should be enabled based on URL params
   const urlParams = new URLSearchParams(window.location.search)
-  const enableExternalControl = urlParams.get('externalControl') === 'true'
   const externalControlDebug = urlParams.get('externalControlDebug') === 'true'
 
   return (
     <Router base={baseUrl}>
-      {/* External control provider - only enable when requested via URL params */}
-      {enableExternalControl && (
+      {/* External control providers - only enabled when requested via URL params.
+          WebMCPProvider registers tools on navigator.modelContext (primary path);
+          ExternalControlProvider is the legacy WebSocket bridge. */}
+      {externalControl && (
         <Suspense fallback={null}>
+          <WebMCPProvider />
           <ExternalControlProvider
             autoConnect={false}
             debug={externalControlDebug}

--- a/noodles-editor/src/external-control/README.md
+++ b/noodles-editor/src/external-control/README.md
@@ -2,11 +2,13 @@
 
 This module enables external AI tools and scripts to control the Noodles application programmatically through a WebSocket-based API.
 
+> **Note**: For MCP clients (Claude Code, Claude Desktop, Cursor), the recommended path is now **WebMCP** (`src/webmcp/`), which registers the full in-app AI tool surface on `navigator.modelContext` under the same `?externalControl=true` flag — no proxy process required. See "Connecting Claude Code to a Running Browser Instance" in the root `AGENTS.md`. The WebSocket bridge below remains available as a legacy path and for custom non-MCP tooling.
+
 ## Architecture
 
 The external control system supports two connection methods:
 
-### Option 1: MCP Protocol (Recommended for Claude Desktop)
+### Option 1: MCP Protocol (Legacy — prefer WebMCP)
 
 Use the MCP proxy to connect Claude Desktop directly to Noodles:
 

--- a/noodles-editor/src/noodles/globals.ts
+++ b/noodles-editor/src/noodles/globals.ts
@@ -5,6 +5,10 @@ const queryParams = new URLSearchParams(window?.location.search ?? '')
 // app has broken in an invalid state
 export const safeMode = queryParams.get('safeMode') === 'true'
 
+// Enables external control of the app (WebMCP tool registration and the
+// legacy WebSocket bridge)
+export const externalControl = queryParams.get('externalControl') === 'true'
+
 export const IS_PROD =
   typeof location !== 'undefined' ? location.hostname === import.meta.env.VITE_PROD_HOSTNAME : false
 

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -30,6 +30,9 @@ import { useLocation, useParams } from 'wouter'
 import { globalContextManager } from '../ai-chat/global-context-manager'
 import { getPendingQuickStartAction } from '../components/quick-start-modal'
 import { analytics } from '../utils/analytics'
+import type { NoodlesProject } from '../ai-chat/types'
+import { setCurrentProject, setModificationApplier } from '../webmcp/bridge'
+import { externalControl } from './globals'
 import { getKeysForProject, getKeysStore } from './keys-store'
 import newProjectJSON from './new.json'
 import { BitmapOverlayWidget, type BitmapOverlayWidgetProps } from './widgets/bitmap-overlay-widget'
@@ -376,6 +379,7 @@ export function getNoodles(): Visualization {
 
   // Use shared hook for project modifications
   const {
+    applyModifications,
     onConnect: onConnectBase,
     onNodesDelete: onNodesDeleteBase,
     updateOperatorId,
@@ -385,6 +389,20 @@ export function getNoodles(): Visualization {
     setNodes,
     setEdges,
   })
+
+  // Keep the WebMCP tool surface in sync with editor state when external
+  // control is enabled (?externalControl=true)
+  useEffect(() => {
+    if (!externalControl) return
+    setModificationApplier(applyModifications)
+    return () => setModificationApplier(null)
+  }, [applyModifications])
+
+  useEffect(() => {
+    if (!externalControl) return
+    // ReactFlow edges type sourceHandle as string | null; the project shape uses undefined
+    setCurrentProject({ nodes, edges } as NoodlesProject)
+  }, [nodes, edges])
 
   // Wrap onConnect to mark unsaved changes
   const onConnect = useCallback(

--- a/noodles-editor/src/utils/debug.ts
+++ b/noodles-editor/src/utils/debug.ts
@@ -35,6 +35,7 @@ export const debugVis = createDebug('noodles:vis') // visualization layer
 // Feature namespaces
 export const debugAiChat = createDebug('noodles:ai-chat') // AI chat panel, context loading, and agents
 export const debugExternal = createDebug('noodles:external') // external control WebSocket and worker bridge
+export const debugWebMCP = createDebug('noodles:webmcp') // WebMCP tool registration and execution
 export const debugGeocode = createDebug('noodles:geocode') // geocoding API calls
 export const debugAnalytics = createDebug('noodles:analytics') // analytics tracking and consent
 

--- a/noodles-editor/src/webmcp/bridge.ts
+++ b/noodles-editor/src/webmcp/bridge.ts
@@ -1,0 +1,43 @@
+// Glue between the lazily-loaded WebMCP chunk and the React editor state.
+// Kept dependency-free (type-only imports) so noodles.tsx can import it
+// without pulling the WebMCP chunk into the main bundle.
+
+import type { NoodlesProject } from '../ai-chat/types'
+import type {
+  ModificationResult,
+  ProjectModification,
+} from '../noodles/hooks/use-project-modifications'
+
+type ModificationApplier = (modifications: ProjectModification[]) => ModificationResult
+
+let applier: ModificationApplier | null = null
+let project: NoodlesProject | null = null
+const projectListeners = new Set<(project: NoodlesProject) => void>()
+
+// The editor registers its useProjectModifications applier here so WebMCP
+// tool calls can actually mutate React Flow state
+export function setModificationApplier(fn: ModificationApplier | null) {
+  applier = fn
+}
+
+export function getModificationApplier(): ModificationApplier | null {
+  return applier
+}
+
+export function setCurrentProject(next: NoodlesProject) {
+  project = next
+  for (const listener of projectListeners) {
+    listener(next)
+  }
+}
+
+export function getCurrentProject(): NoodlesProject | null {
+  return project
+}
+
+export function onProjectChange(listener: (project: NoodlesProject) => void): () => void {
+  projectListeners.add(listener)
+  return () => {
+    projectListeners.delete(listener)
+  }
+}

--- a/noodles-editor/src/webmcp/index.tsx
+++ b/noodles-editor/src/webmcp/index.tsx
@@ -38,6 +38,12 @@ function loadRelayEmbed() {
 
 export const WebMCPProvider: FC = () => {
   useEffect(() => {
+    // An embedding page must not inherit the tool surface — only the top-level
+    // document the user explicitly opted into gets registered
+    if (window.self !== window.top) {
+      debugWebMCP('embedded in an iframe, skipping tool registration')
+      return
+    }
     const controller = new AbortController()
     initWebMCP(controller.signal).catch(error => {
       debugWebMCP('init failed:', error)

--- a/noodles-editor/src/webmcp/index.tsx
+++ b/noodles-editor/src/webmcp/index.tsx
@@ -1,0 +1,50 @@
+// WebMCP provider — registers the AI tool surface on navigator.modelContext
+// while mounted. Loaded lazily from app.tsx when ?externalControl=true.
+
+import { type FC, useEffect } from 'react'
+import { debugWebMCP } from '../utils/debug'
+import { initWebMCP } from './register'
+
+// The npx local relay (@mcp-b/webmcp-local-relay) only discovers tabs that load
+// its embed script; the WebMCP extension and native Chrome paths need nothing.
+// Pinned CDN build, injected on localhost only — same trust model as the
+// legacy WebSocket bridge. The pinned version must match the relay major the
+// docs tell users to run (the discovery handshake changes between majors).
+// To self-host instead, copy embed.js/widget.js/widget.html from the package
+// tarball into public/webmcp/.
+const RELAY_EMBED_URL =
+  'https://cdn.jsdelivr.net/npm/@mcp-b/webmcp-local-relay@4.0.0/dist/browser/embed.js'
+
+function loadRelayEmbed() {
+  const isLocalhost =
+    window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+  if (!isLocalhost) return
+  // [data-webmcp-relay] is the embed's own marker for its widget iframe — its
+  // presence means the relay bridge is already initialized
+  if (document.querySelector('[data-webmcp-relay]')) return
+  if (document.querySelector('script[data-noodles-webmcp-relay]')) return
+
+  try {
+    const script = document.createElement('script')
+    script.src = RELAY_EMBED_URL
+    script.async = true
+    script.dataset.noodlesWebmcpRelay = 'true'
+    script.onerror = () => debugWebMCP('relay embed failed to load')
+    document.head.appendChild(script)
+  } catch (error) {
+    debugWebMCP('relay embed injection failed:', error)
+  }
+}
+
+export const WebMCPProvider: FC = () => {
+  useEffect(() => {
+    const controller = new AbortController()
+    initWebMCP(controller.signal).catch(error => {
+      debugWebMCP('init failed:', error)
+    })
+    loadRelayEmbed()
+    return () => controller.abort()
+  }, [])
+
+  return null
+}

--- a/noodles-editor/src/webmcp/register.ts
+++ b/noodles-editor/src/webmcp/register.ts
@@ -42,7 +42,10 @@ export async function initWebMCP(signal: AbortSignal): Promise<void> {
 
   try {
     // Side-effect import: installs the navigator.modelContext polyfill and the
-    // transports that bridge tools to the WebMCP extension / local relay
+    // transports that bridge tools to the WebMCP extension / local relay.
+    // Note: zod-to-json-schema in package.json exists solely to satisfy this
+    // package's top-level optional-peer import — vite build fails without it,
+    // even though we only pass plain JSON Schema (its Zod path needs Zod 3)
     await import('@mcp-b/global')
 
     // Load the context bundles (code index, docs, examples) so the search/docs
@@ -66,6 +69,7 @@ export async function initWebMCP(signal: AbortSignal): Promise<void> {
         {
           name: definition.name,
           description: definition.description,
+          annotations: definition.annotations,
           inputSchema: definition.inputSchema as InputSchema,
           execute: async (args: Record<string, unknown>) =>
             toToolResponse(definition.name, await runTool(tools, definition, args ?? {})),

--- a/noodles-editor/src/webmcp/register.ts
+++ b/noodles-editor/src/webmcp/register.ts
@@ -1,0 +1,179 @@
+// Registers the shared AI tool surface on navigator.modelContext (WebMCP).
+// External MCP clients (Claude Code, Claude Desktop, Cursor) reach these tools
+// through the WebMCP browser extension, native Chrome (origin trial), or the
+// @mcp-b/webmcp-local-relay stdio bridge.
+
+// Pulls in the global Document/Navigator modelContext type augmentation
+/// <reference types="@mcp-b/webmcp-types" />
+
+import type { InputSchema } from '@mcp-b/webmcp-types'
+import { globalContextManager } from '../ai-chat/global-context-manager'
+import { MCPTools } from '../ai-chat/mcp-tools'
+import { type ToolDefinition, toolDefinitions } from '../ai-chat/tool-definitions'
+import type { ProjectModification, ToolResult } from '../ai-chat/types'
+import type { ProjectModification as ReactFlowModification } from '../noodles/hooks/use-project-modifications'
+import { safeStringify } from '../noodles/utils/serialization'
+import { debugWebMCP } from '../utils/debug'
+import { getCurrentProject, getModificationApplier, onProjectChange } from './bridge'
+
+interface ContentBlock {
+  type: string
+  [key: string]: unknown
+}
+
+interface ToolResponse {
+  content: ContentBlock[]
+  isError?: boolean
+}
+
+// Guards against double registration (registerTool throws on duplicate names)
+// when HMR remounts the provider before the previous AbortSignal fires
+let active = false
+
+export async function initWebMCP(signal: AbortSignal): Promise<void> {
+  if (active) {
+    debugWebMCP('already initialized, skipping')
+    return
+  }
+  active = true
+  signal.addEventListener('abort', () => {
+    active = false
+  })
+
+  try {
+    // Side-effect import: installs the navigator.modelContext polyfill and the
+    // transports that bridge tools to the WebMCP extension / local relay
+    await import('@mcp-b/global')
+
+    // Load the context bundles (code index, docs, examples) so the search/docs
+    // tools work even if the chat panel never opened. On failure those tools
+    // degrade to error results.
+    const loader = await globalContextManager.waitForReady().catch(error => {
+      debugWebMCP('context load failed, search/docs tools degraded:', error)
+      return undefined
+    })
+
+    if (signal.aborted) return
+
+    const tools = new MCPTools(loader)
+    const project = getCurrentProject()
+    if (project) tools.setProject(project)
+    const unsubscribe = onProjectChange(p => tools.setProject(p))
+    signal.addEventListener('abort', unsubscribe)
+
+    for (const definition of toolDefinitions) {
+      navigator.modelContext.registerTool(
+        {
+          name: definition.name,
+          description: definition.description,
+          inputSchema: definition.inputSchema as InputSchema,
+          execute: async (args: Record<string, unknown>) =>
+            toToolResponse(definition.name, await runTool(tools, definition, args ?? {})),
+        },
+        { signal }
+      )
+    }
+
+    debugWebMCP('registered %d tools on navigator.modelContext', toolDefinitions.length)
+  } catch (error) {
+    active = false
+    throw error
+  }
+}
+
+// Executes a tool definition, never letting exceptions escape to the transport
+async function runTool(
+  tools: MCPTools,
+  definition: ToolDefinition,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  try {
+    const result = await definition.execute(tools, params, getCurrentProject)
+
+    // apply_modifications only validates in MCPTools — the actual graph
+    // mutation goes through the editor's applier registered in the bridge
+    if (definition.name === 'apply_modifications' && result.success) {
+      return applyToEditor(result)
+    }
+
+    return result
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+function applyToEditor(validationResult: ToolResult): ToolResult {
+  const applier = getModificationApplier()
+  if (!applier) {
+    return { success: false, error: 'Editor not mounted — open a project first' }
+  }
+
+  const data = validationResult.data as { modifications?: ProjectModification[] } | undefined
+  const modifications = data?.modifications
+  if (!modifications || modifications.length === 0) {
+    return { success: false, error: 'No modifications to apply' }
+  }
+
+  // The editor applier expects React Flow node/edge shapes; the validated
+  // modifications carry the same structure (chat-panel.tsx does the same cast)
+  const applied = applier(modifications as unknown as ReactFlowModification[])
+  if (!applied.success) {
+    return { success: false, error: applied.error ?? 'Failed to apply modifications' }
+  }
+
+  return {
+    success: true,
+    data: {
+      modificationsCount: modifications.length,
+      warnings: applied.warnings,
+      message: `${modifications.length} modification(s) applied to the project`,
+    },
+  }
+}
+
+// Converts a ToolResult into the WebMCP/MCP CallToolResult shape
+function toToolResponse(toolName: string, result: ToolResult): ToolResponse {
+  if (!result.success) {
+    return {
+      content: [{ type: 'text', text: result.error ?? 'Unknown error' }],
+      isError: true,
+    }
+  }
+
+  // Screenshots go back as a proper MCP image block; the base64 payload is
+  // stripped from the text metadata to keep it readable
+  if (toolName === 'capture_visualization' && isScreenshotData(result.data)) {
+    const { screenshot, format = 'jpeg', ...meta } = result.data
+    return {
+      content: [
+        { type: 'image', data: screenshot, mimeType: `image/${format}` },
+        { type: 'text', text: JSON.stringify({ format, ...meta }) },
+      ],
+    }
+  }
+
+  return {
+    content: [{ type: 'text', text: stringifyData(result.data) }],
+  }
+}
+
+function stringifyData(data: unknown): string {
+  // safeStringify sanitizes functions/circular refs but only accepts objects
+  if (typeof data === 'object' && data !== null) {
+    return safeStringify(data as Record<string, unknown>).trimEnd()
+  }
+  return JSON.stringify(data) ?? 'null'
+}
+
+function isScreenshotData(
+  data: unknown
+): data is { screenshot: string; format?: 'png' | 'jpeg'; [key: string]: unknown } {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    typeof (data as { screenshot?: unknown }).screenshot === 'string'
+  )
+}

--- a/noodles-editor/src/webmcp/webmcp.test.ts
+++ b/noodles-editor/src/webmcp/webmcp.test.ts
@@ -48,6 +48,7 @@ vi.mock('../ai-chat/mcp-tools', () => {
 interface RegisteredTool {
   name: string
   description: string
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean }
   inputSchema: { type: string }
   execute: (args: Record<string, unknown>) => Promise<{
     content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>
@@ -99,6 +100,15 @@ describe('initWebMCP', () => {
     for (const call of registerTool.mock.calls) {
       expect(call[1]?.signal).toBeInstanceOf(AbortSignal)
     }
+  })
+
+  it('passes behavior annotations through to registerTool', async () => {
+    await init()
+    for (const def of toolDefinitions) {
+      expect(getRegistered(def.name).annotations, def.name).toEqual(def.annotations)
+    }
+    expect(getRegistered('apply_modifications').annotations?.destructiveHint).toBe(true)
+    expect(getRegistered('list_nodes').annotations?.readOnlyHint).toBe(true)
   })
 
   it('skips re-initialization while already active', async () => {

--- a/noodles-editor/src/webmcp/webmcp.test.ts
+++ b/noodles-editor/src/webmcp/webmcp.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toolDefinitions } from '../ai-chat/tool-definitions'
+import { setCurrentProject, setModificationApplier } from './bridge'
+import { initWebMCP } from './register'
+
+// The polyfill import is a side effect only — the tests install their own fake
+vi.mock('@mcp-b/global', () => ({}))
+
+vi.mock('../ai-chat/global-context-manager', () => ({
+  globalContextManager: {
+    waitForReady: vi.fn(async () => null),
+  },
+}))
+
+vi.mock('../ai-chat/mcp-tools', () => {
+  class MockMCPTools {
+    static instances: MockMCPTools[] = []
+
+    constructor() {
+      MockMCPTools.instances.push(this)
+    }
+
+    setProject = vi.fn()
+    listNodes = vi.fn(async () => ({
+      success: true,
+      data: [{ id: '/scatter', type: 'ScatterplotLayerOp' }],
+    }))
+    getRenderStats = vi.fn(async () => ({ success: true, data: { fps: 60 } }))
+    inspectLayer = vi.fn(async () => ({ success: false, error: 'Layer not found: missing' }))
+    getConsoleErrors = vi.fn(async () => {
+      throw new Error('console tracking exploded')
+    })
+    captureVisualization = vi.fn(async () => ({
+      success: true,
+      data: { screenshot: 'aGVsbG8=', format: 'jpeg', width: 8, height: 8 },
+    }))
+    applyModifications = vi.fn(async (params: { modifications: unknown[] }) => ({
+      success: true,
+      data: {
+        modifications: params.modifications,
+        modificationsCount: params.modifications.length,
+      },
+    }))
+  }
+  return { MCPTools: MockMCPTools }
+})
+
+interface RegisteredTool {
+  name: string
+  description: string
+  inputSchema: { type: string }
+  execute: (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>
+    isError?: boolean
+  }>
+}
+
+let registered: Map<string, RegisteredTool>
+let registerTool: ReturnType<typeof vi.fn>
+let controller: AbortController
+
+async function init() {
+  controller = new AbortController()
+  await initWebMCP(controller.signal)
+}
+
+function getRegistered(name: string): RegisteredTool {
+  const tool = registered.get(name)
+  if (!tool) throw new Error(`Tool not registered: ${name}`)
+  return tool
+}
+
+describe('initWebMCP', () => {
+  beforeEach(() => {
+    registered = new Map()
+    registerTool = vi.fn((tool: RegisteredTool, options?: { signal?: AbortSignal }) => {
+      if (registered.has(tool.name)) throw new Error(`Duplicate tool: ${tool.name}`)
+      if (options?.signal?.aborted) return
+      registered.set(tool.name, tool)
+      options?.signal?.addEventListener('abort', () => registered.delete(tool.name))
+    })
+    Object.defineProperty(navigator, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    })
+    setModificationApplier(null)
+  })
+
+  afterEach(() => {
+    controller?.abort()
+  })
+
+  it('registers every tool definition with an abort signal', async () => {
+    await init()
+    expect(registerTool).toHaveBeenCalledTimes(toolDefinitions.length)
+    for (const def of toolDefinitions) {
+      expect(registered.has(def.name), def.name).toBe(true)
+    }
+    for (const call of registerTool.mock.calls) {
+      expect(call[1]?.signal).toBeInstanceOf(AbortSignal)
+    }
+  })
+
+  it('skips re-initialization while already active', async () => {
+    await init()
+    const first = controller
+    await initWebMCP(new AbortController().signal)
+    expect(registerTool).toHaveBeenCalledTimes(toolDefinitions.length)
+    first.abort()
+  })
+
+  it('re-registers cleanly after abort', async () => {
+    await init()
+    controller.abort()
+    expect(registered.size).toBe(0)
+    await init()
+    expect(registered.size).toBe(toolDefinitions.length)
+  })
+
+  it('returns successful results as a JSON text block', async () => {
+    await init()
+    const response = await getRegistered('list_nodes').execute({})
+    expect(response.isError).toBeUndefined()
+    expect(response.content).toHaveLength(1)
+    expect(response.content[0].type).toBe('text')
+    expect(JSON.parse(response.content[0].text ?? '')).toEqual([
+      { id: '/scatter', type: 'ScatterplotLayerOp' },
+    ])
+  })
+
+  it('returns tool failures as isError responses', async () => {
+    await init()
+    const response = await getRegistered('inspect_layer').execute({ layerId: 'missing' })
+    expect(response.isError).toBe(true)
+    expect(response.content[0].text).toContain('Layer not found')
+  })
+
+  it('converts thrown errors into isError responses instead of rejecting', async () => {
+    await init()
+    const response = await getRegistered('get_console_errors').execute({})
+    expect(response.isError).toBe(true)
+    expect(response.content[0].text).toContain('console tracking exploded')
+  })
+
+  it('returns screenshots as an image block without base64 in the text', async () => {
+    await init()
+    const response = await getRegistered('capture_visualization').execute({ format: 'jpeg' })
+    expect(response.isError).toBeUndefined()
+    const [image, meta] = response.content
+    expect(image.type).toBe('image')
+    expect(image.data).toBe('aGVsbG8=')
+    expect(image.mimeType).toBe('image/jpeg')
+    expect(meta.type).toBe('text')
+    expect(meta.text).not.toContain('aGVsbG8=')
+    expect(meta.text).toContain('"width"')
+  })
+
+  it('fails apply_modifications when the editor applier is not registered', async () => {
+    await init()
+    const response = await getRegistered('apply_modifications').execute({
+      modifications: [{ type: 'add_node', data: { id: '/n', type: 'NumberOp' } }],
+    })
+    expect(response.isError).toBe(true)
+    expect(response.content[0].text).toContain('Editor not mounted')
+  })
+
+  it('applies modifications through the registered editor applier', async () => {
+    await init()
+    const applier = vi.fn(() => ({ success: true, warnings: undefined }))
+    setModificationApplier(applier)
+
+    const modifications = [{ type: 'add_node', data: { id: '/n', type: 'NumberOp' } }]
+    const response = await getRegistered('apply_modifications').execute({ modifications })
+
+    expect(response.isError).toBeUndefined()
+    expect(applier).toHaveBeenCalledWith(modifications)
+    expect(response.content[0].text).toContain('1 modification(s) applied')
+  })
+
+  it('reports applier failures as isError responses', async () => {
+    await init()
+    setModificationApplier(() => ({ success: false, error: 'validation failed' }))
+    const response = await getRegistered('apply_modifications').execute({
+      modifications: [{ type: 'add_node', data: { id: '/n', type: 'NumberOp' } }],
+    })
+    expect(response.isError).toBe(true)
+    expect(response.content[0].text).toContain('validation failed')
+  })
+
+  it('keeps the MCPTools project in sync via the bridge', async () => {
+    await init()
+    const { MCPTools } = await import('../ai-chat/mcp-tools')
+    const instances = (
+      MCPTools as unknown as { instances: Array<{ setProject: ReturnType<typeof vi.fn> }> }
+    ).instances
+    const tools = instances[instances.length - 1]
+
+    const project = { nodes: [{ id: '/n', type: 'NumberOp' }], edges: [] }
+    setCurrentProject(project)
+    expect(tools.setProject).toHaveBeenCalledWith(project)
+
+    // After abort the subscription is removed
+    controller.abort()
+    tools.setProject.mockClear()
+    setCurrentProject(project)
+    expect(tools.setProject).not.toHaveBeenCalled()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -2197,6 +2197,12 @@
         "quadbin": "^0.4.1-alpha.0"
       }
     },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -6239,6 +6245,85 @@
         "@math.gl/core": "4.1.0"
       }
     },
+    "node_modules/@mcp-b/global": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/global/-/global-3.0.0.tgz",
+      "integrity": "sha512-HZWlR2Gb5v/ROtg0noiiHfrnHVPYxxhOPPaeYlXvCd6UB/u82Q3lwtCdWQLw66N25Zp9VSMGRR1Eq72yDFqcNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/transports": "3.0.0",
+        "@mcp-b/webmcp-polyfill": "3.0.0",
+        "@mcp-b/webmcp-ts-sdk": "3.0.0",
+        "@mcp-b/webmcp-types": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/transports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/transports/-/transports-3.0.0.tgz",
+      "integrity": "sha512-WMgeb0P9Bhu+0mN07qkvCo+W9Fucdk9+iyp7wPZYAtQ4ZTcbNuu8Zl1qdNM8oWxXgMbA749w4nUcPsbPaMvSvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/webmcp-ts-sdk": "3.0.0",
+        "zod": "3.25.76"
+      }
+    },
+    "node_modules/@mcp-b/transports/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-polyfill": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-polyfill/-/webmcp-polyfill-3.0.0.tgz",
+      "integrity": "sha512-TCrCOZCTfRWrTp8MpWU8EO4U7r7IvDDaIYW9Ej0aBD2KVR2hvwr4t3T7kPkSYssGhpIZJrq19owSzN1vZabW+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@mcp-b/webmcp-types": "3.0.0",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-ts-sdk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-ts-sdk/-/webmcp-ts-sdk-3.0.0.tgz",
+      "integrity": "sha512-Lbn7ODKWMYd6xqpcl+OmXseKbjwB+Q3F9CUm9vDFpZgviWc3/5CuG3IDylHg/toVMeZz6v5+E8AmBnv8zj5G5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/webmcp-polyfill": "3.0.0",
+        "@mcp-b/webmcp-types": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mcp-b/webmcp-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-types/-/webmcp-types-3.0.0.tgz",
+      "integrity": "sha512-MmKHNAtlyZoK5khz5GnmgEj/ehk5esoUbgOaFndrlZvpjq3ppmIY3BDrwCv6xaihuuIMOoLLDlf0E65wUd4q7A==",
+      "license": "MIT"
+    },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
@@ -7914,7 +7999,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -27250,6 +27334,15 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/zstd-codec": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/zstd-codec/-/zstd-codec-0.1.5.tgz",
@@ -27309,6 +27402,7 @@
         "@mapbox/mapbox-gl-geocoder": "^5.1.2",
         "@mapbox/polyline": "^1.2.1",
         "@math.gl/web-mercator": "^4.1.0",
+        "@mcp-b/global": "^3.0.0",
         "@microlink/react-json-view": "^1.31.15",
         "@observablehq/plot": "^0.6.17",
         "@radix-ui/colors": "^3.0.0",
@@ -27354,10 +27448,12 @@
         "validator": "^13.15.26",
         "web-vitals": "^5.2.0",
         "wouter": "^3.9.0",
-        "zod": "^4.3.6"
+        "zod": "^4.3.6",
+        "zod-to-json-schema": "^3.25.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",
+        "@mcp-b/webmcp-types": "^3.0.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
#### Background

External control of a running Noodles session previously required the WebSocket MCP proxy (`examples/external-control/mcp-proxy.js`), a separate Node process with its own hand-copied camelCase tool surface. WebMCP — the W3C `navigator.modelContext` draft — lets the page itself expose MCP tools, so clients like Claude Code connect with just `claude mcp add webmcp -- npx -y @mcp-b/webmcp-local-relay@4`. Verified end-to-end: tools listed and called over MCP stdio against a live tab, with `apply_modifications` mutating the editor graph in real time.

#### Change List
- Register the full in-app AI tool surface (~22 tools) on `navigator.modelContext` via `@mcp-b/global` under the existing `?externalControl=true` flag (lazy chunk, no main-bundle impact)
- New `src/ai-chat/tool-definitions.ts` as the single source of truth for tool schemas, consumed by both the chat panel (`claude-client.ts` refactor) and WebMCP; adds JSON Schemas for the 9 code-search/docs tools that had none
- New `src/webmcp/` module: registration with AbortSignal teardown, MCP content-block conversion (screenshots as image blocks, failures as `isError`), localhost-only relay embed injection (pinned to relay v4 — the discovery handshake changes between majors)
- Bridge from `noodles.tsx` syncs live project state and wires `useProjectModifications`, so `apply_modifications` actually mutates the live editor graph (the legacy WS path only validated)
- 18 new unit tests (schema parity, registration, error conversion, applier bridge); docs updated to recommend WebMCP with the WebSocket proxy kept as legacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)