### PR TITLE
Add WebMCP origin trial token for noodles.gl

### DIFF
--- a/noodles-editor/index.html
+++ b/noodles-editor/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Noodles.gl Animation Editor" />
     <title>Noodles.gl</title>
+    <meta http-equiv="origin-trial" content="AvebvmJG2+UZfQfZNAt98kKGZWVkszFiXkyPmzqJlGKiZq4tb+DnTnLv7LsHGdsdgA1UE1IKn68am/Y93FEkYAoAAABdeyJvcmlnaW4iOiJodHRwczovL25vb2dsZXMuZ2w6NDQzIiwiZmVhdHVyZSI6IldlYk1DUCIsImV4cGlyeSI6MTc5NDg3MzYwMCwiaXNTdWJkb21haW4iOnRydWV9" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
#### Background

Registers a Chrome Origin Trial token for the WebMCP feature on `*.noodles.gl`. This enables native WebMCP support in Chrome without requiring a relay or browser extension on the production site. The token is valid through 2026-11-16.

#### Change List
- Add `<meta http-equiv="origin-trial">` tag to `noodles-editor/index.html` with the WebMCP origin trial token scoped to `https://noodles.gl` (including subdomains)