### PR TITLE
fix: commit active table cell before row mutations

### DIFF
--- a/noodles-editor/src/noodles/components/table-editor-edit-flow.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor-edit-flow.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
 import { TableEditorOp } from '../operators'
 import type { TableSchema } from '../table-schema'
 import { TableEditor } from './table-editor'
@@ -227,6 +228,131 @@ describe('TableEditor - Edit Flow', () => {
         ],
         'Edit cell name'
       )
+    })
+  })
+
+  describe('Committing the active cell when another target is clicked', () => {
+    // Real pointer input is required here: the bug was a mousedown/blur/mouseup
+    // ordering problem that synthetic fireEvent.click() cannot reproduce.
+    const renderTable = (onDataChange: (data: unknown[], description?: string) => void) =>
+      render(
+        <TableEditor
+          op={mockOp}
+          data={data}
+          schema={schema}
+          onDataChange={onDataChange}
+          onSchemaChange={vi.fn()}
+        />
+      )
+
+    const startEdit = async (container: HTMLElement, text: string, newValue: string) => {
+      await userEvent.click(screen.getByText(text))
+      const input = container.querySelector('input.p-inputtext') as HTMLInputElement
+      await userEvent.fill(input, newValue)
+      return input
+    }
+
+    it('commits a pending edit when another cell is clicked', async () => {
+      const onDataChange = vi.fn()
+      const { container } = renderTable(onDataChange)
+
+      await startEdit(container, 'Alice', 'Charlie')
+      await userEvent.click(screen.getByText('Bob'))
+
+      expect(onDataChange).toHaveBeenCalledWith(
+        [
+          { name: 'Charlie', count: 10 },
+          { name: 'Bob', count: 20 },
+        ],
+        'Edit cell name'
+      )
+    })
+
+    it('commits a pending edit before adding a row, and still adds the row', async () => {
+      const onDataChange = vi.fn()
+      const { container } = renderTable(onDataChange)
+
+      await startEdit(container, 'Alice', 'Charlie')
+      await userEvent.click(screen.getByRole('button', { name: /add row/i }))
+
+      const descriptions = onDataChange.mock.calls.map(call => call[1])
+      expect(descriptions).toEqual(['Edit cell name', 'Add table row'])
+
+      const finalData = onDataChange.mock.calls.at(-1)?.[0]
+      expect(finalData).toHaveLength(3)
+      expect(finalData[0]).toEqual({ name: 'Charlie', count: 10 })
+    })
+
+    it('commits a pending edit before deleting a row, and still deletes the row', async () => {
+      const onDataChange = vi.fn()
+      const { container } = renderTable(onDataChange)
+
+      await startEdit(container, 'Alice', 'Charlie')
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete row/i })
+      await userEvent.click(deleteButtons[1])
+
+      const descriptions = onDataChange.mock.calls.map(call => call[1])
+      expect(descriptions).toEqual(['Edit cell name', 'Delete table row'])
+
+      // The committed edit must survive the delete
+      expect(onDataChange.mock.calls.at(-1)?.[0]).toEqual([{ name: 'Charlie', count: 10 }])
+    })
+
+    it('commits the pending edit only once', async () => {
+      const onDataChange = vi.fn()
+      const { container } = renderTable(onDataChange)
+
+      await startEdit(container, 'Alice', 'Charlie')
+      await userEvent.click(screen.getByText('Bob'))
+
+      const editCalls = onDataChange.mock.calls.filter(call => call[1] === 'Edit cell name')
+      expect(editCalls).toHaveLength(1)
+    })
+
+    it('keeps at most one cell in edit mode at a time', async () => {
+      const onDataChange = vi.fn()
+      const { container } = renderTable(onDataChange)
+      const activeEditors = () => container.querySelectorAll('input.p-inputtext').length
+
+      await userEvent.click(screen.getByText('Alice'))
+      expect(activeEditors()).toBe(1)
+
+      // A different column in a different row
+      await userEvent.click(screen.getByText('20'))
+      expect(activeEditors()).toBe(1)
+
+      // A different column in the same row
+      await userEvent.click(screen.getByText('Bob'))
+      expect(activeEditors()).toBe(1)
+    })
+
+    it('leaves no cell in edit mode after a row mutation', async () => {
+      const onDataChange = vi.fn()
+      const { container } = renderTable(onDataChange)
+      const activeEditors = () => container.querySelectorAll('input.p-inputtext').length
+
+      await userEvent.click(screen.getByText('Alice'))
+      expect(activeEditors()).toBe(1)
+
+      await userEvent.click(screen.getByRole('button', { name: /add row/i }))
+      expect(activeEditors()).toBe(0)
+
+      await userEvent.click(screen.getByText('Bob'))
+      expect(activeEditors()).toBe(1)
+
+      await userEvent.click(screen.getAllByRole('button', { name: /delete row/i })[0])
+      expect(activeEditors()).toBe(0)
+    })
+
+    it('deletes a row normally when no cell is being edited', async () => {
+      const onDataChange = vi.fn()
+      renderTable(onDataChange)
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete row/i })
+      await userEvent.click(deleteButtons[1])
+
+      expect(onDataChange).toHaveBeenCalledWith([{ name: 'Alice', count: 10 }], 'Delete table row')
     })
   })
 

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -11,7 +11,7 @@ import { Button } from 'primereact/button'
 import { InputSwitch } from 'primereact/inputswitch'
 import { InputText } from 'primereact/inputtext'
 import { GeocodingDialog } from './geocoding-dialog'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Temporal } from 'temporal-polyfill'
 import type { TableEditorOp } from '../operators'
 import type { ColumnSchema, ColumnType, DateTimeValue, TableSchema } from '../table-schema'
