### PR TITLE
Add deck.gl scale widget operator

### DIFF
--- a/noodles-editor/src/noodles/components/categories.ts
+++ b/noodles-editor/src/noodles/components/categories.ts
@@ -111,6 +111,7 @@ export const categories = {
     'FpsWidget',
     'FullscreenWidget',
     'LegendWidget',
+    'ScaleWidget',
     'ScreenshotWidget',
     'ZoomWidget',
   ],

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -34,6 +34,7 @@ import {
   RampOp,
   RectangleOp,
   RerouteOp,
+  ScaleWidgetOp,
   ScatterplotLayerOp,
   SelectOp,
   SmoothOp,
@@ -3430,6 +3431,42 @@ describe('BitmapOverlayWidgetOp', () => {
     expect(op.outputData.widget.placement).toBe('fill')
     expect(op.outputData.widget.offsetX).toBe(100)
     expect(op.outputData.widget.offsetY).toBe(50)
+  })
+})
+
+describe('ScaleWidgetOp', () => {
+  it('creates a scale widget with deck.gl defaults', async () => {
+    const op = new ScaleWidgetOp('/scale-widget-0')
+    await op.pull()
+
+    expect(op.outputData.widget).toEqual({
+      id: '/scale-widget-0',
+      type: '_ScaleWidget',
+      placement: 'bottom-left',
+      label: 'Scale',
+    })
+  })
+
+  it('accepts custom scale widget properties', async () => {
+    const op = new ScaleWidgetOp('/scale-widget-0')
+    op.inputs.placement.setValue('top-right')
+    op.inputs.label.setValue('Distance')
+    op.inputs.viewId.setValue('map-view')
+    await op.pull()
+
+    expect(op.outputData.widget).toMatchObject({
+      placement: 'top-right',
+      label: 'Distance',
+      viewId: 'map-view',
+    })
+  })
+
+  it('excludes an empty viewId', async () => {
+    const op = new ScaleWidgetOp('/scale-widget-0')
+    op.inputs.viewId.setValue('')
+    await op.pull()
+
+    expect(op.outputData.widget.viewId).toBeUndefined()
   })
 })
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4407,6 +4407,42 @@ export class CompassWidgetOp extends Operator<CompassWidgetOp> {
   }
 }
 
+export class ScaleWidgetOp extends Operator<ScaleWidgetOp> {
+  static displayName = 'ScaleWidget'
+  static description = 'Display a map distance scale widget'
+
+  createInputs() {
+    return {
+      placement: new StringLiteralField('bottom-left', {
+        values: ['top-left', 'top-right', 'bottom-left', 'bottom-right'],
+      }),
+      label: new StringField('Scale'),
+      viewId: new StringField('', { optional: true }),
+    }
+  }
+
+  createOutputs() {
+    return {
+      widget: new WidgetField(),
+    }
+  }
+
+  execute({
+    placement,
+    label,
+    viewId,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    const widget = {
+      id: this.id,
+      type: '_ScaleWidget',
+      placement,
+      label,
+      ...(viewId && viewId !== '' ? { viewId } : {}),
+    }
+    return { widget }
+  }
+}
+
 export class ScreenshotWidgetOp extends Operator<ScreenshotWidgetOp> {
   static displayName = 'ScreenshotWidget'
   static description = 'Download current frame as PNG widget'
@@ -8275,6 +8311,7 @@ export const opTypes = {
   RectangleOp,
   RerouteOp,
   S2LayerOp,
+  ScaleWidgetOp,
   ScatterOp,
   ScatterplotLayerOp,
   ScenegraphLayerOp,


### PR DESCRIPTION
## Summary

Adds the missing deck.gl ScaleWidget as a Noodles operator.

## Changes

- Add `ScaleWidgetOp` with deck.gl's supported `placement`, `label`, and optional `viewId` properties
- Register ScaleWidget in the operator registry and widget block-library category
- Add regression coverage for defaults, custom properties, and empty view targeting

## Testing

### Unit Tests

- `npm test -- src/noodles/operators.test.ts --run -t ScaleWidgetOp` (3 passed)
- `npx biome check src/noodles/operators.ts src/noodles/operators.test.ts src/noodles/components/categories.ts`
- `npm run build`

The complete operators test file also ran 240 tests successfully. Its three unrelated Tile3DLayer tests require Google/Cesium API keys that are not present in the clean workspace.

### Manual Testing

Save the following as a project `noodles.json` and open it in Noodles:

```json
{
  "nodes": [
    {
      "id": "/deck",
      "type": "DeckRendererOp",
      "data": { "inputs": {}, "locked": false },
      "position": { "x": 0, "y": 0 }
    },
    {
      "id": "/scale-widget",
      "type": "ScaleWidgetOp",
      "data": { "inputs": {}, "locked": false },
      "position": { "x": -350, "y": -100 }
    },
    {
      "id": "/maplibre-basemap",
      "type": "MaplibreBasemapOp",
      "data": { "inputs": {}, "locked": false },
      "position": { "x": -350, "y": 180 }
    },
    {
      "id": "/out",
      "type": "OutOp",
      "data": { "inputs": {}, "locked": false },
      "position": { "x": 390, "y": 0 }
    }
  ],
  "edges": [
    {
      "id": "/scale-widget.out.widget->/deck.par.widgets",
      "source": "/scale-widget",
      "target": "/deck",
      "sourceHandle": "out.widget",
      "targetHandle": "par.widgets"
    },
    {
      "id": "/maplibre-basemap.out.maplibre->/deck.par.basemap",
      "source": "/maplibre-basemap",
      "target": "/deck",
      "sourceHandle": "out.maplibre",
      "targetHandle": "par.basemap"
    },
    {
      "id": "/deck.out.vis->/out.par.vis",
      "source": "/deck",
      "target": "/out",
      "sourceHandle": "out.vis",
      "targetHandle": "par.vis"
    }
  ],
  "viewport": { "x": 400, "y": 250, "zoom": 0.8 },
  "version": 7
}
```

Expected results:

1. A distance scale appears at the lower-left of the map.
2. Changing placement moves the scale to the selected corner.
3. When multiple views are used, setting `viewId` attaches the scale to that view.

## Documentation

No separate documentation changes needed; the operator description and typed fields are exposed by the block library.
