### PR TITLE
Add reusable group layout reconciliation

### DIFF
--- a/noodles-editor/src/noodles/utils/group-layout-utils.test.ts
+++ b/noodles-editor/src/noodles/utils/group-layout-utils.test.ts
@@ -47,8 +47,59 @@ describe('layoutGroups', () => {
 
     expect(body.position).toEqual({ x: 60, y: 60 })
     expect(body.style).toMatchObject({ width: 480, height: 140 })
+    expect(body).toMatchObject({
+      width: 480,
+      height: 140,
+      measured: { width: 480, height: 140 },
+    })
     expect(absolutePosition(result, '/begin')).toEqual({ x: 100, y: 100 })
     expect(absolutePosition(result, '/end')).toEqual({ x: 400, y: 100 })
+  })
+
+  it('replaces stale React Flow dimensions when the fitted style is already correct', () => {
+    const body = {
+      ...group('/body', { x: 60, y: 60 }),
+      width: 1200,
+      height: 400,
+      measured: { width: 1200, height: 400 },
+      style: { width: 480, height: 140 },
+    }
+    const nodes = [
+      body,
+      node('/begin', { x: 40, y: 40 }, '/body', { width: 100, height: 60 }),
+      node('/end', { x: 340, y: 40 }, '/body', { width: 100, height: 60 }),
+    ]
+    const parents = new Map(nodes.map(node => [node.id, node.parentId]))
+
+    const result = layoutGroups(nodes, new Set(['/body']), parents)
+
+    expect(byId(result, '/body')).toMatchObject({
+      width: 480,
+      height: 140,
+      measured: { width: 480, height: 140 },
+      style: { width: 480, height: 140 },
+    })
+  })
+
+  it('keeps the fitted style instead of stale dimensions while children are unmeasured', () => {
+    const body = {
+      ...group('/body', { x: 60, y: 60 }),
+      width: 1200,
+      height: 400,
+      measured: { width: 1200, height: 400 },
+      style: { width: 480, height: 140 },
+    }
+    const nodes = [body, node('/waiting', { x: 40, y: 40 }, '/body')]
+    const parents = new Map(nodes.map(node => [node.id, node.parentId]))
+
+    const result = layoutGroups(nodes, new Set(['/body']), parents)
+
+    expect(byId(result, '/body')).toMatchObject({
+      width: 480,
+      height: 140,
+      measured: { width: 480, height: 140 },
+      style: { width: 480, height: 140 },
+    })
   })
 
   it('reparents nodes without changing their canvas position and orders the parent first', () => {

--- a/noodles-editor/src/noodles/utils/group-layout-utils.test.ts
+++ b/noodles-editor/src/noodles/utils/group-layout-utils.test.ts
@@ -1,0 +1,104 @@
+import type { Node } from '@xyflow/react'
+import { describe, expect, it } from 'vitest'
+import { layoutGroups } from './group-layout-utils'
+
+function node(
+  id: string,
+  position: { x: number; y: number },
+  parentId?: string,
+  size?: { width: number; height: number }
+): Node {
+  return { id, position, parentId, measured: size, data: {} }
+}
+
+function group(id: string, position = { x: 0, y: 0 }, parentId?: string): Node {
+  return {
+    id,
+    type: 'group',
+    position,
+    parentId,
+    style: { width: 1200, height: 400 },
+    data: {},
+  }
+}
+
+function byId(nodes: Node[], id: string): Node {
+  return nodes.find(node => node.id === id)!
+}
+
+function absolutePosition(nodes: Node[], id: string): { x: number; y: number } {
+  const current = byId(nodes, id)
+  if (!current.parentId) return current.position
+  const parent = absolutePosition(nodes, current.parentId)
+  return { x: parent.x + current.position.x, y: parent.y + current.position.y }
+}
+
+describe('layoutGroups', () => {
+  it('shrinks and moves a group around its children with padding', () => {
+    const nodes = [
+      group('/body'),
+      node('/begin', { x: 100, y: 100 }, '/body', { width: 100, height: 60 }),
+      node('/end', { x: 400, y: 100 }, '/body', { width: 100, height: 60 }),
+    ]
+    const parents = new Map(nodes.map(node => [node.id, node.parentId]))
+
+    const result = layoutGroups(nodes, new Set(['/body']), parents)
+    const body = byId(result, '/body')
+
+    expect(body.position).toEqual({ x: 60, y: 60 })
+    expect(body.style).toMatchObject({ width: 480, height: 140 })
+    expect(absolutePosition(result, '/begin')).toEqual({ x: 100, y: 100 })
+    expect(absolutePosition(result, '/end')).toEqual({ x: 400, y: 100 })
+  })
+
+  it('reparents nodes without changing their canvas position and orders the parent first', () => {
+    const nodes = [
+      node('/child', { x: 500, y: 180 }, undefined, { width: 100, height: 60 }),
+      group('/body', { x: 100, y: 100 }),
+    ]
+    const parents = new Map<string, string | undefined>([
+      ['/child', '/body'],
+      ['/body', undefined],
+    ])
+
+    const result = layoutGroups(nodes, new Set(['/body']), parents)
+
+    expect(byId(result, '/child').parentId).toBe('/body')
+    expect(absolutePosition(result, '/child')).toEqual({ x: 500, y: 180 })
+    expect(result.map(node => node.id)).toEqual(['/body', '/child'])
+  })
+
+  it('fits nested groups from the inside out', () => {
+    const nodes = [
+      group('/outer'),
+      group('/inner', { x: 300, y: 100 }),
+      node('/child', { x: 40, y: 40 }, '/inner', { width: 100, height: 60 }),
+    ]
+    const parents = new Map<string, string | undefined>([
+      ['/outer', undefined],
+      ['/inner', '/outer'],
+      ['/child', '/inner'],
+    ])
+
+    const result = layoutGroups(nodes, new Set(['/outer', '/inner']), parents)
+
+    expect(byId(result, '/inner').parentId).toBe('/outer')
+    expect(byId(result, '/inner').style).toMatchObject({ width: 200, height: 140 })
+    expect(byId(result, '/outer').style).toMatchObject({ width: 280, height: 220 })
+    expect(absolutePosition(result, '/child')).toEqual({ x: 340, y: 140 })
+  })
+
+  it('keeps existing bounds until every child is measured', () => {
+    const nodes = [
+      group('/body', { x: 100, y: 100 }),
+      node('/measured', { x: 40, y: 40 }, '/body', { width: 100, height: 60 }),
+      node('/waiting', { x: 300, y: 40 }, '/body'),
+    ]
+    const parents = new Map(nodes.map(node => [node.id, node.parentId]))
+
+    const result = layoutGroups(nodes, new Set(['/body']), parents)
+
+    expect(byId(result, '/body').position).toEqual({ x: 100, y: 100 })
+    expect(byId(result, '/body').style).toMatchObject({ width: 1200, height: 400 })
+  })
+})

--- a/noodles-editor/src/noodles/utils/group-layout-utils.ts
+++ b/noodles-editor/src/noodles/utils/group-layout-utils.ts
@@ -1,0 +1,151 @@
+import type { Node } from '@xyflow/react'
+
+const GROUP_PADDING = 40
+const MIN_GROUP_WIDTH = 200
+const MIN_GROUP_HEIGHT = 100
+
+type Position = { x: number; y: number }
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function nodeSize(node: Node): { width: number; height: number } | undefined {
+  const width =
+    finiteNumber(node.measured?.width) ??
+    finiteNumber(node.width) ??
+    finiteNumber(node.style?.width)
+  const height =
+    finiteNumber(node.measured?.height) ??
+    finiteNumber(node.height) ??
+    finiteNumber(node.style?.height)
+  return width !== undefined && height !== undefined ? { width, height } : undefined
+}
+
+function samePosition(a: Position, b: Position): boolean {
+  return a.x === b.x && a.y === b.y
+}
+
+/**
+ * Applies parent assignments and fits groups around their direct children. Absolute
+ * canvas positions are preserved while parent-relative coordinates are recalculated.
+ */
+export function layoutGroups<TNode extends Node>(
+  nodes: TNode[],
+  groupIds: Set<string>,
+  desiredParent: Map<string, string | undefined>
+): TNode[] {
+  if (groupIds.size === 0) return nodes
+
+  const nodesById = new Map(nodes.map(node => [node.id, node]))
+  const originalAbsolute = new Map<string, Position>()
+  const getOriginalAbsolute = (nodeId: string, visiting = new Set<string>()): Position => {
+    const cached = originalAbsolute.get(nodeId)
+    if (cached) return cached
+    const node = nodesById.get(nodeId)
+    if (!node || visiting.has(nodeId)) return { x: 0, y: 0 }
+    visiting.add(nodeId)
+    const parent = node.parentId ? getOriginalAbsolute(node.parentId, visiting) : { x: 0, y: 0 }
+    const absolute = { x: parent.x + node.position.x, y: parent.y + node.position.y }
+    originalAbsolute.set(nodeId, absolute)
+    return absolute
+  }
+  for (const node of nodes) getOriginalAbsolute(node.id)
+
+  const nextAbsolute = new Map(originalAbsolute)
+  const nextGroupSize = new Map<string, { width: number; height: number }>()
+  const laidOutGroups = new Set<string>()
+
+  const layoutGroup = (groupId: string, visiting = new Set<string>()) => {
+    if (laidOutGroups.has(groupId) || visiting.has(groupId)) return
+    visiting.add(groupId)
+
+    const children = nodes.filter(node => desiredParent.get(node.id) === groupId)
+    for (const child of children) {
+      if (groupIds.has(child.id)) layoutGroup(child.id, visiting)
+    }
+
+    const childRects = children.map(child => {
+      const position = nextAbsolute.get(child.id)!
+      const size = nextGroupSize.get(child.id) ?? nodeSize(child)
+      return size ? { position, size } : undefined
+    })
+
+    // Wait until React Flow has measured every direct child before shrinking. This
+    // prevents a newly created, unmeasured node from being clipped out of the group.
+    if (childRects.length > 0 && childRects.every(rect => rect !== undefined)) {
+      const rects = childRects as Array<{
+        position: Position
+        size: { width: number; height: number }
+      }>
+      const minX = Math.min(...rects.map(rect => rect.position.x))
+      const minY = Math.min(...rects.map(rect => rect.position.y))
+      const maxX = Math.max(...rects.map(rect => rect.position.x + rect.size.width))
+      const maxY = Math.max(...rects.map(rect => rect.position.y + rect.size.height))
+      nextAbsolute.set(groupId, { x: minX - GROUP_PADDING, y: minY - GROUP_PADDING })
+      nextGroupSize.set(groupId, {
+        width: Math.max(MIN_GROUP_WIDTH, maxX - minX + GROUP_PADDING * 2),
+        height: Math.max(MIN_GROUP_HEIGHT, maxY - minY + GROUP_PADDING * 2),
+      })
+    } else {
+      const group = nodesById.get(groupId)!
+      const size = nodeSize(group)
+      if (size) nextGroupSize.set(groupId, size)
+    }
+
+    laidOutGroups.add(groupId)
+    visiting.delete(groupId)
+  }
+
+  for (const groupId of groupIds) layoutGroup(groupId)
+
+  const nextNodes = nodes.map(node => {
+    const parentId = desiredParent.get(node.id)
+    const absolute = nextAbsolute.get(node.id)!
+    const parentAbsolute = parentId ? nextAbsolute.get(parentId) : undefined
+    const position = parentAbsolute
+      ? { x: absolute.x - parentAbsolute.x, y: absolute.y - parentAbsolute.y }
+      : absolute
+    const groupSize = nextGroupSize.get(node.id)
+    const wasInGroup = groupIds.has(node.parentId ?? '')
+    const nextExpandParent =
+      parentId && groupIds.has(parentId) ? true : wasInGroup ? undefined : node.expandParent
+    const parentChanged = node.parentId !== parentId
+    const positionChanged = !samePosition(node.position, position)
+    const expandParentChanged = node.expandParent !== nextExpandParent
+    const sizeChanged =
+      groupSize !== undefined &&
+      (finiteNumber(node.style?.width) !== groupSize.width ||
+        finiteNumber(node.style?.height) !== groupSize.height)
+
+    if (!parentChanged && !positionChanged && !expandParentChanged && !sizeChanged) return node
+
+    return {
+      ...node,
+      parentId,
+      expandParent: nextExpandParent,
+      position,
+      ...(groupSize
+        ? { style: { ...node.style, width: groupSize.width, height: groupSize.height } }
+        : {}),
+    } as TNode
+  })
+
+  // React Flow requires parents to occur before their children in the node array.
+  // This matters when an older node is later assigned to a newly created group.
+  const nextNodesById = new Map(nextNodes.map(node => [node.id, node]))
+  const orderedNodes: TNode[] = []
+  const appended = new Set<string>()
+  const appendWithParent = (node: TNode, visiting = new Set<string>()) => {
+    if (appended.has(node.id) || visiting.has(node.id)) return
+    visiting.add(node.id)
+    const parentId = desiredParent.get(node.id)
+    const parent = parentId ? nextNodesById.get(parentId) : undefined
+    if (parent) appendWithParent(parent, visiting)
+    orderedNodes.push(node)
+    appended.add(node.id)
+  }
+  for (const node of nextNodes) appendWithParent(node)
+
+  return orderedNodes.every((node, index) => node === nodes[index]) ? nodes : orderedNodes
+}

--- a/noodles-editor/src/noodles/utils/group-layout-utils.ts
+++ b/noodles-editor/src/noodles/utils/group-layout-utils.ts
@@ -22,6 +22,12 @@ function nodeSize(node: Node): { width: number; height: number } | undefined {
   return width !== undefined && height !== undefined ? { width, height } : undefined
 }
 
+function styledSize(node: Node): { width: number; height: number } | undefined {
+  const width = finiteNumber(node.style?.width)
+  const height = finiteNumber(node.style?.height)
+  return width !== undefined && height !== undefined ? { width, height } : undefined
+}
+
 function samePosition(a: Position, b: Position): boolean {
   return a.x === b.x && a.y === b.y
 }
@@ -89,7 +95,9 @@ export function layoutGroups<TNode extends Node>(
       })
     } else {
       const group = nodesById.get(groupId)!
-      const size = nodeSize(group)
+      // Group style is the canonical persisted size. React Flow's width and
+      // measured fields are runtime caches and can still contain the old bounds.
+      const size = styledSize(group) ?? nodeSize(group)
       if (size) nextGroupSize.set(groupId, size)
     }
 
