### PR TITLE
fix: use dropdown for TableEditor string literals

### DIFF
--- a/noodles-editor/src/noodles/components/table-editor-edit-flow.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor-edit-flow.test.tsx
@@ -99,6 +99,43 @@ describe('TableEditor - Edit Flow', () => {
         'Edit cell count'
       )
     })
+
+    it('should render string literals as a dropdown and commit the selection immediately', () => {
+      const onDataChange = vi.fn()
+      const literalSchema: TableSchema = {
+        columns: [
+          {
+            name: 'anchor',
+            type: 'stringLiteral',
+            defaultValue: 'start',
+            options: { values: ['start', 'middle', 'end'] },
+          },
+        ],
+      }
+
+      const { getByText, getByRole } = render(
+        <TableEditor
+          op={mockOp}
+          data={[{ anchor: 'start' }]}
+          schema={literalSchema}
+          onDataChange={onDataChange}
+          onSchemaChange={vi.fn()}
+        />
+      )
+
+      fireEvent.click(getByText('start'))
+
+      const dropdown = getByRole('combobox') as HTMLSelectElement
+      expect(Array.from(dropdown.options, option => option.value)).toEqual([
+        'start',
+        'middle',
+        'end',
+      ])
+
+      fireEvent.change(dropdown, { target: { value: 'end' } })
+
+      expect(onDataChange).toHaveBeenCalledWith([{ anchor: 'end' }], 'Edit cell anchor')
+    })
   })
 
   describe('Multiple edit cycles', () => {

--- a/noodles-editor/src/noodles/components/table-editor-edit-flow.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor-edit-flow.test.tsx
@@ -136,6 +136,32 @@ describe('TableEditor - Edit Flow', () => {
 
       expect(onDataChange).toHaveBeenCalledWith([{ anchor: 'end' }], 'Edit cell anchor')
     })
+
+    it('should allow free text editing when a string literal has no configured choices', () => {
+      const onDataChange = vi.fn()
+      const literalSchema: TableSchema = {
+        columns: [{ name: 'anchor', type: 'stringLiteral', defaultValue: '' }],
+      }
+
+      const { getByText, getByRole, queryByRole } = render(
+        <TableEditor
+          op={mockOp}
+          data={[{ anchor: 'custom' }]}
+          schema={literalSchema}
+          onDataChange={onDataChange}
+          onSchemaChange={vi.fn()}
+        />
+      )
+
+      fireEvent.click(getByText('custom'))
+
+      expect(queryByRole('combobox')).toBeNull()
+      const input = getByRole('textbox') as HTMLInputElement
+      fireEvent.change(input, { target: { value: 'updated' } })
+      fireEvent.blur(input)
+
+      expect(onDataChange).toHaveBeenCalledWith([{ anchor: 'updated' }], 'Edit cell anchor')
+    })
   })
 
   describe('Multiple edit cycles', () => {

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -194,6 +194,12 @@ function StringLiteralCellEditor({ value, onChange, onComplete, column }: CellEd
     selectRef.current?.focus()
   }, [])
 
+  if (configuredValues.length === 0) {
+    return (
+      <StringCellEditor value={value} onChange={onChange} onComplete={onComplete} column={column} />
+    )
+  }
+
   return (
     <select
       ref={selectRef}

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -182,6 +182,45 @@ function StringCellEditor({ value, onChange, onComplete }: CellEditorProps) {
   )
 }
 
+function StringLiteralCellEditor({ value, onChange, onComplete, column }: CellEditorProps) {
+  const selectRef = useRef<HTMLSelectElement>(null)
+  const currentValue = String(value ?? '')
+  const configuredValues = column.options?.values ?? []
+  const values = configuredValues.includes(currentValue)
+    ? configuredValues
+    : [currentValue, ...configuredValues]
+
+  useEffect(() => {
+    selectRef.current?.focus()
+  }, [])
+
+  return (
+    <select
+      ref={selectRef}
+      value={currentValue}
+      onChange={e => {
+        onChange(e.currentTarget.value)
+        onComplete()
+      }}
+      onBlur={onComplete}
+      onKeyDown={e => {
+        e.stopPropagation()
+        if (e.key === 'Enter' || e.key === 'Escape') {
+          onComplete()
+        }
+      }}
+      aria-label={`Edit ${column.name}`}
+      className={cx('p-inputtext', s.cellEditor)}
+    >
+      {values.map(option => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  )
+}
+
 function BooleanCellEditor({ value, onChange, onComplete }: CellEditorProps) {
   return (
     <InputSwitch
@@ -518,8 +557,9 @@ function getCellEditor(type: ColumnType) {
     case 'number':
       return NumberCellEditor
     case 'string':
-    case 'stringLiteral':
       return StringCellEditor
+    case 'stringLiteral':
+      return StringLiteralCellEditor
     case 'boolean':
       return BooleanCellEditor
     case 'color':


### PR DESCRIPTION
#### Background

TableEditor string-literal cells were routed through the plain text editor. This allowed values outside the configured choices and could fail to commit the latest value.

#### Change List

- Render string-literal cells as a native dropdown populated from the column schema values
- Commit a selection immediately using the latest-value ref added by #502
- Preserve and display an existing value if it is not present in the configured choices
- Add a regression test covering dropdown options and first-interaction serialization

#### Validation

- TableEditor component suites: 22 tests passed
- Biome lint passed
- Biome format check passed
- Production build passed