### PR TITLE
fix: silence already-applied Vitest postinstall patch

### DIFF
--- a/scripts/patch-vitest-browser-playwright.cjs
+++ b/scripts/patch-vitest-browser-playwright.cjs
@@ -16,8 +16,14 @@ let content = fs.readFileSync(filePath, 'utf-8')
 
 const needle = /(\t+)return route\.fulfill\(\{\n\t+body,\n\t+headers: getHeaders\(this\.project\.browser\.vite\.config\)\n\t+\}\);/
 
-const replacement = (_, indent) =>
-  `${indent}try { return await route.fulfill({ body, headers: getHeaders(this.project.browser.vite.config) }) } catch (e) { if (!e?.message?.includes('already handled')) throw e }`
+const patchedRouteHandler =
+  "try { return await route.fulfill({ body, headers: getHeaders(this.project.browser.vite.config) }) } catch (e) { if (!e?.message?.includes('already handled')) throw e }"
+
+const replacement = (_, indent) => `${indent}${patchedRouteHandler}`
+
+if (content.includes(patchedRouteHandler)) {
+  process.exit(0)
+}
 
 if (!needle.test(content)) {
   console.warn('patch: @vitest/browser-playwright target not found — patch may be outdated, skipping')


### PR DESCRIPTION
## Summary

Stop the `@vitest/browser-playwright` postinstall script from warning when its workaround is already present.

After the first successful patch, later installs could no longer find the original source and printed `target not found — patch may be outdated`. That warning was misleading: the target was missing because the patch had already been applied.

This change checks for the exact injected handler and exits silently when it is found. The existing warning remains for genuinely unknown upstream source. The underlying `route.fulfill()` workaround is unchanged.

## Testing

- `node --check scripts/patch-vitest-browser-playwright.cjs`
- Ran the script against an already-patched installation and confirmed it produced no output.

## Context

The workaround was introduced in #405 for a Vitest/Playwright teardown race.