### PR TITLE
Fix PostHog pageview capture for SPA route changes

### DIFF
--- a/noodles-editor/src/app.tsx
+++ b/noodles-editor/src/app.tsx
@@ -1,10 +1,11 @@
-import { Component, lazy, type ReactNode, Suspense, useEffect } from 'react'
-import { Redirect, Route, Router, Switch, useRoute, useSearchParams } from 'wouter'
+import { Component, lazy, type ReactNode, Suspense, useEffect, useRef } from 'react'
+import { Redirect, Route, Router, Switch, useLocation, useRoute, useSearchParams } from 'wouter'
 import { AnalyticsConsentBanner } from './components/analytics-consent-banner'
 import { type ModalView, QuickStartModal } from './components/quick-start-modal'
 import { externalControl } from './noodles/globals'
 import { useUIStore } from './noodles/store'
 import TimelineEditor from './timeline-editor'
+import { analytics } from './utils/analytics'
 import { debugApp } from './utils/debug'
 
 const ExternalControlProvider = lazy(() =>
@@ -37,6 +38,20 @@ class AnalyticsErrorBoundary extends Component<{ children: ReactNode }, { hasErr
   }
 }
 
+// Fires $pageview on each route change; skips first render since PostHog init captures that.
+function PageviewTracker() {
+  const [location] = useLocation()
+  const isFirstRender = useRef(true)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    analytics.capturePageview()
+  }, [location])
+  return null
+}
+
 const baseUrl = import.meta.env.BASE_URL.replace(/\/+$/, '')
 
 function App() {
@@ -48,6 +63,7 @@ function App() {
 
   return (
     <Router base={baseUrl}>
+      <PageviewTracker />
       {/* External control providers - only enabled when requested via URL params.
           WebMCPProvider registers tools on navigator.modelContext (primary path);
           ExternalControlProvider is the legacy WebSocket bridge. */}

--- a/noodles-editor/src/app.tsx
+++ b/noodles-editor/src/app.tsx
@@ -38,14 +38,20 @@ class AnalyticsErrorBoundary extends Component<{ children: ReactNode }, { hasErr
   }
 }
 
-// Fires $pageview on each route change; skips first render since PostHog init captures that.
+// Fires $pageview on each route change. Skips first render only when the user already had consent
+// at mount time — in that case PostHog's capture_pageview:true init already fired the event.
+// First-time visitors who consent on the landing page are covered by setConsent's capturePageview call.
 function PageviewTracker() {
   const [location] = useLocation()
+  // Snapshot at mount: was PostHog already tracking when this component rendered?
+  const hadConsentAtMount = useRef(analytics.isEnabled())
   const isFirstRender = useRef(true)
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false
-      return
+      if (hadConsentAtMount.current) {
+        return // PostHog init already captured this pageview
+      }
     }
     analytics.capturePageview()
   }, [location])

--- a/noodles-editor/src/utils/analytics.ts
+++ b/noodles-editor/src/utils/analytics.ts
@@ -41,7 +41,7 @@ export class AnalyticsManager {
         opt_out_capturing_by_default: !consent?.enabled,
         autocapture: false, // Privacy: manual events only
         disable_session_recording: true, // Privacy: no session recording
-        capture_pageview: false, // Manual tracking
+        capture_pageview: true, // Captures initial page load; route changes tracked manually
         capture_pageleave: true,
         capture_exceptions: true, // Capture unhandled exceptions
         loaded: posthog => {
@@ -155,6 +155,17 @@ export class AnalyticsManager {
       posthog.reset()
     } catch (error) {
       debugAnalytics('Analytics reset failed:', error)
+    }
+  }
+
+  capturePageview() {
+    if (!this.initialized || !this.getConsent()?.enabled) {
+      return
+    }
+    try {
+      posthog.capture('$pageview')
+    } catch (error) {
+      debugAnalytics('Analytics pageview capture failed:', error)
     }
   }
 

--- a/noodles-editor/src/utils/analytics.ts
+++ b/noodles-editor/src/utils/analytics.ts
@@ -82,6 +82,9 @@ export class AnalyticsManager {
       if (this.initialized) {
         if (enabled) {
           posthog.opt_in_capturing()
+          // Capture the landing page if the user consents without having navigated away —
+          // posthog.init fires capture_pageview only when already opted in at init time.
+          posthog.capture('$pageview')
         } else {
           posthog.opt_out_capturing()
         }


### PR DESCRIPTION
#### Background

PostHog's automatic `capture_pageview` only fires on hard page loads, so route changes within the wouter SPA were never tracked.

#### Change List
- Enable `capture_pageview: true` in PostHog init to capture the initial page load
- Add `capturePageview()` method to `AnalyticsManager` with the same consent/init guards as other tracking calls
- Add `PageviewTracker` component inside `<Router>` that fires `$pageview` on every wouter location change, skipping the first render to avoid double-counting the initial load