### PR TITLE
fix: execute connected geocoder queries

### DIFF
--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -1667,7 +1667,7 @@ function GeocoderOpComponent({
               field={field}
               disabled={locked}
               handle={PAR_HANDLE_OPTIONS}
-              renderInput={false}
+              renderInput={queryConnected}
             />
           ))}
         <div

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -66,6 +66,7 @@ import {
   hasOp,
   setHoveredOutputHandle,
   updateOperatorId,
+  useEdgeConnectionStore,
   useNestingStore,
   useOperatorStore,
   useUIStore,
@@ -1555,6 +1556,9 @@ function GeocoderOpComponent({
   const connectionErrors = useConnectionErrors(op)
   const hasConnectionErrors = connectionErrors.size > 0
   const isDimmed = useNodeDimmed(id)
+  const queryConnected = useEdgeConnectionStore(state =>
+    state.connectionMap.has(`${id}::par.query`)
+  )
 
   // Get API key directly from store (reactive)
   const apiKey = useKeysStore(state => state.getKey('mapbox'))
@@ -1562,6 +1566,12 @@ function GeocoderOpComponent({
   useLayoutEffect(() => {
     if (!op) return
     op.removeConnectionError('geocoder-setup')
+
+    // Connected queries execute headlessly; match other connected inputs by
+    // hiding the editor instead of mounting a second, interactive query UI.
+    if (queryConnected) {
+      return
+    }
 
     if (!containerRef.current) {
       return
@@ -1624,7 +1634,7 @@ function GeocoderOpComponent({
       g.onRemove()
       geocoderRef.current = undefined
     }
-  }, [op, apiKey])
+  }, [op, apiKey, queryConnected])
 
   const locked = useLocked(op)
   useFieldVisibility(op)
@@ -1663,7 +1673,7 @@ function GeocoderOpComponent({
         <div
           ref={containerRef}
           className={s.fieldWrapper}
-          style={{ display: hasError ? 'none' : 'block' }}
+          style={{ display: hasError || queryConnected ? 'none' : 'block' }}
         />
         <div className={s.outputHandleContainer}>
           {Object.entries(op.outputs).map(([key, field]) => (

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -1,7 +1,8 @@
 import * as turf from '@turf/turf'
 import { Temporal } from 'temporal-polyfill'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { NumberField } from './fields'
+import { NumberField, StringField } from './fields'
+import { getKeysStore } from './keys-store'
 import {
   AccessorOp,
   BitmapOverlayWidgetOp,
@@ -17,6 +18,7 @@ import {
   ExpressionOp,
   FileOp,
   FilterOp,
+  GeocoderOp,
   GeoJsonLayerOp,
   GeoJsonTransformOp,
   JSONOp,
@@ -3837,6 +3839,61 @@ describe('DirectionsOp', () => {
     // Verify DirectionsOp correctly parses the GeoJSON Features
     expect(directionsOp.inputs.origin.value).toEqual({ lng: -74.006, lat: 40.7128 })
     expect(directionsOp.inputs.destination.value).toEqual({ lng: -73.935242, lat: 40.73061 })
+  })
+})
+
+describe('GeocoderOp', () => {
+  afterEach(() => {
+    getKeysStore().clearBrowserKey('mapbox')
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('geocodes its query when executed', async () => {
+    getKeysStore().setBrowserKey('mapbox', 'test-token')
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        features: [
+          {
+            place_name: 'Los Angeles, California, United States',
+            center: [-118.2437, 34.0522],
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const geocoderOp = new GeocoderOp('/geocoder')
+    geocoderOp.inputs.query.addConnection('query-connection', new StringField('Los Angeles'))
+    const result = await geocoderOp.execute({ query: 'Los Angeles' })
+
+    expect(result).toEqual({ location: { lng: -118.2437, lat: 34.0522 } })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.mapbox.com/geocoding/v5/mapbox.places/Los%20Angeles.json?access_token=test-token&limit=5'
+    )
+  })
+
+  it('preserves the user-selected result when its query is not connected', async () => {
+    getKeysStore().setBrowserKey('mapbox', 'test-token')
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const geocoderOp = new GeocoderOp('/geocoder')
+    geocoderOp.outputs.location.next({ lng: -118.2437, lat: 34.0522 })
+
+    await expect(geocoderOp.execute({ query: 'Los Angeles' })).resolves.toEqual({
+      location: { lng: -118.2437, lat: 34.0522 },
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('requires a Mapbox API key', async () => {
+    vi.spyOn(getKeysStore(), 'getKey').mockReturnValue(undefined)
+    const geocoderOp = new GeocoderOp('/geocoder')
+
+    await expect(geocoderOp.execute({ query: 'Los Angeles' })).rejects.toThrow(
+      'Mapbox API key required (Settings > API Keys)'
+    )
   })
 })
 

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -3852,6 +3852,7 @@ describe('GeocoderOp', () => {
   it('geocodes its query when executed', async () => {
     getKeysStore().setBrowserKey('mapbox', 'test-token')
     const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
       json: vi.fn().mockResolvedValue({
         features: [
           {
@@ -3867,7 +3868,15 @@ describe('GeocoderOp', () => {
     geocoderOp.inputs.query.addConnection('query-connection', new StringField('Los Angeles'))
     const result = await geocoderOp.execute({ query: 'Los Angeles' })
 
-    expect(result).toEqual({ location: { lng: -118.2437, lat: 34.0522 } })
+    expect(result).toEqual({
+      location: { lng: -118.2437, lat: 34.0522 },
+      results: [
+        {
+          place_name: 'Los Angeles, California, United States',
+          coordinates: { longitude: -118.2437, latitude: 34.0522 },
+        },
+      ],
+    })
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.mapbox.com/geocoding/v5/mapbox.places/Los%20Angeles.json?access_token=test-token&limit=5'
     )
@@ -3883,6 +3892,7 @@ describe('GeocoderOp', () => {
 
     await expect(geocoderOp.execute({ query: 'Los Angeles' })).resolves.toEqual({
       location: { lng: -118.2437, lat: 34.0522 },
+      results: [],
     })
     expect(fetchMock).not.toHaveBeenCalled()
   })
@@ -3893,6 +3903,67 @@ describe('GeocoderOp', () => {
 
     await expect(geocoderOp.execute({ query: 'Los Angeles' })).rejects.toThrow(
       'Mapbox API key required (Settings > API Keys)'
+    )
+  })
+
+  it('clears stale outputs when a connected query becomes blank', async () => {
+    vi.spyOn(getKeysStore(), 'getKey').mockReturnValue('test-token')
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        features: [{ place_name: 'Long Beach', center: [-118.1937, 33.7701] }],
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const geocoderOp = new GeocoderOp('/geocoder')
+    geocoderOp.inputs.query.addConnection('query-connection', new StringField('Long Beach'))
+    const firstResult = await geocoderOp.execute({ query: 'Long Beach' })
+    geocoderOp.outputs.location.next(firstResult.location)
+    geocoderOp.outputs.results.next(firstResult.results)
+
+    await expect(geocoderOp.execute({ query: '   ' })).resolves.toEqual({
+      location: { lng: 0, lat: 0 },
+      results: [],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns empty outputs without error when Mapbox has no results', async () => {
+    vi.spyOn(getKeysStore(), 'getKey').mockReturnValue('test-token')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ features: [] }),
+      })
+    )
+
+    const geocoderOp = new GeocoderOp('/geocoder')
+    geocoderOp.inputs.query.addConnection('query-connection', new StringField('Unknown place'))
+
+    await expect(geocoderOp.execute({ query: 'Unknown place' })).resolves.toEqual({
+      location: { lng: 0, lat: 0 },
+      results: [],
+    })
+  })
+
+  it('surfaces Mapbox service failures separately from empty results', async () => {
+    vi.spyOn(getKeysStore(), 'getKey').mockReturnValue('test-token')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+      })
+    )
+
+    const geocoderOp = new GeocoderOp('/geocoder')
+    geocoderOp.inputs.query.addConnection('query-connection', new StringField('Long Beach'))
+
+    await expect(geocoderOp.execute({ query: 'Long Beach' })).rejects.toThrow(
+      'Mapbox geocoding failed: 429 Too Many Requests'
     )
   })
 })

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -2566,6 +2566,7 @@ export class GeocoderOp extends Operator<GeocoderOp> {
   createOutputs() {
     return {
       location: new Point2DField(),
+      results: new DataField(),
     }
   }
   async execute({
@@ -2584,20 +2585,19 @@ export class GeocoderOp extends Operator<GeocoderOp> {
       return this.outputData
     }
 
-    if (!query.trim()) {
-      return this.outputData
-    }
+    const emptyResult = { location: { lng: 0, lat: 0 }, results: [] }
+    if (!query.trim()) return emptyResult
 
-    const [result] = await geocodeWithMapbox(query, apiKey)
-    if (!result) {
-      throw new Error(`No geocoding results for "${query}"`)
-    }
+    const results = await geocodeWithMapbox(query, apiKey)
+    const [result] = results
+    if (!result) return emptyResult
 
     return {
       location: {
         lng: result.coordinates.longitude,
         lat: result.coordinates.latitude,
       },
+      results,
     }
   }
 }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -136,6 +136,7 @@ import { getArc } from '../utils/arc-geometry'
 import { colorToHex, hexToColor } from '../utils/color'
 import { debugDirty, debugExecute, debugParams, debugPull } from '../utils/debug'
 import { getDirections } from '../utils/directions'
+import { geocodeWithMapbox } from '../utils/geocoding'
 import {
   applyStyleOverrides,
   type MaplibreStyle,
@@ -2567,14 +2568,37 @@ export class GeocoderOp extends Operator<GeocoderOp> {
       location: new Point2DField(),
     }
   }
-  async execute(_: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+  async execute({
+    query,
+  }: ExtractProps<typeof this.inputs>): Promise<ExtractProps<typeof this.outputs>> {
     const { getKey } = getKeysStore()
-    if (!getKey('mapbox')) {
+    const apiKey = getKey('mapbox')
+    if (!apiKey) {
       throw new Error('Mapbox API key required (Settings > API Keys)')
     }
-    // Push-based: the UI component drives op.outputs.location.next() directly.
-    // Return current output so downstream pull-chain succeeds.
-    return this.outputData
+
+    // An unconnected query is driven by GeocoderOpComponent so the user can
+    // inspect Mapbox's suggestions and choose a result. Only connected queries
+    // should geocode automatically during graph execution.
+    if (this.inputs.query.subscriptions.size === 0) {
+      return this.outputData
+    }
+
+    if (!query.trim()) {
+      return this.outputData
+    }
+
+    const [result] = await geocodeWithMapbox(query, apiKey)
+    if (!result) {
+      throw new Error(`No geocoding results for "${query}"`)
+    }
+
+    return {
+      location: {
+        lng: result.coordinates.longitude,
+        lat: result.coordinates.latitude,
+      },
+    }
   }
 }
 

--- a/noodles-editor/src/utils/geocoding.ts
+++ b/noodles-editor/src/utils/geocoding.ts
@@ -162,25 +162,20 @@ export async function geocodeWithGooglePlaces(query: string): Promise<GeocodingR
 
 // Geocode using Mapbox Geocoding API
 export async function geocodeWithMapbox(query: string, apiKey: string): Promise<GeocodingResult[]> {
-  try {
-    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(query)}.json?access_token=${apiKey}&limit=5`
-    const response = await fetch(url)
-    const data: MapboxGeocodingResponse = await response.json()
-
-    if (data.features) {
-      return data.features.map(feature => ({
-        place_name: feature.place_name,
-        coordinates: {
-          longitude: feature.center[0],
-          latitude: feature.center[1],
-        },
-      }))
-    }
-    return []
-  } catch (error) {
-    debugGeocode('Mapbox geocoding error:', error)
-    return []
+  const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(query)}.json?access_token=${apiKey}&limit=5`
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Mapbox geocoding failed: ${response.status} ${response.statusText}`)
   }
+
+  const data: MapboxGeocodingResponse = await response.json()
+  return (data.features ?? []).map(feature => ({
+    place_name: feature.place_name,
+    coordinates: {
+      longitude: feature.center[0],
+      latitude: feature.center[1],
+    },
+  }))
 }
 
 // Geocode using Photon API (free, OSM-based)


### PR DESCRIPTION
#### Background

`GeocoderOp.execute()` previously returned the last UI-selected output without performing a geocoding request. This meant graph-connected queries, including queries driven by a ForLoop, could not resolve headlessly.

#### Change List

<img width="1380" height="260" alt="Screenshot 2026-07-31 at 12 53 56 PM" src="https://github.com/user-attachments/assets/572ef179-95f3-444f-8efc-ec8b34f86bc9" />

<img width="827" height="538" alt="image" src="https://github.com/user-attachments/assets/e59db94a-3365-45fa-999b-d8bfe713ac54" />

- Execute Mapbox forward geocoding when the `query` input has a graph connection.
- Preserve the interactive Mapbox typeahead and explicit result selection when `query` is unconnected.
- Do not mount the interactive typeahead for connected queries.
- Render connected queries with the standard compact input row and handle layout.
- Add coverage for connected execution, interactive-result preservation, and missing API keys.

## Testing

### Unit Tests

- `npm test -- --run src/noodles/operators.test.ts -t GeocoderOp` (3 passed)
- `npm run build`

### Manual Testing

1. Add an unconnected Geocoder node with a Mapbox key configured.
2. Search for a place and choose one of the typeahead results.
3. Expected: the interactive selector remains visible and the chosen coordinates appear on `location`.
4. Connect a String output to `Geocoder.query`.
5. Expected: the typeahead is replaced by the normal compact connected-input row, and `location` updates from the first Mapbox result.
6. Disconnect `query`.
7. Expected: the interactive typeahead returns.

## Documentation

No documentation changes needed; behavior is documented in code and covered by operator tests.