@@ -116,7 +124,11 @@ export function layoutGroups<TNode extends Node>(
     const sizeChanged =
       groupSize !== undefined &&
       (finiteNumber(node.style?.width) !== groupSize.width ||
-        finiteNumber(node.style?.height) !== groupSize.height)
+        finiteNumber(node.style?.height) !== groupSize.height ||
+        finiteNumber(node.width) !== groupSize.width ||
+        finiteNumber(node.height) !== groupSize.height ||
+        finiteNumber(node.measured?.width) !== groupSize.width ||
+        finiteNumber(node.measured?.height) !== groupSize.height)
 
     if (!parentChanged && !positionChanged && !expandParentChanged && !sizeChanged) return node
 
@@ -126,7 +138,12 @@ export function layoutGroups<TNode extends Node>(
       expandParent: nextExpandParent,
       position,
       ...(groupSize
-        ? { style: { ...node.style, width: groupSize.width, height: groupSize.height } }
+        ? {
+            width: groupSize.width,
+            height: groupSize.height,
+            measured: { ...node.measured, ...groupSize },
+            style: { ...node.style, width: groupSize.width, height: groupSize.height },
+          }
         : {}),
     } as TNode
   })

--- a/noodles-editor/src/noodles/utils/serialization.test.ts
+++ b/noodles-editor/src/noodles/utils/serialization.test.ts
@@ -136,10 +136,27 @@ describe('serializeNodes', () => {
     clearOps()
   })
 
