### PR TITLE
fix: surface layer loading errors and prevent infinite render wait

### DIFF
--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -1685,10 +1685,16 @@ export function getNoodles(): Visualization {
   }, [nodes])
 
   useEffect(() => {
-    // Subscribe to DeckRendererOp output instead of OutOp input
-    // This creates an active subscription chain that keeps upstream operators executing
-    if (deckRendererOp) {
-      const visSub = deckRendererOp.outputs.vis.subscribe(
+    // Subscribe to DeckRendererOp output if available, otherwise fall back to OutOp input
+    // DeckRendererOp creates active subscription chain, but may not be available during initial render
+    const field = deckRendererOp?.outputs.vis || outOp?.inputs.vis
+
+    if (field) {
+      debugVis(
+        'Creating vis subscription from %s',
+        deckRendererOp ? 'DeckRendererOp.outputs.vis' : 'OutOp.inputs.vis'
+      )
+      const visSub = field.subscribe(
         ({ deckProps: { layers, widgets, ...deckProps }, mapProps }) => {
           // Map layers from POJOs to deck.gl instances
           const instantiatedLayers =
@@ -1726,7 +1732,10 @@ export function getNoodles(): Visualization {
                 ...layer,
                 ...(instantiatedExtensions ? { extensions: instantiatedExtensions } : {}),
                 // Prevent deck.gl layer errors from crashing the GPU process
-                onError: (e: Error) => debugVis('Layer error in %s: %o', type, e),
+                onError: (e: Error) => {
+                  console.error(`[Noodles] Layer error in ${layer.id} (${type}):`, e)
+                  debugVis('Layer error in %s (id=%s): %o', type, layer.id, e)
+                },
               })
             }) || []
 
@@ -1772,10 +1781,11 @@ export function getNoodles(): Visualization {
         }
       )
       return () => {
+        debugVis('Cleaning up vis subscription')
         visSub.unsubscribe()
       }
     }
-  }, [deckRendererOp, selectedGeoJsonFeatures])
+  }, [deckRendererOp, outOp, selectedGeoJsonFeatures])
 
   const propertiesPanel = (
     <ErrorBoundary title="Property Panel Error">

--- a/noodles-editor/src/render/draw-loop.ts
+++ b/noodles-editor/src/render/draw-loop.ts
@@ -18,8 +18,37 @@ interface UseDeckDrawLoopProps {
   props?: Partial<DeckProps>
 }
 
-const isDeckReady = (deck: Deck | null) =>
-  !deck || deck.props.layers.every(layer => !layer || (!Array.isArray(layer) && layer.isLoaded))
+const isDeckReady = (deck: Deck | null) => {
+  if (!deck) return true
+
+  const unloadedLayers = deck.props.layers.filter(
+    layer => layer && !Array.isArray(layer) && !layer.isLoaded
+  )
+
+  if (unloadedLayers.length > 0) {
+    // Check for layers in error state
+    const errorLayers = unloadedLayers.filter(layer => {
+      // Deck.gl layers have an internalState that tracks loading errors
+      // biome-ignore lint/suspicious/noExplicitAny: accessing deck.gl internal state
+      const state = (layer as any).internalState
+      return state?.loadOptions?.error || state?.asyncPropLoadError
+    })
+
+    if (errorLayers.length > 0) {
+      const errorDetails = errorLayers
+        .map(layer => {
+          // biome-ignore lint/suspicious/noExplicitAny: accessing deck.gl internal state
+          const state = (layer as any).internalState
+          const error = state?.loadOptions?.error || state?.asyncPropLoadError
+          return `${layer.id}: ${error?.message || error}`
+        })
+        .join('; ')
+      debugRender('deck has layers in error state (will never load): %s', errorDetails)
+    }
+  }
+
+  return deck.props.layers.every(layer => !layer || (!Array.isArray(layer) && layer.isLoaded))
+}
 
 export function useDeckDrawLoop({
   deck,
@@ -38,9 +67,24 @@ export function useDeckDrawLoop({
     async function drawPass() {
       try {
         let resolvePass: (value?: unknown) => void
-        const passPromise = new Promise(res => {
+        // biome-ignore lint/suspicious/noExplicitAny: Promise.reject accepts any error type
+        let rejectPass: (reason?: any) => void
+        const passPromise = new Promise((res, rej) => {
           resolvePass = res
+          rejectPass = rej
         })
+
+        // Timeout after 30 seconds to prevent infinite waiting
+        const cancelTimeout = workerSetTimeout(() => {
+          if (waitForData && !isDeckReady(deck)) {
+            const unloadedLayers =
+              deck?.props.layers.filter(
+                layer => layer && !Array.isArray(layer) && !layer.isLoaded
+              ) || []
+            const layerInfo = unloadedLayers.map(l => `${l.id} (${l.constructor.name})`).join(', ')
+            rejectPass(new Error(`Render timeout: layers did not load after 30s: ${layerInfo}`))
+          }
+        }, 30000)
 
         deck?.setProps({
           ...props,
@@ -51,7 +95,10 @@ export function useDeckDrawLoop({
               return // layers aren't loaded
             }
             // Use worker timer so the delay fires even when the tab is hidden.
-            workerSetTimeout(() => resolvePass(), captureDelay)
+            workerSetTimeout(() => {
+              cancelTimeout()
+              resolvePass()
+            }, captureDelay)
           },
         })
         // Pump Deck.gl's render directly via worker timer so onAfterRender fires even when
@@ -61,6 +108,7 @@ export function useDeckDrawLoop({
         try {
           await passPromise
         } finally {
+          cancelTimeout()
           cancelRedrawLoop()
         }
         captureFrame?.()


### PR DESCRIPTION
#### Background

After landing PR #447, rendering could get stuck indefinitely when layers failed to load (e.g., ScenegraphLayer with missing model URL). The only indication was "deck waiting for layers to load" spammed in the console, with no information about WHY layers weren't loading. This was especially problematic during export/capture operations.

#### Change List
- Enhanced `isDeckReady()` in draw-loop.ts to detect and log layers in error state with detailed error messages
- Added 30-second timeout in draw loop to prevent infinite waiting, with error listing unloaded layers
- Improved layer error logging in noodles.tsx: now logs to console (not just debug channel) with layer ID and type
- Fixed subscription race condition: added fallback to subscribe to OutOp when DeckRendererOp not yet available during initial render
- Added debug logging to track subscription source (DeckRendererOp.outputs.vis vs OutOp.inputs.vis)

Now when a layer fails to load, developers see:
1. Console error: `[Noodles] Layer error in <id> (<type>): <message>`
2. Debug log (when enabled): `deck has layers in error state (will never load): <details>`
3. Timeout after 30s: `Render timeout: layers did not load after 30s: <list>`

This makes debugging layer loading issues much faster and prevents exports from hanging indefinitely.