### PR TITLE
Fix IconLayer JSON icon mapping inputs

### DIFF
--- a/noodles-editor/src/noodles/icon-layer-upload.test.ts
+++ b/noodles-editor/src/noodles/icon-layer-upload.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { FileUrlField } from './fields'
-import { IconLayerOp } from './operators'
+import { FileUrlField, MapStyleField } from './fields'
+import { useFileSystemStore } from './filesystem-store'
+import { FileOp, IconLayerOp } from './operators'
+import { canConnect } from './utils/can-connect'
+import { memoryProjectStore } from './utils/memory-project-store'
 
 describe('IconLayerOp Upload Support', () => {
   describe('Field Configuration', () => {
@@ -23,6 +26,29 @@ describe('IconLayerOp Upload Support', () => {
       expect(op.inputs.iconAtlas.value).toBe(
         'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.png'
       )
+    })
+
+    it('iconMapping should accept JSON URLs and parsed objects', () => {
+      const op = new IconLayerOp('/test-icon-layer')
+      const mapping = { marker: { x: 0, y: 0, width: 32, height: 32 } }
+
+      expect(op.inputs.iconMapping).toBeInstanceOf(MapStyleField)
+      expect(op.inputs.iconMapping.accept).toBe('.json')
+
+      op.inputs.iconMapping.setValue(mapping)
+      expect(op.inputs.iconMapping.value).toEqual(mapping)
+    })
+
+    it('iconMapping should accept parsed JSON from a File operator connection', () => {
+      const fileOp = new FileOp('/mapping-file')
+      const iconOp = new IconLayerOp('/test-icon-layer')
+      const mapping = { marker: { x: 0, y: 0, width: 32, height: 32 } }
+
+      fileOp.outputs.data.setValue(mapping)
+      expect(canConnect(fileOp.outputs.data, iconOp.inputs.iconMapping)).toBe(true)
+
+      iconOp.inputs.iconMapping.addConnection('mapping-edge', fileOp.outputs.data, 'value')
+      expect(iconOp.inputs.iconMapping.value).toEqual(mapping)
     })
 
     it('getIcon should be a FileUrlField', () => {
@@ -132,6 +158,74 @@ describe('IconLayerOp Upload Support', () => {
       })
 
       expect(result.layer.iconAtlas).toBe('https://example.com/icons.png')
+    })
+
+    it('should pass through external icon mapping URLs', async () => {
+      const op = new IconLayerOp('/test-icon-layer')
+
+      const result = await op.execute({
+        data: [],
+        visible: true,
+        opacity: 1,
+        getPosition: [0, 0],
+        iconAtlas: 'https://example.com/icons.png',
+        iconMapping: 'https://example.com/icons.json',
+        billboard: true,
+        getIcon: '',
+        getSize: 1,
+        sizeUnits: 'pixels',
+        sizeScale: 1,
+        sizeMinPixels: 0,
+        sizeMaxPixels: 256,
+        getPixelOffset: [0, 0],
+        getColor: [255, 255, 255, 255],
+        getAngle: 0,
+        sizeBasis: 'pixels',
+        parameters: { depthTest: true },
+        extensions: [],
+      })
+
+      expect(result.layer.iconMapping).toBe('https://example.com/icons.json')
+    })
+
+    it('should parse a project-relative icon mapping file', async () => {
+      const op = new IconLayerOp('/test-icon-layer')
+      const mapping = { marker: { x: 0, y: 0, width: 32, height: 32 } }
+      const previousState = useFileSystemStore.getState()
+      useFileSystemStore.setState({
+        currentProjectName: 'test-project',
+        activeStorageType: 'memory',
+      })
+      memoryProjectStore.writeAsset('test-project', 'icons.json', JSON.stringify(mapping))
+
+      try {
+        const result = await op.execute({
+          data: [],
+          visible: true,
+          opacity: 1,
+          getPosition: [0, 0],
+          iconAtlas: 'https://example.com/icons.png',
+          iconMapping: '@/icons.json',
+          billboard: true,
+          getIcon: '',
+          getSize: 1,
+          sizeUnits: 'pixels',
+          sizeScale: 1,
+          sizeMinPixels: 0,
+          sizeMaxPixels: 256,
+          getPixelOffset: [0, 0],
+          getColor: [255, 255, 255, 255],
+          getAngle: 0,
+          sizeBasis: 'pixels',
+          parameters: { depthTest: true },
+          extensions: [],
+        })
+
+        expect(result.layer.iconMapping).toEqual(mapping)
+      } finally {
+        memoryProjectStore.deleteProject('test-project')
+        useFileSystemStore.setState(previousState)
+      }
     })
 
     it('should reject project-relative iconAtlas URL when no project loaded', async () => {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -5220,7 +5220,8 @@ export class IconLayerOp extends Operator<IconLayerOp> {
         'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.png',
         { showByDefault: false, accept: '.png,.jpg,.jpeg,.gif,.webp,.svg' }
       ),
-      iconMapping: new FileUrlField(
+      // MapStyleField accepts either a URL string or a parsed JSON object and retains file upload UI.
+      iconMapping: new MapStyleField(
         'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.json',
         { showByDefault: false, accept: '.json' }
       ),
@@ -5302,6 +5303,39 @@ export class IconLayerOp extends Operator<IconLayerOp> {
 
       const blob = new Blob([result.data], { type: mimeType })
       return URL.createObjectURL(blob)
+    }
+
+    const resolveIconMapping = async (
+      mapping: string | Record<string, unknown>
+    ): Promise<string | Record<string, unknown>> => {
+      if (typeof mapping !== 'string' || !mapping.startsWith(projectScheme)) {
+        return mapping
+      }
+
+      const { readAsset } = await import('./storage')
+      const { useFileSystemStore } = await import('./filesystem-store')
+
+      const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
+      if (!currentProjectName) {
+        throw new Error('No project loaded. Please save or load a project first.')
+      }
+
+      const fileName = mapping.substring(projectScheme.length)
+      const result = await readAsset(activeStorageType, currentProjectName, fileName)
+      if (!result.success) {
+        throw new Error(result.error.message)
+      }
+
+      try {
+        const parsed = JSON.parse(result.data)
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('icon mapping must be a JSON object')
+        }
+        return parsed as Record<string, unknown>
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(`Unable to parse icon mapping "${mapping}": ${message}`)
+      }
     }
 
     // Helper to resolve image URL and extract dimensions
@@ -5386,9 +5420,13 @@ export class IconLayerOp extends Operator<IconLayerOp> {
 
       iconProps = { getIcon: cached.accessor }
     } else {
-      // Atlas mode - resolve atlas URL
+      // Atlas mode - resolve uploaded project assets and accept parsed JSON from connected inputs
       const resolvedIconAtlas = await resolveProjectUrl(iconAtlas)
-      iconProps = { iconMapping, iconAtlas: resolvedIconAtlas }
+      const resolvedIconMapping = await resolveIconMapping(iconMapping)
+      iconProps = {
+        iconMapping: resolvedIconMapping as IconLayerProps['iconMapping'],
+        iconAtlas: resolvedIconAtlas,
+      }
     }
 
     const props: IconLayerProps = {


### PR DESCRIPTION
## Summary

Fixes IconLayer icon mappings so parsed JSON objects and uploaded project JSON files work alongside normal mapping URLs.

## Changes

- Change `iconMapping` to the existing URL-or-object field type, allowing FileOp JSON output to connect without being rejected by string validation
- Read and parse project-relative `@/*.json` icon mapping assets before passing them to deck.gl
- Preserve regular HTTP, data, and blob URL support through deck.gl's async icon mapping loader
- Add regression tests for object connections, uploaded project assets, and external URLs

## Testing

### Unit Tests

- `npm test -- src/noodles/icon-layer-upload.test.ts --run` — 31 passed
- `npx biome format src/noodles/operators.ts src/noodles/icon-layer-upload.test.ts`
- `npx biome lint src/noodles/operators.ts src/noodles/icon-layer-upload.test.ts`
- `npm run build`

### Manual Testing

1. Add an IconLayer and leave it in atlas mode (`getIcon` empty).
2. Upload an atlas PNG through `iconAtlas` and its mapping JSON through `iconMapping`.
3. Expected: the mapping is parsed from the project asset and icons render without a `/projects/@...json` 404.
4. Alternatively, load the mapping with a File operator using JSON format and connect `File.data` to `IconLayer.iconMapping`.
5. Expected: the connection is accepted and the parsed mapping object reaches the layer.
6. Paste an HTTPS or data URL into `iconMapping`.
7. Expected: the URL remains available to deck.gl's async mapping loader.

## Documentation

No separate documentation changes needed; this restores deck.gl's documented URL-or-object behavior for the existing IconLayer input.
