### PR TITLE
Fix duplicate for loop group IDs

### DIFF
--- a/noodles-editor/src/noodles/__tests__/node-operations-integration.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/node-operations-integration.test.tsx
@@ -1184,6 +1184,22 @@ describe('Node Operations Integration Tests', () => {
       expect(metaNode.parentId).toBe(groupNode.id)
     })
 
+    it('creates a unique visual group for each ForLoop', () => {
+      const first = createNodesForType('ForLoop', { x: 100, y: 100 }, '/')
+      transformGraph({ nodes: first.nodes as any, edges: first.edges as any })
+
+      const second = createNodesForType('ForLoop', { x: 200, y: 200 }, '/')
+
+      const firstGroup = first.nodes.find(n => n.type === 'group')!
+      const secondGroup = second.nodes.find(n => n.type === 'group')!
+      expect(secondGroup.id).not.toBe(firstGroup.id)
+
+      for (const child of second.nodes.filter(n => n.type !== 'group')) {
+        expect(child.parentId).toBe(secondGroup.id)
+        expect(child.parentId).not.toBe(firstGroup.id)
+      }
+    })
+
     it('creates ForLoop child node IDs within the group namespace', () => {
       const { nodes } = createNodesForType('ForLoop', { x: 100, y: 100 }, '/')
 

--- a/noodles-editor/src/noodles/utils/node-creation-utils.ts
+++ b/noodles-editor/src/noodles/utils/node-creation-utils.ts
@@ -54,9 +54,13 @@ export function createNodesForType(
 
   if (type === 'ForLoop') {
     // ForLoop scope: group node containing ForLoopBeginOp, ForLoopEndOp, and ForLoopMetaOp
-    const bodyId = nodeId('for-loop-body', currentContainerId)
+    const beginId = makeOpId('ForLoopBeginOp', currentContainerId)
+    // Group nodes are React Flow-only nodes, so nodeId() cannot see them in the
+    // operator store. Derive the visual group's suffix from the unique begin operator
+    // instead. This gives every loop its own group while keeping it in the same container.
+    const bodyId = beginId.replace(/for-loop-begin(-\d+)?$/, 'for-loop-body$1')
     const beginNode = {
-      id: makeOpId('ForLoopBeginOp', currentContainerId),
+      id: beginId,
       type: 'ForLoopBeginOp',
       data: undefined,
       parentId: bodyId,


### PR DESCRIPTION
#### Background
ForLoop visual groups used operator-store ID generation even though group nodes are not operators, causing multiple loops to reuse the same serialized group ID.

#### Change List
- Derive each group ID from its unique ForLoopBegin operator ID so their numeric suffixes stay aligned.
- Add regression coverage verifying multiple loops use distinct groups and correct parent references.

Tests: `npm test -- --run src/noodles/__tests__/node-operations-integration.test.tsx src/noodles/hooks/use-node-drop-on-edge.test.ts src/noodles/utils/serialization.test.ts`; `npm run lint`; `npm run format:check`.