### PR TITLE
fix: prevent npm from reformatting package-lock.json

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,7 +1,7 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [scripts]
-setup = "(cd noodles-editor && npm install)"
+setup = "npm install"
 
 [scripts.run.run]
 available_in = "local"

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-	"name": "noodles.gl",
-	"version": "1.0.0",
-	"private": true,
-	"workspaces": [
-		"website",
-		"noodles-editor"
-	],
-	"scripts": {
-		"postinstall": "node scripts/patch-vitest-browser-playwright.cjs",
-		"build:app": "(cd noodles-editor && npm run build)",
-		"build:app:cloudflare": "(cd noodles-editor && npm run generate:context && VITE_USE_CDN_DUCKDB=true npm run build)",
-		"build:website": "(cd website && npm run build)",
-		"build:all": "npm run build:app && npm run build:website && mkdir -p website/build/app && cp -r noodles-editor/dist/* website/build/app/",
-		"build:all:cloudflare": "npm run build:website && npm run build:app:cloudflare && mkdir -p website/build/app && cp -r noodles-editor/dist/* website/build/app/",
-		"start:website": "(cd website && npm start)",
-		"start:app": "(cd noodles-editor && npm start)",
-		"serve:website": "(cd website && npm run serve)",
-		"serve:app": "(cd noodles-editor && npm run serve)",
-		"validate:examples": "node scripts/validate-examples.js"
-	},
-	"devDependencies": {
-		"@testing-library/dom": "^10.4.1"
-	}
+  "name": "noodles.gl",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "website",
+    "noodles-editor"
+  ],
+  "scripts": {
+    "postinstall": "node scripts/patch-vitest-browser-playwright.cjs",
+    "build:app": "(cd noodles-editor && npm run build)",
+    "build:app:cloudflare": "(cd noodles-editor && npm run generate:context && VITE_USE_CDN_DUCKDB=true npm run build)",
+    "build:website": "(cd website && npm run build)",
+    "build:all": "npm run build:app && npm run build:website && mkdir -p website/build/app && cp -r noodles-editor/dist/* website/build/app/",
+    "build:all:cloudflare": "npm run build:website && npm run build:app:cloudflare && mkdir -p website/build/app && cp -r noodles-editor/dist/* website/build/app/",
+    "start:website": "(cd website && npm start)",
+    "start:app": "(cd noodles-editor && npm start)",
+    "serve:website": "(cd website && npm run serve)",
+    "serve:app": "(cd noodles-editor && npm run serve)",
+    "validate:examples": "node scripts/validate-examples.js"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1"
+  }
 }


### PR DESCRIPTION
## Summary
Restore consistent two-space formatting across the root npm manifests so `npm install` no longer rewrites all 30,966 lines of `package-lock.json`.

The investigation also uncovered a stale workspace setup command that invoked npm from `noodles-editor`; this PR updates it to run from the npm workspace root as a small related cleanup.

## Root Cause
#529 incidentally changed the root `package.json` indentation from two spaces to tabs. The committed `package-lock.json` and the repository’s `.editorconfig` still use two spaces. Because npm infers lockfile indentation from `package.json`, the next `npm install` serialized the entire lockfile with tabs despite making no semantic dependency changes.

## Changes
- Restore two-space indentation in the root `package.json`, matching `.editorconfig` and `package-lock.json`.
- Update the workspace setup command to run `npm install` from the repository root instead of discovering the npm workspace indirectly from `noodles-editor`.
- Avoid the nested `.npmrc` warning during workspace setup.

## Testing
### Unit Tests
- Not run; the application code and dependency graph are unchanged.

### Manual Testing
- Ran `npm install --package-lock-only --ignore-scripts --audit=false` from the repository root.
- Confirmed npm completed successfully and produced zero `package-lock.json` diff.
- Confirmed the `package.json` change has zero non-whitespace differences.

## Documentation
- No documentation changes needed.

## Related Issues
- Follow-up to #529.