### PR TITLE
Align ForLoop execution scope with visual membership

### DIFF
--- a/noodles-editor/src/noodles/graph-executor.test.ts
+++ b/noodles-editor/src/noodles/graph-executor.test.ts
@@ -1289,6 +1289,65 @@ describe('ForLoop execution via GraphExecutor.executeFrame()', () => {
     expect(scopes[0].beginOp).toBe(beginOp)
     expect(scopes[0].endOp).toBe(endOp)
   })
+
+  it('excludes downstream branches that do not reconnect before ForLoopEnd', () => {
+    const executor = new GraphExecutor()
+    const beginOp = new ForLoopBeginOp('/forloop-begin')
+    const bodyOp = new MathOp('/body')
+    const deadEndOp = new MathOp('/dead-end')
+    const endOp = new ForLoopEndOp('/forloop-end')
+
+    for (const op of [beginOp, bodyOp, deadEndOp, endOp]) executor.addNode(op)
+    executor.addEdge(beginOp.id, bodyOp.id)
+    executor.addEdge(bodyOp.id, endOp.id)
+    executor.addEdge(beginOp.id, deadEndOp.id)
+
+    const [scope] = executor.findForLoopScopes()
+
+    expect(scope.scopeNodeIds).toEqual([beginOp.id, bodyOp.id, endOp.id])
+    expect(scope.scopeNodeIds).not.toContain(deadEndOp.id)
+  })
+
+  it('uses visual group definitions to pair nested loop boundaries', () => {
+    const executor = new GraphExecutor()
+    const outerBegin = new ForLoopBeginOp('/outer-begin')
+    const innerBegin = new ForLoopBeginOp('/inner-begin')
+    const innerEnd = new ForLoopEndOp('/inner-end')
+    const outerEnd = new ForLoopEndOp('/outer-end')
+
+    for (const op of [outerBegin, innerBegin, innerEnd, outerEnd]) executor.addNode(op)
+    executor.addEdge(outerBegin.id, innerBegin.id)
+    executor.addEdge(innerBegin.id, innerEnd.id)
+    executor.addEdge(innerEnd.id, outerEnd.id)
+    executor.setForLoopDefinitions([
+      {
+        groupId: '/outer-body',
+        beginId: outerBegin.id,
+        endId: outerEnd.id,
+        metaIds: [],
+      },
+      {
+        groupId: '/inner-body',
+        beginId: innerBegin.id,
+        endId: innerEnd.id,
+        metaIds: [],
+      },
+    ])
+
+    const scopes = executor.findForLoopScopes()
+    const outerScope = scopes.find(scope => scope.beginOp === outerBegin)!
+    const innerScope = scopes.find(scope => scope.beginOp === innerBegin)!
+
+    expect(outerScope.endOp).toBe(outerEnd)
+    expect(outerScope.scopeNodeIds).toEqual([
+      outerBegin.id,
+      innerBegin.id,
+      innerEnd.id,
+      outerEnd.id,
+    ])
+    expect(innerScope.endOp).toBe(innerEnd)
+    expect(innerScope.scopeNodeIds).toEqual([innerBegin.id, innerEnd.id])
+  })
 })
 
 describe('GraphExecutor - ForLoop execution with executeForLoopScope', () => {

--- a/noodles-editor/src/noodles/graph-executor.test.ts
+++ b/noodles-editor/src/noodles/graph-executor.test.ts
@@ -1348,6 +1348,92 @@ describe('ForLoop execution via GraphExecutor.executeFrame()', () => {
     expect(innerScope.endOp).toBe(innerEnd)
     expect(innerScope.scopeNodeIds).toEqual([innerBegin.id, innerEnd.id])
   })
+
+  it('executes nested loop boundaries only within their parent iteration', async () => {
+    const executor = new GraphExecutor()
+    const outerBegin = new ForLoopBeginOp('/outer-begin')
+    const innerBegin = new ForLoopBeginOp('/inner-begin')
+    const innerMath = new MathOp('/inner-math')
+    const innerEnd = new ForLoopEndOp('/inner-end')
+    const outerEnd = new ForLoopEndOp('/outer-end')
+
+    outerBegin.inputs.data.setValue([
+      [1, 2],
+      [3, 4],
+    ])
+    innerBegin.inputs.data.addConnection('outer-to-inner', outerBegin.outputs.item)
+    innerMath.inputs.a.addConnection('inner-to-math', innerBegin.outputs.item)
+    innerMath.inputs.b.setValue(2)
+    innerMath.inputs.operator.setValue('multiply')
+    innerEnd.inputs.item.addConnection('math-to-inner-end', innerMath.outputs.result)
+    outerEnd.inputs.item.addConnection('inner-end-to-outer-end', innerEnd.outputs.data)
+
+    innerBegin.addUpstreamDependency(outerBegin)
+    outerBegin.addDownstreamDependent(innerBegin)
+    innerMath.addUpstreamDependency(innerBegin)
+    innerBegin.addDownstreamDependent(innerMath)
+    innerEnd.addUpstreamDependency(innerMath)
+    innerMath.addDownstreamDependent(innerEnd)
+    outerEnd.addUpstreamDependency(innerEnd)
+    innerEnd.addDownstreamDependent(outerEnd)
+
+    for (const op of [outerBegin, innerBegin, innerMath, innerEnd, outerEnd]) {
+      executor.addNode(op)
+    }
+    executor.buildFromEdges([
+      {
+        id: 'outer-to-inner',
+        source: outerBegin.id,
+        sourceHandle: 'out.item',
+        target: innerBegin.id,
+        targetHandle: 'par.data',
+      },
+      {
+        id: 'inner-to-math',
+        source: innerBegin.id,
+        sourceHandle: 'out.item',
+        target: innerMath.id,
+        targetHandle: 'par.a',
+      },
+      {
+        id: 'math-to-inner-end',
+        source: innerMath.id,
+        sourceHandle: 'out.result',
+        target: innerEnd.id,
+        targetHandle: 'par.item',
+      },
+      {
+        id: 'inner-end-to-outer-end',
+        source: innerEnd.id,
+        sourceHandle: 'out.data',
+        target: outerEnd.id,
+        targetHandle: 'par.item',
+      },
+    ])
+    executor.setForLoopDefinitions([
+      {
+        groupId: '/outer-body',
+        beginId: outerBegin.id,
+        endId: outerEnd.id,
+        metaIds: [],
+      },
+      {
+        groupId: '/inner-body',
+        beginId: innerBegin.id,
+        endId: innerEnd.id,
+        metaIds: [],
+      },
+    ])
+    const executeScope = vi.spyOn(executor, 'executeForLoopScope')
+
+    await executor.executeFrame(performance.now())
+
+    expect(outerEnd.outputs.data.value).toEqual([
+      [2, 4],
+      [6, 8],
+    ])
+    expect(executeScope.mock.calls.filter(([begin]) => begin === innerBegin)).toHaveLength(2)
+  })
 })
 
 describe('GraphExecutor - ForLoop execution with executeForLoopScope', () => {

--- a/noodles-editor/src/noodles/graph-executor.ts
+++ b/noodles-editor/src/noodles/graph-executor.ts
@@ -6,7 +6,11 @@ import { visibilityAdaptiveLoop } from '../utils/worker-timer'
 import type { Field } from './fields'
 import type { ForLoopBeginOp, ForLoopEndOp, ForLoopMetaOp, IOperator, Operator } from './operators'
 import { getAllOps } from './store'
-import type { ForLoopDefinition } from './utils/for-loop-group-utils'
+import {
+  type ForLoopDefinition,
+  findForLoopDefinitions,
+  type GraphNode,
+} from './utils/for-loop-group-utils'
 import type { OpId } from './utils/id-utils'
 
 export type ComputeResult<T = unknown> = {
@@ -140,7 +144,6 @@ type ForLoopScope = {
   endOp: ForLoopEndOp
   metaOp?: ForLoopMetaOp
   scopeNodeIds: string[]
-  groupId: string
 }
 
 // GraphExecutor - manages execution of the operator graph
@@ -650,7 +653,6 @@ export class GraphExecutor {
       endOp,
       metaOp,
       scopeNodeIds,
-      groupId: allScopes?.find(scope => scope.beginOp === beginOp)?.groupId ?? '',
     }
     const loopScopes = allScopes ?? this.findForLoopScopes()
     const nestedScopes = this.findDirectNestedForLoopScopes(currentScope, loopScopes)
@@ -852,7 +854,6 @@ export class GraphExecutor {
             endOp,
             metaOp,
             scopeNodeIds,
-            groupId: definition?.groupId ?? (op.id.split('/').slice(0, -1).join('/') || '/'),
           })
         }
       }
