### PR TITLE
Sync ForLoop visual membership with graph connections

### DIFF
--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -104,6 +104,7 @@ import {
   selectDirectory,
   writeFileToDirectory,
 } from './utils/filesystem'
+import { reconcileForLoopGroups } from './utils/for-loop-group-utils'
 import { edgeId, nodeId } from './utils/id-utils'
 import { generateDraftId, memoryProjectStore } from './utils/memory-project-store'
 import { migrateProject } from './utils/migrate-schema'
@@ -330,6 +331,30 @@ export function getNoodles(): Visualization {
       .join(',')
     return `${nodeIds}|${edgeIds}`
   }, [nodes, edges])
+
+  // Visual ForLoop groups are derived from the directed Begin-to-End subgraph. Re-run
+  // when connectivity, membership, or measured dimensions change, but not during a drag.
+  const forLoopLayoutKey = useMemo(() => {
+    const nodeState = nodes
+      .map(
+        node =>
+          `${node.id}:${node.type}:${node.parentId ?? ''}:${node.measured?.width ?? ''}x${node.measured?.height ?? ''}`
+      )
+      .sort()
+      .join(',')
+    const connectivity = edges
+      .map(edge => `${edge.source}->${edge.target}`)
+      .sort()
+      .join(',')
+    return `${nodeState}|${connectivity}`
+  }, [nodes, edges])
+
+  // nodes/edges are represented by forLoopLayoutKey; position-only updates intentionally
+  // do not trigger this effect because drag-stop performs the fit once per gesture.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional key-based reconciliation
+  useEffect(() => {
+    setNodes(currentNodes => reconcileForLoopGroups(currentNodes, edges))
+  }, [forLoopLayoutKey, setNodes])
 
   // `transformGraph` needs all nodes to build the opMap and resolve connections
   // Use useEffect instead of useMemo to avoid setState during render