@@ -666,6 +666,36 @@ function getCellRenderer(type: ColumnType) {
   }
 }
 
+// Tracks the cell currently in edit mode so row mutations can commit it first.
+// Without this, clicking "Add Row" or a delete button while a cell is mid-edit
+// can drop the pending value.
+interface ActiveEdit {
+  set: (commit: () => void) => void
+  clear: () => void
+  flush: () => void
+}
+
+function useActiveEdit(): ActiveEdit {
+  const commitRef = useRef<(() => void) | null>(null)
+
+  return useMemo(
+    () => ({
+      set: commit => {
+        commitRef.current = commit
+      },
+      clear: () => {
+        commitRef.current = null
+      },
+      flush: () => {
+        const commit = commitRef.current
+        commitRef.current = null
+        commit?.()
+      },
+    }),
+    []
+  )
+}
+
 // Editable cell component
 interface EditableCellProps {
   getValue: () => unknown
@@ -677,6 +707,7 @@ interface EditableCellProps {
         updateData: (rowIndex: number, columnId: string, value: unknown) => void
         deleteRow: (rowIndex: number) => void
         schema: TableSchema
+        activeEdit: ActiveEdit
       }
     }
   }
@@ -688,6 +719,7 @@ function EditableCell({ getValue, row, column, table }: EditableCellProps) {
   const [value, setValue] = useState(currentValue)
   const valueRef = useRef(currentValue)
   const prevValueRef = useRef(currentValue)
+  const isEditingRef = useRef(false)
 
   // Sync state with current value when not editing
   if (!isEditing && currentValue !== prevValueRef.current) {
@@ -704,9 +736,7 @@ function EditableCell({ getValue, row, column, table }: EditableCellProps) {
   const EditorComponent = getCellEditor(colSchema.type)
   const renderer = getCellRenderer(colSchema.type)
 
-  const startEditing = () => {
-    setIsEditing(true)
-  }
+  const activeEdit = table.options.meta?.activeEdit
 
   const handleChange = (newValue: unknown) => {
     setValue(newValue)
@@ -714,8 +744,20 @@ function EditableCell({ getValue, row, column, table }: EditableCellProps) {
   }
 
   const handleComplete = () => {
+    // Guard against committing twice when a flush is followed by the blur it caused
+    if (!isEditingRef.current) return
+    isEditingRef.current = false
     setIsEditing(false)
+    activeEdit?.clear()
     table.options.meta?.updateData(row.index, column.id, valueRef.current)
+  }
+
+  const startEditing = () => {
+    // Commit any other cell still in edit mode before taking over
+    activeEdit?.flush()
+    isEditingRef.current = true
+    setIsEditing(true)
+    activeEdit?.set(handleComplete)
   }
 
   if (isEditing) {
@@ -768,24 +810,36 @@ interface TableEditorProps {
 
 export function TableEditor({ data, schema, onDataChange, onSchemaChange }: TableEditorProps) {
   const [tableData, setTableData] = useState(data)
+  const activeEdit = useActiveEdit()
+
+  // Mirrors tableData so a flushed cell edit and the row mutation that triggered
+  // it can both run in one tick without the second reading stale state
+  const tableDataRef = useRef(tableData)
+  tableDataRef.current = tableData
+
+  const commitData = (newData: unknown[], description: string) => {
+    tableDataRef.current = newData
+    setTableData(newData)
+    onDataChange(newData, description)
+  }
 
   useEffect(() => {
     setTableData(data)
   }, [data])
 
   const addRow = () => {
+    activeEdit.flush()
     const newRow: Record<string, unknown> = {}
     for (const col of schema.columns) {
       newRow[col.name] = col.defaultValue ?? getDefaultValue(col)
     }
-    const newData = [...tableData, newRow]
-    setTableData(newData)
-    onDataChange(newData, 'Add table row')
+    commitData([...tableDataRef.current, newRow], 'Add table row')
   }
 
   const handleSchemaChange = (newSchema: TableSchema) => {
+    activeEdit.flush()
     // Update data to match new schema
-    const newData = tableData.map(row => {
+    const newData = tableDataRef.current.map(row => {
       const newRow: Record<string, unknown> = {}
       for (const col of newSchema.columns) {
         const existingValue = row[col.name]
@@ -800,6 +854,7 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
     })
 
     onSchemaChange(newSchema, newData)
+    tableDataRef.current = newData
     setTableData(newData)
   }
 
@@ -826,8 +881,12 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
         <Button
           icon="pi pi-trash"
           className={`p-button-text p-button-sm ${s.deleteButton}`}
+          // Suppress the editor blur so unmounting it doesn't reflow the row and
+          // move this button out from under the pointer before mouseup lands
+          onMouseDown={e => e.preventDefault()}
           onClick={() => props.table.options.meta?.deleteRow(props.row.index)}
           tooltip="Delete row"
+          aria-label="Delete row"
         />
       ),
       size: 50,
@@ -841,24 +900,25 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
     meta: {
       updateData: (rowIndex: number, columnId: string, value: unknown) => {
         // Only update if value actually changed
-        const currentValue = tableData[rowIndex]?.[columnId]
+        const currentData = tableDataRef.current
+        const currentValue = currentData[rowIndex]?.[columnId]
         if (currentValue === value) {
           return
         }
-        const newData = [...tableData]
+        const newData = [...currentData]
         newData[rowIndex] = {
           ...newData[rowIndex],
           [columnId]: value,
         }
-        setTableData(newData)
-        onDataChange(newData, `Edit cell ${columnId}`)
+        commitData(newData, `Edit cell ${columnId}`)
       },
       deleteRow: (rowIndex: number) => {
-        const newData = tableData.filter((_, index) => index !== rowIndex)
-        setTableData(newData)
-        onDataChange(newData, 'Delete table row')
+        activeEdit.flush()
+        const newData = tableDataRef.current.filter((_, index) => index !== rowIndex)
+        commitData(newData, 'Delete table row')
       },
       schema,
+      activeEdit,
     },
   })
 
@@ -906,6 +966,7 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
         <Button
           label="Add Row"
           icon="pi pi-plus"
+          onMouseDown={e => e.preventDefault()}
           onClick={addRow}
           className={`p-button-sm p-button-text ${s.addRowButton}`}
         />


### PR DESCRIPTION
## Summary
Clicking a row's delete button while a cell was mid-edit committed the cell edit but **silently dropped the delete** — the row stayed. This fixes that, and adds coverage for the "only one active cell" invariant, which nothing tested before.

## Root Cause
Not a state bug — an event-ordering one. Instrumenting the DOM during a delete click shows:

```
mousedown -> BUTTON.deleteButton
blur      -> INPUT.cellEditor     ← editor unmounts, row reflows
mouseup   -> TD.cellContainer     ← button moved 27px; mouseup misses it
```

`mousedown` on the button blurs the editor, which unmounts it and shrinks the column widths. The button shifts out from under the pointer, so `mouseup` lands on the `<td>` instead. No `click` event is ever synthesized and `deleteRow` never runs.

## Changes
- `onMouseDown={e => e.preventDefault()}` on the delete and Add Row buttons, suppressing the blur so the row doesn't reflow before `mouseup` lands. Same technique #502 used for the geocoder button.
- Added an `activeEdit` registry so row mutations explicitly flush the pending cell edit first. Suppressing the blur defers it, so `deleteRow` would otherwise commit *after* the mutation and read stale data.
- Row mutations now read through `tableDataRef`, so a flushed edit and the mutation that triggered it can both run in one tick without the second seeing stale state.
- An `isEditingRef` guard prevents a double commit from `flush()` plus the later blur.
- Added `aria-label="Delete row"` — the button previously had only a PrimeReact `tooltip` and no accessible name.

## Testing

### Unit Tests
7 tests added to `table-editor-edit-flow.test.tsx` (30 pass in the two table suites; full suite 130 files / 2670 tests green):

- commits a pending edit when another cell is clicked
- commits before adding a row, **and still adds the row**
- commits before deleting a row, **and still deletes the row** ← the actual regression
- commits the pending edit only once
- deletes a row normally when no cell is being edited
- keeps at most one cell in edit mode at a time
- leaves no cell in edit mode after a row mutation

These use real pointer input (`userEvent` from `vitest/browser`). This matters: `fireEvent.click()` synthesizes a `click` directly and **cannot** reproduce this class of bug — the pre-existing tests passed against the broken code. Verified the new tests fail on `main`, and that reverting only the `preventDefault` line reintroduces the failure, so they pin the real defect rather than incidental changes.

### Manual Testing

Open `http://localhost:5173/?project=table-editor-demo` (existing `public/noodles/table-editor-demo.json`) and select `/cities-table`.

1. **Delete while editing** (the bug):
   - Click a `city` cell in row 1 and type a new name — do *not* press Enter
   - Click the trash icon on row 2
   - Expected: row 1 keeps your typed value **and row 2 is deleted**
   - Before this fix: the edit was kept but row 2 remained

2. **Add Row while editing:**
   - Edit a `city` cell without pressing Enter, then click "Add Row"
   - Expected: the edit is committed and a new row is appended

3. **One active cell:**
   - Click a cell to edit, then click a different cell (another row, and another column in the same row)
   - Expected: only one cell is ever in edit mode; the previous one commits

4. **Multi-input editors** — repeat step 1 on the `position` (point2d) column, which has two inputs and a geocoder button, and confirm the geocoder still opens

5. **Undo:** press Cmd+Z after a delete-while-editing and confirm the edit and delete undo cleanly

## Documentation
No documentation changes needed — this restores intended behavior with no user-facing API change. Rationale for both `preventDefault` calls and the `tableDataRef` mirror is in code comments, since they look removable but aren't.

## Related Issues
None filed.