-  it('includes group nodes as-is', () => {
-    const groupNode = { id: 'group1', type: 'group', data: {}, position: { x: 0, y: 0 } }
+  it('serializes group dimensions canonically in style', () => {
+    const groupNode = {
+      id: 'group1',
+      type: 'group',
+      data: {},
+      position: { x: 0, y: 0 },
+      width: 1200,
+      height: 400,
+      measured: { width: 1200, height: 400 },
+      style: { width: 480, height: 140 },
+    }
     const result = serializeNodes(getOpStore(), [groupNode], [])
-    expect(result).toEqual([groupNode])
+    expect(result).toEqual([
+      {
+        id: 'group1',
+        type: 'group',
+        data: {},
+        position: { x: 0, y: 0 },
+        style: { width: 480, height: 140 },
+      },
+    ])
   })
 
   it('skips nodes without corresponding op', () => {

--- a/noodles-editor/src/noodles/utils/serialization.ts
+++ b/noodles-editor/src/noodles/utils/serialization.ts
@@ -103,8 +103,22 @@ export function serializeNodes(
   const preparedNodes: NodeJSON<unknown>[] = []
   for (const node of nodes) {
     if (node.type === 'group') {
-      // Include visual aid nodes (e.g. for loops) as-is
-      preparedNodes.push(node)
+      // React Flow's runtime dimensions override style dimensions when a project
+      // is loaded. Persist the fitted size in style, not the transient measurement
+      // cache, so a stale measurement cannot resurrect old group bounds.
+      const { measured, width, height, ...cleanedGroup } = node
+      const fittedWidth = node.style?.width ?? measured?.width ?? width
+      const fittedHeight = node.style?.height ?? measured?.height ?? height
+      preparedNodes.push({
+        ...cleanedGroup,
+        ...((fittedWidth !== undefined || fittedHeight !== undefined) && {
+          style: {
+            ...node.style,
+            ...(fittedWidth !== undefined && { width: fittedWidth }),
+            ...(fittedHeight !== undefined && { height: fittedHeight }),
+          },
+        }),
+      })
       continue
     }
     const op = store.getOp(node.id)
@@ -228,8 +242,11 @@ export function serializeEdges(
       // array order at load time — keep files canonical by not persisting it
       if (serialized.type === MULTI_INPUT_EDGE_TYPE) {
         delete serialized.type
-        const { orderIndex: _orderIndex, groupSize: _groupSize, ...data } = (serialized.data ??
-          {}) as Record<string, unknown>
+        const {
+          orderIndex: _orderIndex,
+          groupSize: _groupSize,
+          ...data
+        } = (serialized.data ?? {}) as Record<string, unknown>
         if (Object.keys(data).length > 0) {
           serialized.data = data
         } else {


### PR DESCRIPTION
## Summary

Adds the coordinate and bounds foundation used by the ForLoop visual-membership follow-up. This PR is stacked above the merged #539 and intentionally contains no editor wiring.

## Changes

- Reparent React Flow nodes without changing their absolute canvas position.
- Fit groups around measured direct children with padding and minimum dimensions.
- Lay out nested groups from the inside out and keep parents before children in node order.
- Defer shrinking while any child is still unmeasured.
- Keep fitted `style`, `width`, `height`, and `measured` dimensions synchronized so stale React Flow caches cannot override new bounds.
- Serialize group dimensions canonically in `style` instead of persisting transient measurement caches.

## Testing

### Automated

- Full editor suite: 2,683 passed, 10 skipped.
- Regression coverage for stale cached dimensions both before and after children are measured.
- `npm run lint`
- `npm run format:check`
- `npm run build`

### Fixture validation

- The supplied migrated project normalizes its oversized group from `12287×7652` to `3083×1393` and its over-tall group from `1200×682` to `1223×437`.

## Documentation

No documentation changes needed.

## Related PRs

- Followed by #541, #542, and migration PR #544.