@@ -574,12 +599,13 @@ export function getNoodles(): Visualization {
   const onNodeDragStop = useCallback(
     (event: React.MouseEvent, node: ReactFlowNode) => {
       const result = onNodeDragStopBase(event, node)
+      setNodes(currentNodes => reconcileForLoopGroups(currentNodes, graphRef.current.edges))
       // Mark as unsaved if a node was inserted into an edge
       if (result) {
         setHasUnsavedChanges(true)
       }
     },
-    [onNodeDragStopBase]
+    [onNodeDragStopBase, setNodes]
   )
 
   const onNodeContextMenu = useCallback(

--- a/noodles-editor/src/noodles/utils/for-loop-group-utils.test.ts
+++ b/noodles-editor/src/noodles/utils/for-loop-group-utils.test.ts
@@ -1,0 +1,140 @@
+import type { Edge, Node } from '@xyflow/react'
+import { describe, expect, it } from 'vitest'
+import { reconcileForLoopGroups } from './for-loop-group-utils'
+
+function node(
+  id: string,
+  type: string,
+  position: { x: number; y: number },
+  parentId?: string,
+  size = { width: 100, height: 60 }
+): Node {
+  return { id, type, position, parentId, measured: size, data: {} }
+}
+
+function group(id: string, position = { x: 0, y: 0 }, parentId?: string): Node {
+  return {
+    id,
+    type: 'group',
+    position,
+    parentId,
+    style: { width: 1200, height: 400 },
+    data: {},
+  }
+}
+
+function edge(source: string, target: string): Edge {
+  return { id: `${source}->${target}`, source, target }
+}
+
+function byId(nodes: Node[], id: string): Node {
+  return nodes.find(node => node.id === id)!
+}
+
+function absolutePosition(nodes: Node[], id: string): { x: number; y: number } {
+  const current = byId(nodes, id)
+  if (!current.parentId) return current.position
+  const parent = absolutePosition(nodes, current.parentId)
+  return { x: parent.x + current.position.x, y: parent.y + current.position.y }
+}
+
+describe('reconcileForLoopGroups', () => {
+  it('adds a node on the Begin-to-End path while preserving its screen position', () => {
+    const nodes = [
+      node('/inserted', 'MathOp', { x: 500, y: 180 }),
+      group('/body', { x: 100, y: 100 }),
+      node('/begin', 'ForLoopBeginOp', { x: 0, y: 100 }, '/body'),
+      node('/end', 'ForLoopEndOp', { x: 900, y: 100 }, '/body'),
+      node('/meta', 'ForLoopMetaOp', { x: 450, y: 250 }, '/body'),
+    ]
+
+    const result = reconcileForLoopGroups(nodes, [
+      edge('/begin', '/inserted'),
+      edge('/inserted', '/end'),
+    ])
+
+    expect(byId(result, '/inserted').parentId).toBe('/body')
+    expect(absolutePosition(result, '/inserted')).toEqual({ x: 500, y: 180 })
+    expect(result.findIndex(node => node.id === '/body')).toBeLessThan(
+      result.findIndex(node => node.id === '/inserted')
+    )
+  })
+
+  it('removes disconnected former members from the visual group', () => {
+    const nodes = [
+      group('/body'),
+      node('/begin', 'ForLoopBeginOp', { x: 40, y: 40 }, '/body'),
+      node('/end', 'ForLoopEndOp', { x: 500, y: 40 }, '/body'),
+      node('/old', 'MathOp', { x: 250, y: 40 }, '/body'),
+    ]
+
+    const result = reconcileForLoopGroups(nodes, [edge('/begin', '/end')])
+
+    expect(byId(result, '/old').parentId).toBeUndefined()
+    expect(absolutePosition(result, '/old')).toEqual({ x: 250, y: 40 })
+  })
+
+  it('includes rejoining branches but excludes dead-end branches', () => {
+    const nodes = [
+      group('/body'),
+      node('/begin', 'ForLoopBeginOp', { x: 0, y: 0 }, '/body'),
+      node('/end', 'ForLoopEndOp', { x: 900, y: 0 }, '/body'),
+      node('/rejoins', 'MathOp', { x: 300, y: 0 }),
+      node('/dead-end', 'MathOp', { x: 300, y: 200 }),
+    ]
+    const edges = [
+      edge('/begin', '/rejoins'),
+      edge('/rejoins', '/end'),
+      edge('/begin', '/dead-end'),
+    ]
+
+    const result = reconcileForLoopGroups(nodes, edges)
+
+    expect(byId(result, '/rejoins').parentId).toBe('/body')
+    expect(byId(result, '/dead-end').parentId).toBeUndefined()
+  })
+
+  it('places an inner loop group inside its outer loop', () => {
+    const nodes = [
+      group('/outer-body'),
+      node('/outer-begin', 'ForLoopBeginOp', { x: 0, y: 0 }, '/outer-body'),
+      node('/outer-end', 'ForLoopEndOp', { x: 1000, y: 0 }, '/outer-body'),
+      group('/inner-body', { x: 300, y: 100 }),
+      node('/inner-begin', 'ForLoopBeginOp', { x: 0, y: 0 }, '/inner-body'),
+      node('/inner-end', 'ForLoopEndOp', { x: 300, y: 0 }, '/inner-body'),
+    ]
+    const edges = [
+      edge('/outer-begin', '/inner-begin'),
+      edge('/inner-begin', '/inner-end'),
+      edge('/inner-end', '/outer-end'),
+    ]
+
+    const result = reconcileForLoopGroups(nodes, edges)
+
+    expect(byId(result, '/inner-body').parentId).toBe('/outer-body')
+    expect(byId(result, '/inner-begin').parentId).toBe('/inner-body')
+    expect(byId(result, '/inner-end').parentId).toBe('/inner-body')
+  })
+
+  it('keeps the current owner for a node shared by two loop scopes', () => {
+    const nodes = [
+      group('/a-body'),
+      node('/a-begin', 'ForLoopBeginOp', { x: 0, y: 0 }, '/a-body'),
+      node('/a-end', 'ForLoopEndOp', { x: 500, y: 0 }, '/a-body'),
+      group('/b-body', { x: 0, y: 300 }),
+      node('/b-begin', 'ForLoopBeginOp', { x: 0, y: 0 }, '/b-body'),
+      node('/b-end', 'ForLoopEndOp', { x: 500, y: 0 }, '/b-body'),
+      node('/shared', 'MathOp', { x: 250, y: 0 }, '/b-body'),
+    ]
+    const edges = [
+      edge('/a-begin', '/shared'),
+      edge('/shared', '/a-end'),
+      edge('/b-begin', '/shared'),
+      edge('/shared', '/b-end'),
+    ]
+
+    const result = reconcileForLoopGroups(nodes, edges)
+
+    expect(byId(result, '/shared').parentId).toBe('/b-body')
+  })
+})

--- a/noodles-editor/src/noodles/utils/for-loop-group-utils.test.ts
+++ b/noodles-editor/src/noodles/utils/for-loop-group-utils.test.ts
@@ -74,6 +74,22 @@ describe('reconcileForLoopGroups', () => {
     expect(absolutePosition(result, '/old')).toEqual({ x: 250, y: 40 })
   })
 
+  it('clears stale membership when the final loop is missing an endpoint', () => {
+    const nodes = [
+      group('/body', { x: 100, y: 100 }),
+      node('/begin', 'ForLoopBeginOp', { x: 40, y: 40 }, '/body'),
+      node('/meta', 'ForLoopMetaOp', { x: 300, y: 40 }, '/body'),
+      node('/old', 'MathOp', { x: 550, y: 40 }, '/body'),
+    ]
+
+    const result = reconcileForLoopGroups(nodes, [])
+
+    expect(byId(result, '/begin').parentId).toBeUndefined()
+    expect(byId(result, '/meta').parentId).toBeUndefined()
+    expect(byId(result, '/old').parentId).toBeUndefined()
+    expect(absolutePosition(result, '/old')).toEqual({ x: 650, y: 140 })
+  })
+
   it('includes rejoining branches but excludes dead-end branches', () => {
     const nodes = [
       group('/body'),

--- a/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
+++ b/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
@@ -1,0 +1,156 @@
+import type { Node } from '@xyflow/react'
+import { layoutGroups } from './group-layout-utils'
+
+type GraphEdge = { source: string; target: string }
+type GraphNode = { id: string; type?: string; parentId?: string }
+
+export type ForLoopDefinition = {
+  groupId: string
+  beginId: string
+  endId: string
+  metaIds: string[]
+}
+
+type LoopGroup = {
+  groupId: string
+  beginId: string
+  endId: string
+  metaIds: string[]
+  scopeNodeIds: Set<string>
+}
+
+function reachableFrom(startId: string, adjacency: Map<string, Set<string>>): Set<string> {
+  const visited = new Set<string>()
+  const queue = [startId]
+
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    if (visited.has(id)) continue
+    visited.add(id)
+    queue.push(...(adjacency.get(id) ?? []))
+  }
+
+  return visited
+}
+
+export function findForLoopDefinitions(nodes: GraphNode[]): ForLoopDefinition[] {
+  const definitions: ForLoopDefinition[] = []
+
+  for (const group of nodes) {
+    if (group.type !== 'group') continue
+    const children = nodes.filter(node => node.parentId === group.id)
+    const begins = children.filter(node => node.type === 'ForLoopBeginOp')
+    const ends = children.filter(node => node.type === 'ForLoopEndOp')
+    if (begins.length !== 1 || ends.length !== 1) continue
+
+    definitions.push({
+      groupId: group.id,
+      beginId: begins[0].id,
+      endId: ends[0].id,
+      metaIds: children.filter(node => node.type === 'ForLoopMetaOp').map(node => node.id),
+    })
+  }
+
+  return definitions
+}
+
+function findLoopGroups(nodes: Node[], edges: GraphEdge[]): LoopGroup[] {
+  const adjacency = new Map<string, Set<string>>()
+  const reverseAdjacency = new Map<string, Set<string>>()
+
+  for (const edge of edges) {
+    if (!adjacency.has(edge.source)) adjacency.set(edge.source, new Set())
+    if (!reverseAdjacency.has(edge.target)) reverseAdjacency.set(edge.target, new Set())
+    adjacency.get(edge.source)!.add(edge.target)
+    reverseAdjacency.get(edge.target)!.add(edge.source)
+  }
+
+  const groups: LoopGroup[] = []
+  for (const definition of findForLoopDefinitions(nodes)) {
+    const { groupId, beginId, endId, metaIds } = definition
+    const downstream = reachableFrom(beginId, adjacency)
+    const upstream = reachableFrom(endId, reverseAdjacency)
+    const scopeNodeIds = new Set([...downstream].filter(id => upstream.has(id)))
+
+    groups.push({
+      groupId,
+      beginId,
+      endId,
+      metaIds,
+      scopeNodeIds,
+    })
+  }
+
+  return groups
+}
+
+function chooseOwner(node: Node, candidates: LoopGroup[]): string | undefined {
+  if (candidates.length === 0) return undefined
+  if (node.parentId && candidates.some(candidate => candidate.groupId === node.parentId)) {
+    return node.parentId
+  }
+
+  return [...candidates].sort(
+    (a, b) => a.scopeNodeIds.size - b.scopeNodeIds.size || a.groupId.localeCompare(b.groupId)
+  )[0].groupId
+}
+
+/**
+ * Makes visual ForLoop membership match the directed Begin-to-End subgraph and fits
+ * each visual group around its direct children. Screen positions are preserved when
+ * nodes enter or leave a group.
+ */
+export function reconcileForLoopGroups<TNode extends Node>(
+  nodes: TNode[],
+  edges: GraphEdge[]
+): TNode[] {
+  const loopGroups = findLoopGroups(nodes, edges)
+  if (loopGroups.length === 0) return nodes
+
+  const nodesById = new Map(nodes.map(node => [node.id, node]))
+  const loopGroupIds = new Set(loopGroups.map(group => group.groupId))
+  const candidatesByNodeId = new Map<string, LoopGroup[]>()
+
+  for (const group of loopGroups) {
+    for (const nodeId of group.scopeNodeIds) {
+      const candidates = candidatesByNodeId.get(nodeId) ?? []
+      candidates.push(group)
+      candidatesByNodeId.set(nodeId, candidates)
+    }
+  }
+
+  const desiredParent = new Map<string, string | undefined>()
+  for (const node of nodes) {
+    desiredParent.set(node.id, node.parentId)
+    if (node.type === 'group') continue
+
+    const ownLoop = loopGroups.find(
+      group =>
+        group.beginId === node.id || group.endId === node.id || group.metaIds.includes(node.id)
+    )
+    if (ownLoop) {
+      desiredParent.set(node.id, ownLoop.groupId)
+      continue
+    }
+
+    const owner = chooseOwner(node, candidatesByNodeId.get(node.id) ?? [])
+    if (owner || loopGroupIds.has(node.parentId ?? '')) {
+      desiredParent.set(node.id, owner)
+    }
+  }
+
+  // A nested loop is represented by its group inside the outer group. Its operators
+  // remain direct children of the inner group.
+  for (const loop of loopGroups) {
+    const groupNode = nodesById.get(loop.groupId)!
+    const outerCandidates = (candidatesByNodeId.get(loop.beginId) ?? []).filter(
+      candidate => candidate.groupId !== loop.groupId
+    )
+    const owner = chooseOwner(groupNode, outerCandidates)
+    if (owner || loopGroupIds.has(groupNode.parentId ?? '')) {
+      desiredParent.set(loop.groupId, owner)
+    }
+  }
+
+  return layoutGroups(nodes, loopGroupIds, desiredParent)
+}

--- a/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
+++ b/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
@@ -105,10 +105,19 @@ export function reconcileForLoopGroups<TNode extends Node>(
   edges: GraphEdge[]
 ): TNode[] {
   const loopGroups = findLoopGroups(nodes, edges)
-  if (loopGroups.length === 0) return nodes
+  const loopMarkerTypes = new Set(['ForLoopBeginOp', 'ForLoopEndOp', 'ForLoopMetaOp'])
+  const loopGroupIds = new Set(
+    nodes
+      .filter(
+        group =>
+          group.type === 'group' &&
+          nodes.some(node => node.parentId === group.id && loopMarkerTypes.has(node.type ?? ''))
+      )
+      .map(group => group.id)
+  )
+  if (loopGroupIds.size === 0) return nodes
 
   const nodesById = new Map(nodes.map(node => [node.id, node]))
-  const loopGroupIds = new Set(loopGroups.map(group => group.groupId))
   const candidatesByNodeId = new Map<string, LoopGroup[]>()
 
   for (const group of loopGroups) {
@@ -122,7 +131,10 @@ export function reconcileForLoopGroups<TNode extends Node>(
   const desiredParent = new Map<string, string | undefined>()
   for (const node of nodes) {
     desiredParent.set(node.id, node.parentId)
-    if (node.type === 'group') continue
+    if (node.type === 'group') {
+      if (loopGroupIds.has(node.parentId ?? '')) desiredParent.set(node.id, undefined)
+      continue
+    }
 
     const ownLoop = loopGroups.find(
       group =>


### PR DESCRIPTION
## Summary
Keeps serialized ForLoop visual groups synchronized with the directed Begin-to-End subgraph. This PR is the second follow-up layer above #539 and depends on #540.

## Changes
- Derive loop members from nodes that are both downstream of Begin and upstream of End.
- Add newly connected nodes to the visual group and remove disconnected former members.
- Preserve absolute canvas positions while changing `parentId`.
- Refit groups after connectivity, measurement, and drag-stop changes.
- Represent nested loops through nested group wrappers; preserve a shared node’s current valid owner when scopes overlap.

## Testing
### Unit Tests
- `npm test -- --run src/noodles/utils/group-layout-utils.test.ts src/noodles/utils/for-loop-group-utils.test.ts`
- Covered insertion, removal, rejoining and dead-end branches, nested loops, shared nodes, resizing, and coordinate preservation.

### Manual Testing
1. Create a ForLoop and insert a Number/Math node onto the Begin-to-End edge.
   - Expected: the node becomes a child of the loop group without jumping.
2. Move a grouped node inward and release it.
   - Expected: the group shrinks to fit its children with padding.
3. Reconnect the loop directly from Begin to End.
   - Expected: the disconnected former body node leaves the visual group without moving on the canvas.

## Documentation
No documentation changes needed.

## Related PRs
- Depends on #540.
- Stack root: #539.