@@ -1020,7 +1021,7 @@ export function stopExecutor(): void {
 }
 
 // Update graph from edges - syncs nodes from the store
-export function updateGraph(edges: Edge[], forLoopDefinitions: ForLoopDefinition[] = []): void {
+export function updateGraph(nodes: GraphNode[], edges: Edge[]): void {
   if (!globalExecutor) {
     initializeExecutor()
   }
@@ -1029,7 +1030,7 @@ export function updateGraph(edges: Edge[], forLoopDefinitions: ForLoopDefinition
     globalExecutor.syncNodesFromStore()
     // Build edge relationships
     globalExecutor.buildFromEdges(edges)
-    globalExecutor.setForLoopDefinitions(forLoopDefinitions)
+    globalExecutor.setForLoopDefinitions(findForLoopDefinitions(nodes))
     // Start the RAF loop if not already running
     if (!globalExecutor.isRunning) {
       globalExecutor.start()

--- a/noodles-editor/src/noodles/graph-executor.ts
+++ b/noodles-editor/src/noodles/graph-executor.ts
@@ -135,6 +135,14 @@ export type PerformanceMetrics = {
   totalOperators: number
 }
 
+type ForLoopScope = {
+  beginOp: ForLoopBeginOp
+  endOp: ForLoopEndOp
+  metaOp?: ForLoopMetaOp
+  scopeNodeIds: string[]
+  groupId: string
+}
+
 // GraphExecutor - manages execution of the operator graph
 export class GraphExecutor {
   private nodes: Map<string, Operator<IOperator>> = new Map()
@@ -395,13 +403,22 @@ export class GraphExecutor {
     // ForLoop scopes need to complete their iterations before downstream operators can pull their results
     const forLoopScopes = this.findForLoopScopes()
 
-    for (const scope of forLoopScopes) {
+    const nestedBeginIds = new Set(
+      forLoopScopes.flatMap(parentScope =>
+        forLoopScopes
+          .filter(scope => this.isNestedForLoopScope(parentScope, scope))
+          .map(scope => scope.beginOp.id)
+      )
+    )
+
+    for (const scope of forLoopScopes.filter(scope => !nestedBeginIds.has(scope.beginOp.id))) {
       try {
         const loopResults = await this.executeForLoopScope(
           scope.beginOp,
           scope.endOp,
           scope.scopeNodeIds,
-          scope.metaOp
+          scope.metaOp,
+          forLoopScopes
         )
         results.set(scope.endOp.id, { value: { data: loopResults }, changed: true })
       } catch (error) {
@@ -612,7 +629,8 @@ export class GraphExecutor {
     beginOp: ForLoopBeginOp,
     endOp: ForLoopEndOp,
     scopeNodeIds: string[],
-    metaOp?: ForLoopMetaOp
+    metaOp?: ForLoopMetaOp,
+    allScopes?: ForLoopScope[]
   ): Promise<unknown[]> {
     // First pull beginOp to get the input data
     await beginOp.pull()
@@ -627,41 +645,54 @@ export class GraphExecutor {
     const total = data.length
     const results: unknown[] = []
 
-    // Get intermediate nodes (excluding begin, meta, end)
-    const intermediateNodeIds = scopeNodeIds.filter(
+    const currentScope: ForLoopScope = {
+      beginOp,
+      endOp,
+      metaOp,
+      scopeNodeIds,
+      groupId: allScopes?.find(scope => scope.beginOp === beginOp)?.groupId ?? '',
+    }
+    const loopScopes = allScopes ?? this.findForLoopScopes()
+    const nestedScopes = this.findDirectNestedForLoopScopes(currentScope, loopScopes)
+    const nestedScopeByNodeId = new Map<string, ForLoopScope>()
+    for (const nestedScope of nestedScopes) {
+      for (const nodeId of nestedScope.scopeNodeIds) {
+        nestedScopeByNodeId.set(nodeId, nestedScope)
+      }
+    }
+
+    // Sort the complete path so nested loops can execute atomically at the point
+    // where their Begin boundary occurs in the parent's execution order.
+    const executionNodeIds = scopeNodeIds.filter(
       id => id !== beginOp.id && id !== endOp.id && id !== metaOp?.id
     )
-
-    // Sort intermediate nodes topologically for execution order
     const scopeNodes = new Map(
-      intermediateNodeIds
+      executionNodeIds
         .map(id => [id, this.nodes.get(id)] as const)
         .filter((entry): entry is [string, Operator<IOperator>] => entry[1] !== undefined)
     )
     const scopeEdges = this.edges.filter(e => scopeNodes.has(e.source) && scopeNodes.has(e.target))
     const { sorted } = topologicalSort(scopeNodes, scopeEdges)
-    const executionOrder = sorted.map(id => this.nodes.get(id)!).filter(Boolean)
+    const executionOrder = sorted
 
     // Get initial accumulator value if meta op exists
     let accumulator: unknown = metaOp?.inputs.initialValue.value ?? null
 
     // Hoist edge lookup out of the loop for O(1) per-iteration performance
     // Instead of calling getOutputValueForField() every iteration (O(edges) scan)
-    const lastIntermediateOp = executionOrder[executionOrder.length - 1]
+    const targetHandle = this.getFieldHandle(endOp.inputs.item)
+    const connectingEdge = this.edges.find(
+      edge => edge.target === endOp.id && edge.targetHandle === targetHandle
+    )
+    const resultSourceOp = connectingEdge ? this.nodes.get(connectingEdge.source) : undefined
     let resultOutputKey: string | null = null
-    if (lastIntermediateOp) {
-      const targetHandle = this.getFieldHandle(endOp.inputs.item)
-      if (!targetHandle) {
-        console.warn(
-          `[GraphExecutor] getFieldHandle returned empty for endOp.inputs.item in ForLoop ${beginOp.id}`
-        )
-      }
-      const connectingEdge = this.edges.find(
-        edge => edge.source === lastIntermediateOp.id && edge.targetHandle === targetHandle
+    if (!targetHandle) {
+      console.warn(
+        `[GraphExecutor] getFieldHandle returned empty for endOp.inputs.item in ForLoop ${beginOp.id}`
       )
-      if (connectingEdge) {
-        resultOutputKey = connectingEdge.sourceHandle.split('.')[1] || null
-      }
+    }
+    if (connectingEdge) {
+      resultOutputKey = connectingEdge.sourceHandle.split('.')[1] || null
     }
 
     for (let index = 0; index < total; index++) {
@@ -689,19 +720,39 @@ export class GraphExecutor {
       }
 
       // Mark intermediate operators dirty for this iteration
-      for (const op of executionOrder) {
-        op.markDirty()
+      for (const nodeId of executionOrder) {
+        this.nodes.get(nodeId)?.markDirty()
       }
 
-      // Pull each intermediate operator in order
-      for (const op of executionOrder) {
-        await op.pull()
+      // Pull ordinary operators in order. A nested loop executes once, as an
+      // atomic operation, when its Begin boundary is reached; the parent skips
+      // the rest of that loop's internal nodes.
+      const executedNestedScopes = new Set<string>()
+      for (const nodeId of executionOrder) {
+        const nestedScope = nestedScopeByNodeId.get(nodeId)
+        if (nestedScope) {
+          if (
+            nodeId === nestedScope.beginOp.id &&
+            !executedNestedScopes.has(nestedScope.beginOp.id)
+          ) {
+            await this.executeForLoopScope(
+              nestedScope.beginOp,
+              nestedScope.endOp,
+              nestedScope.scopeNodeIds,
+              nestedScope.metaOp,
+              loopScopes
+            )
+            executedNestedScopes.add(nestedScope.beginOp.id)
+          }
+          continue
+        }
+        await this.nodes.get(nodeId)?.pull()
       }
 
       // Collect result from this iteration using pre-computed output key
       const resultValue =
-        lastIntermediateOp && resultOutputKey && lastIntermediateOp._cachedOutput
-          ? (lastIntermediateOp._cachedOutput[resultOutputKey] ?? endOp.inputs.item.value)
+        resultSourceOp && resultOutputKey && resultSourceOp._cachedOutput
+          ? (resultSourceOp._cachedOutput[resultOutputKey] ?? endOp.inputs.item.value)
           : executionOrder.length > 0
             ? endOp.inputs.item.value
             : beginOp.outputs.item.value
@@ -720,22 +771,32 @@ export class GraphExecutor {
     return results
   }
 
+  private isNestedForLoopScope(parent: ForLoopScope, child: ForLoopScope): boolean {
+    return (
+      parent.beginOp !== child.beginOp &&
+      parent.scopeNodeIds.includes(child.beginOp.id) &&
+      parent.scopeNodeIds.includes(child.endOp.id)
+    )
+  }
+
+  private findDirectNestedForLoopScopes(
+    parent: ForLoopScope,
+    scopes: ForLoopScope[]
+  ): ForLoopScope[] {
+    const nestedScopes = scopes.filter(scope => this.isNestedForLoopScope(parent, scope))
+    return nestedScopes.filter(
+      child =>
+        !nestedScopes.some(
+          possibleParent =>
+            possibleParent !== child && this.isNestedForLoopScope(possibleParent, child)
+        )
+    )
+  }
+
   // Find ForLoop scopes in the graph. A scope contains only nodes that are both
   // downstream of Begin and upstream of its paired End (nodes on a Begin-to-End path).
-  findForLoopScopes(): Array<{
-    beginOp: ForLoopBeginOp
-    endOp: ForLoopEndOp
-    metaOp?: ForLoopMetaOp
-    scopeNodeIds: string[]
-    groupId: string
-  }> {
-    const scopes: Array<{
-      beginOp: ForLoopBeginOp
-      endOp: ForLoopEndOp
-      metaOp?: ForLoopMetaOp
-      scopeNodeIds: string[]
-      groupId: string
-    }> = []
+  findForLoopScopes(): ForLoopScope[] {
+    const scopes: ForLoopScope[] = []
 
     const reachable = (startId: string, graph: Map<string, Set<string>>): Set<string> => {
       const visited = new Set<string>()

--- a/noodles-editor/src/noodles/graph-executor.ts
+++ b/noodles-editor/src/noodles/graph-executor.ts
@@ -6,6 +6,7 @@ import { visibilityAdaptiveLoop } from '../utils/worker-timer'
 import type { Field } from './fields'
 import type { ForLoopBeginOp, ForLoopEndOp, ForLoopMetaOp, IOperator, Operator } from './operators'
 import { getAllOps } from './store'
+import type { ForLoopDefinition } from './utils/for-loop-group-utils'
 import type { OpId } from './utils/id-utils'
 
 export type ComputeResult<T = unknown> = {
@@ -142,6 +143,7 @@ export class GraphExecutor {
   private downstream: Map<string, Set<string>> = new Map()
   private sortedOrder: string[] = []
   private executionLevels: string[][] = []
+  private forLoopDefinitions: ForLoopDefinition[] = []
   private isDirty = true
   private options: Required<ExecutorOptions>
   // Track nodes added directly via addNode() (not from store sync)
@@ -173,6 +175,10 @@ export class GraphExecutor {
       enableProfiling: options.enableProfiling ?? false,
     }
     this.frameInterval = 1000 / this.options.targetFPS
+  }
+
+  setForLoopDefinitions(definitions: ForLoopDefinition[]): void {
+    this.forLoopDefinitions = definitions
   }
 
   // Start the execution loop
@@ -714,7 +720,8 @@ export class GraphExecutor {
     return results
   }
 
-  // Find ForLoop scopes in the graph (ForLoopBegin + ForLoopEnd pairs within same group)
+  // Find ForLoop scopes in the graph. A scope contains only nodes that are both
+  // downstream of Begin and upstream of its paired End (nodes on a Begin-to-End path).
   findForLoopScopes(): Array<{
     beginOp: ForLoopBeginOp
     endOp: ForLoopEndOp
@@ -730,50 +737,61 @@ export class GraphExecutor {
       groupId: string
     }> = []
 
+    const reachable = (startId: string, graph: Map<string, Set<string>>): Set<string> => {
+      const visited = new Set<string>()
+      const queue = [startId]
+      while (queue.length > 0) {
+        const id = queue.shift()!
+        if (visited.has(id)) continue
+        visited.add(id)
+        queue.push(...(graph.get(id) ?? []))
+      }
+      return visited
+    }
+
+    const definitionByBeginId = new Map(
+      this.forLoopDefinitions.map(definition => [definition.beginId, definition])
+    )
+
     // Find all ForLoopBeginOp nodes
     for (const [_, op] of this.nodes) {
       const opType = (op.constructor as { displayName?: string }).displayName
       if (opType === 'ForLoopBegin') {
-        // Find the corresponding ForLoopEndOp by traversing downstream
-        const visited = new Set<string>()
-        const queue = [op.id]
-        let endOp: ForLoopEndOp | undefined
-        let metaOp: ForLoopMetaOp | undefined
-        const scopeNodeIds: string[] = [op.id]
-
-        while (queue.length > 0) {
-          const nodeId = queue.shift()!
-          if (visited.has(nodeId)) continue
-          visited.add(nodeId)
-
-          const downstream = this.getDownstream(nodeId)
-          for (const downstreamId of downstream) {
-            const downstreamNode = this.nodes.get(downstreamId)
-            if (!downstreamNode) continue
-
-            const downstreamType = (downstreamNode.constructor as { displayName?: string })
-              .displayName
-            if (downstreamType === 'ForLoopEnd') {
-              endOp = downstreamNode as ForLoopEndOp
-              scopeNodeIds.push(downstreamId)
-            } else if (downstreamType === 'ForLoopMeta') {
-              metaOp = downstreamNode as ForLoopMetaOp
-              scopeNodeIds.push(downstreamId)
-              queue.push(downstreamId)
-            } else {
-              scopeNodeIds.push(downstreamId)
-              queue.push(downstreamId)
-            }
-          }
-        }
+        const definition = definitionByBeginId.get(op.id)
+        const downstream = reachable(op.id, this.downstream)
+        const configuredEnd = definition ? this.nodes.get(definition.endId) : undefined
+        const inferredEnd = [...downstream]
+          .map(id => this.nodes.get(id))
+          .find(
+            candidate =>
+              (candidate?.constructor as { displayName?: string } | undefined)?.displayName ===
+              'ForLoopEnd'
+          )
+        const endOp = (configuredEnd ?? inferredEnd) as ForLoopEndOp | undefined
 
         if (endOp) {
+          const upstream = reachable(endOp.id, this.upstream)
+          const scopeNodeIds = [...this.nodes.keys()].filter(
+            id => downstream.has(id) && upstream.has(id)
+          )
+          const configuredMeta = definition?.metaIds
+            .map(id => this.nodes.get(id))
+            .find(candidate => candidate && scopeNodeIds.includes(candidate.id))
+          const inferredMeta = scopeNodeIds
+            .map(id => this.nodes.get(id))
+            .find(
+              candidate =>
+                (candidate?.constructor as { displayName?: string } | undefined)?.displayName ===
+                'ForLoopMeta'
+            )
+          const metaOp = (configuredMeta ?? inferredMeta) as ForLoopMetaOp | undefined
+
           scopes.push({
             beginOp: op as ForLoopBeginOp,
             endOp,
             metaOp,
             scopeNodeIds,
-            groupId: op.id.split('/').slice(0, -1).join('/') || '/',
+            groupId: definition?.groupId ?? (op.id.split('/').slice(0, -1).join('/') || '/'),
           })
         }
       }
@@ -941,7 +959,7 @@ export function stopExecutor(): void {
 }
 
 // Update graph from edges - syncs nodes from the store
-export function updateGraph(edges: Edge[]): void {
+export function updateGraph(edges: Edge[], forLoopDefinitions: ForLoopDefinition[] = []): void {
   if (!globalExecutor) {
     initializeExecutor()
   }
@@ -950,6 +968,7 @@ export function updateGraph(edges: Edge[]): void {
     globalExecutor.syncNodesFromStore()
     // Build edge relationships
     globalExecutor.buildFromEdges(edges)
+    globalExecutor.setForLoopDefinitions(forLoopDefinitions)
     // Start the RAF loop if not already running
     if (!globalExecutor.isRunning) {
       globalExecutor.start()

--- a/noodles-editor/src/noodles/transform-graph.test.ts
+++ b/noodles-editor/src/noodles/transform-graph.test.ts
@@ -1,5 +1,6 @@
 import type { Node as ReactFlowNode } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getExecutor } from './graph-executor'
 import type { Edge } from './noodles'
 import {
   type CodeOp,
@@ -271,6 +272,82 @@ describe('transform-graph stale edge and unknown type warnings', () => {
       String(call[0]).includes('Unknown operator type')
     )
     expect(unknownTypeErrors).toHaveLength(0)
+  })
+
+  it('passes visual group definitions to the executor for nested loop pairing', () => {
+    const nodes = [
+      {
+        id: '/outer-body',
+        type: 'group',
+        data: {},
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '/outer-begin',
+        type: 'ForLoopBeginOp',
+        data: { inputs: {} },
+        position: { x: 0, y: 0 },
+        parentId: '/outer-body',
+      },
+      {
+        id: '/outer-end',
+        type: 'ForLoopEndOp',
+        data: { inputs: {} },
+        position: { x: 900, y: 0 },
+        parentId: '/outer-body',
+      },
+      {
+        id: '/inner-body',
+        type: 'group',
+        data: {},
+        position: { x: 300, y: 100 },
+      },
+      {
+        id: '/inner-begin',
+        type: 'ForLoopBeginOp',
+        data: { inputs: {} },
+        position: { x: 0, y: 0 },
+        parentId: '/inner-body',
+      },
+      {
+        id: '/inner-end',
+        type: 'ForLoopEndOp',
+        data: { inputs: {} },
+        position: { x: 300, y: 0 },
+        parentId: '/inner-body',
+      },
+    ]
+    const edges = [
+      {
+        id: '/outer-begin.out.item->/inner-begin.par.data',
+        source: '/outer-begin',
+        target: '/inner-begin',
+        sourceHandle: 'out.item',
+        targetHandle: 'par.data',
+      },
+      {
+        id: '/inner-begin.out.item->/inner-end.par.item',
+        source: '/inner-begin',
+        target: '/inner-end',
+        sourceHandle: 'out.item',
+        targetHandle: 'par.item',
+      },
+      {
+        id: '/inner-end.out.data->/outer-end.par.item',
+        source: '/inner-end',
+        target: '/outer-end',
+        sourceHandle: 'out.data',
+        targetHandle: 'par.item',
+      },
+    ]
+
+    transformGraph({ nodes, edges })
+
+    const scopes = getExecutor()!.findForLoopScopes()
+    const outerScope = scopes.find(scope => scope.beginOp.id === '/outer-begin')!
+    const innerScope = scopes.find(scope => scope.beginOp.id === '/inner-begin')!
+    expect(outerScope.endOp.id).toBe('/outer-end')
+    expect(innerScope.endOp.id).toBe('/inner-end')
   })
 
   it('sets a connection error on the target operator when source node is missing', () => {

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -7,7 +7,6 @@ import type { IOperator, Operator, OpType } from './operators'
 import { ContainerOp, ForLoopEndOp, GraphInputOp, opTypes, type SpecialNodeType } from './operators'
 import { getOpStore } from './store'
 import { validateConnection } from './utils/can-connect'
-import { findForLoopDefinitions } from './utils/for-loop-group-utils'
 import { getParentPath, isDirectChild, parseHandleId } from './utils/path-utils'
 import { computeVisibilityHeuristic } from './utils/visibility-heuristic'
 
@@ -205,7 +204,7 @@ export function transformGraph<
   })
 
   // Update dependency graph
-  updateGraph(edges as unknown as ExecutorEdge[], findForLoopDefinitions(_nodes))
+  updateGraph(_nodes, edges as unknown as ExecutorEdge[])
 
   // Remove any connections that are not in the edges array.
   // Also clear connection errors for removed edges.

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -7,6 +7,7 @@ import type { IOperator, Operator, OpType } from './operators'
 import { ContainerOp, ForLoopEndOp, GraphInputOp, opTypes, type SpecialNodeType } from './operators'
 import { getOpStore } from './store'
 import { validateConnection } from './utils/can-connect'
+import { findForLoopDefinitions } from './utils/for-loop-group-utils'
 import { getParentPath, isDirectChild, parseHandleId } from './utils/path-utils'
 import { computeVisibilityHeuristic } from './utils/visibility-heuristic'
 
@@ -204,7 +205,7 @@ export function transformGraph<
   })
 
   // Update dependency graph
-  updateGraph(edges as unknown as ExecutorEdge[])
+  updateGraph(edges as unknown as ExecutorEdge[], findForLoopDefinitions(nodes))
 
   // Remove any connections that are not in the edges array.
   // Also clear connection errors for removed edges.

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -205,7 +205,7 @@ export function transformGraph<
   })
 
   // Update dependency graph
-  updateGraph(edges as unknown as ExecutorEdge[], findForLoopDefinitions(nodes))
+  updateGraph(edges as unknown as ExecutorEdge[], findForLoopDefinitions(_nodes))
 
   // Remove any connections that are not in the edges array.
   // Also clear connection errors for removed edges.

--- a/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
+++ b/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
@@ -2,7 +2,7 @@ import type { Node } from '@xyflow/react'
 import { layoutGroups } from './group-layout-utils'
 
 type GraphEdge = { source: string; target: string }
-type GraphNode = { id: string; type?: string; parentId?: string }
+export type GraphNode = { id: string; type?: string; parentId?: string }
 
 export type ForLoopDefinition = {
   groupId: string


### PR DESCRIPTION
## Summary

Uses the same paired Begin-to-End path definition for loop execution that the preceding visual-membership PR uses for rendering. This is the execution layer in the stack above #539.

## Changes

- Pass serialized visual nodes and edges to `updateGraph`, which derives and installs visual-group Begin/End/Meta definitions centrally.
- Restrict execution scope to nodes that are downstream of Begin and upstream of the paired End.
- Exclude downstream dead-end branches that cannot contribute to End.
- Pair nested loop boundaries from their visual groups instead of stopping at the first reachable End.
- Execute nested loops atomically within each parent iteration so their boundaries and internal operators are not pulled twice.
- Remove unused execution-scope `groupId` state and path-based group inference.

## Testing

### Automated

- `npm test -- --run` — 2,682 passed, 10 skipped.
- Regression coverage for dead-end branches, nested boundary pairing, and nested-loop execution counts.
- `npm run lint`
- `npm run format:check`
- `npm run build`

### Manual

1. Insert an operator into a ForLoop Begin-to-End chain and provide an input array.
   - Expected: the inserted operator runs once per item and the End output collects its results.
2. Add a branch from Begin that does not reconnect to End.
   - Expected: the dead-end branch is not part of loop iteration scope.
3. Place a complete inner ForLoop on the outer Begin-to-End path.
   - Expected: each Begin is paired with its visual group End, and the inner loop runs once per outer item.

## Documentation

No documentation changes needed.

## Related PRs

- Depends on #541.
- Earlier stack layers: #540 and #539.
- Followed by migration PR #544.
