### PR TITLE
fix: migrate legacy for loop groups

### DIFF
--- a/noodles-editor/public/noodles/table-editor-demo.json
+++ b/noodles-editor/public/noodles/table-editor-demo.json
@@ -1,5 +1,5 @@
 {
-  "version": 15,
+  "version": 16,
   "edges": [
     {
       "id": "/cities-table.out.data->/scatter.par.data",

--- a/noodles-editor/src/examples/aggregation-example/noodles.json
+++ b/noodles-editor/src/examples/aggregation-example/noodles.json
@@ -97,7 +97,7 @@
     "y": 907.0984953781293,
     "zoom": 0.8019816514742112
   },
-  "version": 15,
+  "version": 16,
   "name": "SF Bike Parking Aggregation",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/california-earthquakes/noodles.json
+++ b/noodles-editor/src/examples/california-earthquakes/noodles.json
@@ -83,7 +83,7 @@
     "y": 172.88548024794358,
     "zoom": 0.4813563009649149
   },
-  "version": 15,
+  "version": 16,
   "name": "California Earthquakes",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/cesium-hubble/noodles.json
+++ b/noodles-editor/src/examples/cesium-hubble/noodles.json
@@ -1,5 +1,5 @@
 {
-  "version": 15,
+  "version": 16,
   "edges": [
     {
       "id": "/basemap.out.maplibre->/renderer.par.basemap",

--- a/noodles-editor/src/examples/chargers/noodles.json
+++ b/noodles-editor/src/examples/chargers/noodles.json
@@ -4,7 +4,7 @@
     "y": 562.2542727922879,
     "zoom": 0.5709600637849074
   },
-  "version": 15,
+  "version": 16,
   "name": "EV Chargers with Live API Data",
   "edges": [
     {

--- a/noodles-editor/src/examples/custom-maplibre-layer-test/noodles.json
+++ b/noodles-editor/src/examples/custom-maplibre-layer-test/noodles.json
@@ -1,5 +1,5 @@
 {
-  "version": 15,
+  "version": 16,
   "edges": [
     {
       "id": "/maplibre-basemap.maplibre->/deck-renderer.basemap",

--- a/noodles-editor/src/examples/geojson-example/noodles.json
+++ b/noodles-editor/src/examples/geojson-example/noodles.json
@@ -55,7 +55,7 @@
     "y": 46.884631018890104,
     "zoom": 0.5895523675768745
   },
-  "version": 15,
+  "version": 16,
   "name": "GeoJSON BART Stations",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/nyc-census/noodles.json
+++ b/noodles-editor/src/examples/nyc-census/noodles.json
@@ -69,7 +69,7 @@
     "y": 75.01093484232683,
     "zoom": 0.4556733508888464
   },
-  "version": 15,
+  "version": 16,
   "name": "NYC Census",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/nyc-taxis/noodles.json
+++ b/noodles-editor/src/examples/nyc-taxis/noodles.json
@@ -139,7 +139,7 @@
     "y": 204.01752158305402,
     "zoom": 0.467987771000214
   },
-  "version": 15,
+  "version": 16,
   "name": "NYC Taxis",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/orbit/noodles.json
+++ b/noodles-editor/src/examples/orbit/noodles.json
@@ -34,7 +34,7 @@
     "y": 546.6972278664407,
     "zoom": 0.981085979917294
   },
-  "version": 15,
+  "version": 16,
   "name": "Orbit View 3D Scene",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/sf-elevation-contours/noodles.json
+++ b/noodles-editor/src/examples/sf-elevation-contours/noodles.json
@@ -55,7 +55,7 @@
     "y": 48.131400370141876,
     "zoom": 0.42504626773596543
   },
-  "version": 15,
+  "version": 16,
   "name": "San Francisco Elevation Contours",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/simple-mesh-example/noodles.json
+++ b/noodles-editor/src/examples/simple-mesh-example/noodles.json
@@ -55,7 +55,7 @@
     "y": 608.5965459146154,
     "zoom": 1.2637785153212067
   },
-  "version": 15,
+  "version": 16,
   "name": "Simple Mesh Layer BART Stations",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/uk-commute/noodles.json
+++ b/noodles-editor/src/examples/uk-commute/noodles.json
@@ -139,7 +139,7 @@
     "y": 138.99036470751906,
     "zoom": 0.46798777100021355
   },
-  "version": 15,
+  "version": 16,
   "name": "UK Commute Patterns",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/us-county-unemployment/noodles.json
+++ b/noodles-editor/src/examples/us-county-unemployment/noodles.json
@@ -83,7 +83,7 @@
     "y": 206.86749887589406,
     "zoom": 0.6158038261288714
   },
-  "version": 15,
+  "version": 16,
   "name": "US County Unemployment",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/examples/world-flights/noodles.json
+++ b/noodles-editor/src/examples/world-flights/noodles.json
@@ -160,7 +160,7 @@
     "y": 461.29570352289136,
     "zoom": 0.5265126624852493
   },
-  "version": 15,
+  "version": 16,
   "name": "World Flights",
   "editorSettings": {
     "layoutMode": "noodles-on-top",

--- a/noodles-editor/src/noodles/__migrations__/016-repair-forloop-groups.test.ts
+++ b/noodles-editor/src/noodles/__migrations__/016-repair-forloop-groups.test.ts
@@ -1,0 +1,125 @@
+import type { Edge, Node } from '@xyflow/react'
+import { describe, expect, it } from 'vitest'
+import type { NoodlesProjectJSON } from '../utils/serialization'
+import { down, up } from './016-repair-forloop-groups'
+
+function node(
+  id: string,
+  type: string,
+  position: { x: number; y: number },
+  parentId?: string
+): Node {
+  return { id, type, position, parentId, width: 100, height: 60, data: {} }
+}
+
+function edge(source: string, target: string): Edge {
+  return { id: `${source}->${target}`, source, target }
+}
+
+function absolutePosition(nodes: Node[], id: string): { x: number; y: number } {
+  const current = nodes.find(node => node.id === id)!
+  if (!current.parentId) return current.position
+  const parent = absolutePosition(nodes, current.parentId)
+  return { x: parent.x + current.position.x, y: parent.y + current.position.y }
+}
+
+function makeProject(nodes: Node[], edges: Edge[]): NoodlesProjectJSON {
+  return {
+    version: 15,
+    nodes,
+    edges,
+    viewport: { x: 0, y: 0, zoom: 1 },
+    timeline: {},
+  }
+}
+
+describe('016-repair-forloop-groups', () => {
+  it('reconstructs unique groups for legacy unparented loop triplets', async () => {
+    const nodes: Node[] = [
+      {
+        id: '/for-loop-body',
+        type: 'group',
+        position: { x: -5000, y: -4000 },
+        style: { width: 12000, height: 7000 },
+        data: {},
+      },
+      node('/for-loop-begin', 'ForLoopBeginOp', { x: -4300, y: 900 }),
+      node('/first-body', 'MathOp', { x: -3900, y: 900 }),
+      node('/for-loop-end', 'ForLoopEndOp', { x: -3400, y: 900 }),
+      node('/for-loop-meta', 'ForLoopMetaOp', { x: -3800, y: 1200 }),
+      node('/for-loop-begin-1', 'ForLoopBeginOp', { x: 2000, y: -3600 }),
+      node('/second-body', 'MathOp', { x: 3500, y: -3600 }),
+      node('/for-loop-end-1', 'ForLoopEndOp', { x: 4800, y: -3600 }),
+      node('/for-loop-meta-1', 'ForLoopMetaOp', { x: 3500, y: -3100 }),
+      node('/for-loop-begin-2', 'ForLoopBeginOp', { x: -700, y: -4700 }),
+      node('/third-body', 'MathOp', { x: -300, y: -4700 }),
+      node('/for-loop-end-2', 'ForLoopEndOp', { x: 100, y: -4700 }),
+      node('/for-loop-meta-2', 'ForLoopMetaOp', { x: -300, y: -4400 }),
+      node('/unrelated', 'MathOp', { x: 7000, y: 7000 }),
+    ]
+    const edges = [
+      edge('/for-loop-begin', '/first-body'),
+      edge('/first-body', '/for-loop-end'),
+      edge('/for-loop-begin-1', '/second-body'),
+      edge('/second-body', '/for-loop-end-1'),
+      edge('/for-loop-begin-2', '/third-body'),
+      edge('/third-body', '/for-loop-end-2'),
+    ]
+    const originalPositions = new Map(
+      nodes
+        .filter(current => current.type !== 'group')
+        .map(current => [current.id, absolutePosition(nodes, current.id)])
+    )
+
+    const migrated = await up(makeProject(nodes, edges))
+    const migratedNodes = migrated.nodes as Node[]
+
+    expect(
+      migratedNodes.filter(current => current.type === 'group').map(current => current.id)
+    ).toEqual(['/for-loop-body', '/for-loop-body-1', '/for-loop-body-2'])
+    for (const suffix of ['', '-1', '-2']) {
+      const groupId = `/for-loop-body${suffix}`
+      expect(
+        migratedNodes.find(current => current.id === `/for-loop-begin${suffix}`)?.parentId
+      ).toBe(groupId)
+      expect(migratedNodes.find(current => current.id === `/for-loop-end${suffix}`)?.parentId).toBe(
+        groupId
+      )
+      expect(
+        migratedNodes.find(current => current.id === `/for-loop-meta${suffix}`)?.parentId
+      ).toBe(groupId)
+    }
+    expect(migratedNodes.find(current => current.id === '/first-body')?.parentId).toBe(
+      '/for-loop-body'
+    )
+    expect(migratedNodes.find(current => current.id === '/second-body')?.parentId).toBe(
+      '/for-loop-body-1'
+    )
+    expect(migratedNodes.find(current => current.id === '/third-body')?.parentId).toBe(
+      '/for-loop-body-2'
+    )
+    expect(migratedNodes.find(current => current.id === '/unrelated')?.parentId).toBeUndefined()
+    for (const [id, position] of originalPositions) {
+      expect(absolutePosition(migratedNodes, id)).toEqual(position)
+    }
+  })
+
+  it('does not guess when generated boundaries are incomplete or disconnected', async () => {
+    const nodes = [
+      node('/for-loop-begin', 'ForLoopBeginOp', { x: 0, y: 0 }),
+      node('/for-loop-end', 'ForLoopEndOp', { x: 500, y: 0 }),
+      node('/for-loop-begin-1', 'ForLoopBeginOp', { x: 0, y: 300 }),
+    ]
+    const project = makeProject(nodes, [])
+
+    const migrated = await up(project)
+
+    expect(migrated).toBe(project)
+  })
+
+  it('keeps repaired v16 group data when migrating down', async () => {
+    const project = makeProject([], [])
+
+    expect(await down(project)).toBe(project)
+  })
+})

--- a/noodles-editor/src/noodles/__migrations__/016-repair-forloop-groups.test.ts
+++ b/noodles-editor/src/noodles/__migrations__/016-repair-forloop-groups.test.ts
@@ -34,36 +34,38 @@ function makeProject(nodes: Node[], edges: Edge[]): NoodlesProjectJSON {
 }
 
 describe('016-repair-forloop-groups', () => {
-  it('reconstructs unique groups for legacy unparented loop triplets', async () => {
+  it('reconstructs unique groups from operator types and connectivity after markers are renamed', async () => {
     const nodes: Node[] = [
       {
-        id: '/for-loop-body',
+        id: '/legacy-loop-shell',
         type: 'group',
         position: { x: -5000, y: -4000 },
         style: { width: 12000, height: 7000 },
+        selectable: false,
+        draggable: false,
         data: {},
       },
-      node('/for-loop-begin', 'ForLoopBeginOp', { x: -4300, y: 900 }),
+      node('/start-alpha', 'ForLoopBeginOp', { x: -4300, y: 900 }),
       node('/first-body', 'MathOp', { x: -3900, y: 900 }),
-      node('/for-loop-end', 'ForLoopEndOp', { x: -3400, y: 900 }),
-      node('/for-loop-meta', 'ForLoopMetaOp', { x: -3800, y: 1200 }),
-      node('/for-loop-begin-1', 'ForLoopBeginOp', { x: 2000, y: -3600 }),
+      node('/finish-alpha', 'ForLoopEndOp', { x: -3400, y: 900 }),
+      node('/meta-near-alpha', 'ForLoopMetaOp', { x: -3800, y: 1200 }),
+      node('/renamed-start', 'ForLoopBeginOp', { x: 2000, y: -3600 }),
       node('/second-body', 'MathOp', { x: 3500, y: -3600 }),
-      node('/for-loop-end-1', 'ForLoopEndOp', { x: 4800, y: -3600 }),
-      node('/for-loop-meta-1', 'ForLoopMetaOp', { x: 3500, y: -3100 }),
-      node('/for-loop-begin-2', 'ForLoopBeginOp', { x: -700, y: -4700 }),
+      node('/renamed-finish', 'ForLoopEndOp', { x: 4800, y: -3600 }),
+      node('/unrelated-meta-name', 'ForLoopMetaOp', { x: 3500, y: -3100 }),
+      node('/loop-entry-custom', 'ForLoopBeginOp', { x: -700, y: -4700 }),
       node('/third-body', 'MathOp', { x: -300, y: -4700 }),
-      node('/for-loop-end-2', 'ForLoopEndOp', { x: 100, y: -4700 }),
-      node('/for-loop-meta-2', 'ForLoopMetaOp', { x: -300, y: -4400 }),
+      node('/loop-exit-custom', 'ForLoopEndOp', { x: 100, y: -4700 }),
+      node('/metadata-custom', 'ForLoopMetaOp', { x: -300, y: -4400 }),
       node('/unrelated', 'MathOp', { x: 7000, y: 7000 }),
     ]
     const edges = [
-      edge('/for-loop-begin', '/first-body'),
-      edge('/first-body', '/for-loop-end'),
-      edge('/for-loop-begin-1', '/second-body'),
-      edge('/second-body', '/for-loop-end-1'),
-      edge('/for-loop-begin-2', '/third-body'),
-      edge('/third-body', '/for-loop-end-2'),
+      edge('/start-alpha', '/first-body'),
+      edge('/first-body', '/finish-alpha'),
+      edge('/renamed-start', '/second-body'),
+      edge('/second-body', '/renamed-finish'),
+      edge('/loop-entry-custom', '/third-body'),
+      edge('/third-body', '/loop-exit-custom'),
     ]
     const originalPositions = new Map(
       nodes
@@ -76,27 +78,24 @@ describe('016-repair-forloop-groups', () => {
 
     expect(
       migratedNodes.filter(current => current.type === 'group').map(current => current.id)
-    ).toEqual(['/for-loop-body', '/for-loop-body-1', '/for-loop-body-2'])
-    for (const suffix of ['', '-1', '-2']) {
-      const groupId = `/for-loop-body${suffix}`
-      expect(
-        migratedNodes.find(current => current.id === `/for-loop-begin${suffix}`)?.parentId
-      ).toBe(groupId)
-      expect(migratedNodes.find(current => current.id === `/for-loop-end${suffix}`)?.parentId).toBe(
-        groupId
-      )
-      expect(
-        migratedNodes.find(current => current.id === `/for-loop-meta${suffix}`)?.parentId
-      ).toBe(groupId)
+    ).toEqual(['/legacy-loop-shell', '/for-loop-body', '/for-loop-body-1'])
+    for (const [beginId, endId, metaId, groupId] of [
+      ['/start-alpha', '/finish-alpha', '/meta-near-alpha', '/legacy-loop-shell'],
+      ['/renamed-start', '/renamed-finish', '/unrelated-meta-name', '/for-loop-body'],
+      ['/loop-entry-custom', '/loop-exit-custom', '/metadata-custom', '/for-loop-body-1'],
+    ]) {
+      expect(migratedNodes.find(current => current.id === beginId)?.parentId).toBe(groupId)
+      expect(migratedNodes.find(current => current.id === endId)?.parentId).toBe(groupId)
+      expect(migratedNodes.find(current => current.id === metaId)?.parentId).toBe(groupId)
     }
     expect(migratedNodes.find(current => current.id === '/first-body')?.parentId).toBe(
-      '/for-loop-body'
+      '/legacy-loop-shell'
     )
     expect(migratedNodes.find(current => current.id === '/second-body')?.parentId).toBe(
-      '/for-loop-body-1'
+      '/for-loop-body'
     )
     expect(migratedNodes.find(current => current.id === '/third-body')?.parentId).toBe(
-      '/for-loop-body-2'
+      '/for-loop-body-1'
     )
     expect(migratedNodes.find(current => current.id === '/unrelated')?.parentId).toBeUndefined()
     for (const [id, position] of originalPositions) {
@@ -104,17 +103,42 @@ describe('016-repair-forloop-groups', () => {
     }
   })
 
-  it('does not guess when generated boundaries are incomplete or disconnected', async () => {
+  it('does not guess when boundaries are incomplete or disconnected', async () => {
     const nodes = [
-      node('/for-loop-begin', 'ForLoopBeginOp', { x: 0, y: 0 }),
-      node('/for-loop-end', 'ForLoopEndOp', { x: 500, y: 0 }),
-      node('/for-loop-begin-1', 'ForLoopBeginOp', { x: 0, y: 300 }),
+      node('/start', 'ForLoopBeginOp', { x: 0, y: 0 }),
+      node('/finish', 'ForLoopEndOp', { x: 500, y: 0 }),
+      node('/another-start', 'ForLoopBeginOp', { x: 0, y: 300 }),
     ]
     const project = makeProject(nodes, [])
 
     const migrated = await up(project)
 
     expect(migrated).toBe(project)
+  })
+
+  it('pairs nested boundaries from the inside out', async () => {
+    const nodes = [
+      node('/outer-start', 'ForLoopBeginOp', { x: 0, y: 0 }),
+      node('/inner-start', 'ForLoopBeginOp', { x: 300, y: 100 }),
+      node('/inner-finish', 'ForLoopEndOp', { x: 600, y: 100 }),
+      node('/outer-finish', 'ForLoopEndOp', { x: 900, y: 0 }),
+    ]
+    const edges = [
+      edge('/outer-start', '/inner-start'),
+      edge('/inner-start', '/inner-finish'),
+      edge('/inner-finish', '/outer-finish'),
+    ]
+
+    const migrated = await up(makeProject(nodes, edges))
+    const migratedNodes = migrated.nodes as Node[]
+    const innerGroupId = migratedNodes.find(node => node.id === '/inner-start')?.parentId
+    const outerGroupId = migratedNodes.find(node => node.id === '/outer-start')?.parentId
+
+    expect(innerGroupId).toBe('/for-loop-body')
+    expect(outerGroupId).toBe('/for-loop-body-1')
+    expect(migratedNodes.find(node => node.id === '/inner-finish')?.parentId).toBe(innerGroupId)
+    expect(migratedNodes.find(node => node.id === '/outer-finish')?.parentId).toBe(outerGroupId)
+    expect(migratedNodes.find(node => node.id === innerGroupId)?.parentId).toBe(outerGroupId)
   })
 
   it('keeps repaired v16 group data when migrating down', async () => {

--- a/noodles-editor/src/noodles/__migrations__/016-repair-forloop-groups.ts
+++ b/noodles-editor/src/noodles/__migrations__/016-repair-forloop-groups.ts
@@ -1,0 +1,15 @@
+import type { Node } from '@xyflow/react'
+import { repairLegacyForLoopGroups } from '../utils/for-loop-group-utils'
+import type { NoodlesProjectJSON } from '../utils/serialization'
+
+export async function up(project: NoodlesProjectJSON): Promise<NoodlesProjectJSON> {
+  const nodes = repairLegacyForLoopGroups(project.nodes as Node[], project.edges)
+  if (nodes === project.nodes) return project
+  return { ...project, nodes }
+}
+
+// The repaired representation is valid in v15, and the original malformed
+// parent assignments cannot be reconstructed safely.
+export async function down(project: NoodlesProjectJSON): Promise<NoodlesProjectJSON> {
+  return project
+}

--- a/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
+++ b/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
@@ -11,13 +11,6 @@ export type ForLoopDefinition = {
   metaIds: string[]
 }
 
-const LOOP_BEGIN_SUFFIX = /for-loop-begin(-\d+)?$/
-
-function relatedLoopId(beginId: string, part: 'body' | 'end' | 'meta'): string | undefined {
-  if (!LOOP_BEGIN_SUFFIX.test(beginId)) return undefined
-  return beginId.replace(LOOP_BEGIN_SUFFIX, `for-loop-${part}$1`)
-}
-
 type LoopGroup = {
   groupId: string
   beginId: string
@@ -38,6 +31,46 @@ function reachableFrom(startId: string, adjacency: Map<string, Set<string>>): Se
   }
 
   return visited
+}
+
+function distancesFrom(startId: string, adjacency: Map<string, Set<string>>): Map<string, number> {
+  const distances = new Map([[startId, 0]])
+  const queue = [startId]
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    const distance = distances.get(id)!
+    for (const nextId of adjacency.get(id) ?? []) {
+      if (distances.has(nextId)) continue
+      distances.set(nextId, distance + 1)
+      queue.push(nextId)
+    }
+  }
+  return distances
+}
+
+function absolutePosition(
+  nodeId: string,
+  nodesById: Map<string, Node>,
+  visiting = new Set<string>()
+): { x: number; y: number } {
+  const node = nodesById.get(nodeId)
+  if (!node || visiting.has(nodeId)) return { x: 0, y: 0 }
+  visiting.add(nodeId)
+  const parent = node.parentId
+    ? absolutePosition(node.parentId, nodesById, visiting)
+    : { x: 0, y: 0 }
+  return { x: parent.x + node.position.x, y: parent.y + node.position.y }
+}
+
+function uniqueLoopGroupId(beginId: string, usedIds: Set<string>): string {
+  const slashIndex = beginId.lastIndexOf('/')
+  const containerId = slashIndex > 0 ? beginId.slice(0, slashIndex) : ''
+  const baseId = `${containerId}/for-loop-body`
+  let id = baseId
+  let suffix = 1
+  while (usedIds.has(id)) id = `${baseId}-${suffix++}`
+  usedIds.add(id)
+  return id
 }
 
 export function findForLoopDefinitions(nodes: GraphNode[]): ForLoopDefinition[] {
@@ -176,8 +209,9 @@ export function reconcileForLoopGroups<TNode extends Node>(
 
 /**
  * Repairs loop groups produced before loop body IDs were unique. The repair is
- * deliberately conservative: it only reconstructs generated Begin/End pairs
- * whose numeric suffixes match and that still have a directed path between them.
+ * based on operator types and graph topology so renamed markers are supported.
+ * Innermost Begin operators are paired first with their nearest reachable End;
+ * equal-distance candidates are left untouched rather than guessed.
  */
 export function repairLegacyForLoopGroups<TNode extends Node>(
   nodes: TNode[],
@@ -186,58 +220,162 @@ export function repairLegacyForLoopGroups<TNode extends Node>(
   const nodesById = new Map(nodes.map(node => [node.id, node]))
   const existingDefinitions = findForLoopDefinitions(nodes)
   const definedBeginIds = new Set(existingDefinitions.map(definition => definition.beginId))
+  const definedEndIds = new Set(existingDefinitions.map(definition => definition.endId))
+  const definedMetaIds = new Set(existingDefinitions.flatMap(definition => definition.metaIds))
+  const definedGroupIds = new Set(existingDefinitions.map(definition => definition.groupId))
   const adjacency = new Map<string, Set<string>>()
+  const reverseAdjacency = new Map<string, Set<string>>()
   for (const edge of edges) {
     if (!adjacency.has(edge.source)) adjacency.set(edge.source, new Set())
+    if (!reverseAdjacency.has(edge.target)) reverseAdjacency.set(edge.target, new Set())
     adjacency.get(edge.source)!.add(edge.target)
+    reverseAdjacency.get(edge.target)!.add(edge.source)
   }
 
+  const nodeOrder = new Map(nodes.map((node, index) => [node.id, index]))
+  const begins = nodes.filter(
+    node => node.type === 'ForLoopBeginOp' && !definedBeginIds.has(node.id)
+  )
+  const ends = nodes.filter(node => node.type === 'ForLoopEndOp' && !definedEndIds.has(node.id))
+  const beginIds = new Set(begins.map(node => node.id))
+  const distancesByBeginId = new Map(
+    begins.map(begin => [begin.id, distancesFrom(begin.id, adjacency)])
+  )
+  const orderedBegins = [...begins].sort((a, b) => {
+    const nestedBeginCount = (begin: TNode) =>
+      [...(distancesByBeginId.get(begin.id)?.keys() ?? [])].filter(
+        id => id !== begin.id && beginIds.has(id)
+      ).length
+    return nestedBeginCount(a) - nestedBeginCount(b) || nodeOrder.get(a.id)! - nodeOrder.get(b.id)!
+  })
+
+  const assignedEndIds = new Set<string>()
+  const pairs: Array<{
+    begin: TNode
+    end: TNode
+    meta?: TNode
+    scopeNodeIds: Set<string>
+  }> = []
+  for (const begin of orderedBegins) {
+    const distances = distancesByBeginId.get(begin.id)!
+    const candidates = ends
+      .filter(end => !assignedEndIds.has(end.id) && distances.has(end.id))
+      .sort(
+        (a, b) =>
+          distances.get(a.id)! - distances.get(b.id)! || nodeOrder.get(a.id)! - nodeOrder.get(b.id)!
+      )
+    if (candidates.length === 0) continue
+    if (candidates[1] && distances.get(candidates[0].id) === distances.get(candidates[1].id)) {
+      continue
+    }
+
+    const end = candidates[0]
+    assignedEndIds.add(end.id)
+    const downstream = reachableFrom(begin.id, adjacency)
+    const upstream = reachableFrom(end.id, reverseAdjacency)
+    pairs.push({
+      begin,
+      end,
+      scopeNodeIds: new Set([...downstream].filter(id => upstream.has(id))),
+    })
+  }
+  if (pairs.length === 0) return nodes
+
+  // Meta operators are intentionally unconnected in many projects. Prefer a
+  // connected Meta when present, otherwise assign the nearest unused Meta to
+  // the visual center of the paired boundaries.
+  const availableMetas = nodes.filter(
+    node => node.type === 'ForLoopMetaOp' && !definedMetaIds.has(node.id)
+  )
+  const assignedMetaIds = new Set<string>()
+  for (const pair of pairs) {
+    const beginPosition = absolutePosition(pair.begin.id, nodesById)
+    const endPosition = absolutePosition(pair.end.id, nodesById)
+    const center = {
+      x: (beginPosition.x + endPosition.x) / 2,
+      y: (beginPosition.y + endPosition.y) / 2,
+    }
+    const metas = availableMetas
+      .filter(meta => !assignedMetaIds.has(meta.id))
+      .sort((a, b) => {
+        const aConnected = pair.scopeNodeIds.has(a.id) ? 0 : 1
+        const bConnected = pair.scopeNodeIds.has(b.id) ? 0 : 1
+        if (aConnected !== bConnected) return aConnected - bConnected
+        const distance = (meta: TNode) => {
+          const position = absolutePosition(meta.id, nodesById)
+          return (position.x - center.x) ** 2 + (position.y - center.y) ** 2
+        }
+        return distance(a) - distance(b) || nodeOrder.get(a.id)! - nodeOrder.get(b.id)!
+      })
+    if (metas[0]) {
+      pair.meta = metas[0]
+      assignedMetaIds.add(metas[0].id)
+    }
+  }
+
+  const loopMarkerTypes = new Set(['ForLoopBeginOp', 'ForLoopEndOp', 'ForLoopMetaOp'])
+  const reusableGroups = nodes.filter(
+    group =>
+      group.type === 'group' &&
+      !definedGroupIds.has(group.id) &&
+      (nodes.some(child => child.parentId === group.id && loopMarkerTypes.has(child.type ?? '')) ||
+        (group.selectable === false && group.draggable === false))
+  )
+  const unusedReusableGroups = new Set(reusableGroups.map(group => group.id))
+  const usedIds = new Set(nodes.map(node => node.id))
   const repairedNodes = [...nodes]
   const desiredParent = new Map(nodes.map(node => [node.id, node.parentId]))
   const loopGroupIds = new Set(existingDefinitions.map(definition => definition.groupId))
-  let repaired = false
+  const assignedLegacyGroupIds = new Set<string>()
 
-  for (const begin of nodes.filter(node => node.type === 'ForLoopBeginOp')) {
-    if (definedBeginIds.has(begin.id)) continue
-
-    const groupId = relatedLoopId(begin.id, 'body')
-    const endId = relatedLoopId(begin.id, 'end')
-    const metaId = relatedLoopId(begin.id, 'meta')
-    if (!groupId || !endId) continue
-
-    const end = nodesById.get(endId)
-    if (end?.type !== 'ForLoopEndOp' || !reachableFrom(begin.id, adjacency).has(end.id)) continue
-
-    let group = nodesById.get(groupId)
-    if (group && group.type !== 'group') continue
-
-    if (!group) {
+  for (const pair of pairs) {
+    const currentMarkers = new Set([pair.begin.id, pair.end.id, pair.meta?.id].filter(Boolean))
+    const reusableGroup = reusableGroups
+      .filter(group => unusedReusableGroups.has(group.id))
+      .sort((a, b) => {
+        const markerCount = (group: TNode) =>
+          nodes.filter(node => node.parentId === group.id && currentMarkers.has(node.id)).length
+        return markerCount(b) - markerCount(a) || nodeOrder.get(a.id)! - nodeOrder.get(b.id)!
+      })[0]
+    const groupId = reusableGroup?.id ?? uniqueLoopGroupId(pair.begin.id, usedIds)
+    let group = reusableGroup
+    if (group) {
+      unusedReusableGroups.delete(group.id)
+    } else {
       group = {
         id: groupId,
         type: 'group',
         data: {},
         selectable: false,
         draggable: false,
-        parentId: begin.parentId,
-        position: { ...begin.position },
+        parentId: pair.begin.parentId,
+        position: { ...pair.begin.position },
         style: { width: 1200, height: 400 },
       } as TNode
       repairedNodes.push(group)
       nodesById.set(groupId, group)
-      desiredParent.set(groupId, begin.parentId)
-      repaired = true
+      desiredParent.set(groupId, pair.begin.parentId)
     }
 
     loopGroupIds.add(groupId)
-    for (const marker of [begin, end, metaId ? nodesById.get(metaId) : undefined]) {
+    assignedLegacyGroupIds.add(groupId)
+    for (const marker of [pair.begin, pair.end, pair.meta]) {
       if (!marker) continue
-      if (marker.parentId !== groupId) repaired = true
       desiredParent.set(marker.id, groupId)
     }
   }
 
-  if (!repaired) return nodes
-
   const seededNodes = layoutGroups(repairedNodes, loopGroupIds, desiredParent)
-  return reconcileForLoopGroups(seededNodes, edges)
+  const reconciledNodes = reconcileForLoopGroups(seededNodes, edges)
+
+  // Drop only redundant legacy group shells that became empty after their loop
+  // markers and connected bodies were reassigned. Groups retaining any child
+  // are preserved to avoid deleting user-authored visual structure.
+  return reconciledNodes.filter(
+    group =>
+      group.type !== 'group' ||
+      assignedLegacyGroupIds.has(group.id) ||
+      !unusedReusableGroups.has(group.id) ||
+      reconciledNodes.some(node => node.parentId === group.id)
+  )
 }

--- a/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
+++ b/noodles-editor/src/noodles/utils/for-loop-group-utils.ts
@@ -11,6 +11,13 @@ export type ForLoopDefinition = {
   metaIds: string[]
 }
 
+const LOOP_BEGIN_SUFFIX = /for-loop-begin(-\d+)?$/
+
+function relatedLoopId(beginId: string, part: 'body' | 'end' | 'meta'): string | undefined {
+  if (!LOOP_BEGIN_SUFFIX.test(beginId)) return undefined
+  return beginId.replace(LOOP_BEGIN_SUFFIX, `for-loop-${part}$1`)
+}
+
 type LoopGroup = {
   groupId: string
   beginId: string
@@ -165,4 +172,72 @@ export function reconcileForLoopGroups<TNode extends Node>(
   }
 
   return layoutGroups(nodes, loopGroupIds, desiredParent)
+}
+
+/**
+ * Repairs loop groups produced before loop body IDs were unique. The repair is
+ * deliberately conservative: it only reconstructs generated Begin/End pairs
+ * whose numeric suffixes match and that still have a directed path between them.
+ */
+export function repairLegacyForLoopGroups<TNode extends Node>(
+  nodes: TNode[],
+  edges: GraphEdge[]
+): TNode[] {
+  const nodesById = new Map(nodes.map(node => [node.id, node]))
+  const existingDefinitions = findForLoopDefinitions(nodes)
+  const definedBeginIds = new Set(existingDefinitions.map(definition => definition.beginId))
+  const adjacency = new Map<string, Set<string>>()
+  for (const edge of edges) {
+    if (!adjacency.has(edge.source)) adjacency.set(edge.source, new Set())
+    adjacency.get(edge.source)!.add(edge.target)
+  }
+
+  const repairedNodes = [...nodes]
+  const desiredParent = new Map(nodes.map(node => [node.id, node.parentId]))
+  const loopGroupIds = new Set(existingDefinitions.map(definition => definition.groupId))
+  let repaired = false
+
+  for (const begin of nodes.filter(node => node.type === 'ForLoopBeginOp')) {
+    if (definedBeginIds.has(begin.id)) continue
+
+    const groupId = relatedLoopId(begin.id, 'body')
+    const endId = relatedLoopId(begin.id, 'end')
+    const metaId = relatedLoopId(begin.id, 'meta')
+    if (!groupId || !endId) continue
+
+    const end = nodesById.get(endId)
+    if (end?.type !== 'ForLoopEndOp' || !reachableFrom(begin.id, adjacency).has(end.id)) continue
+
+    let group = nodesById.get(groupId)
+    if (group && group.type !== 'group') continue
+
+    if (!group) {
+      group = {
+        id: groupId,
+        type: 'group',
+        data: {},
+        selectable: false,
+        draggable: false,
+        parentId: begin.parentId,
+        position: { ...begin.position },
+        style: { width: 1200, height: 400 },
+      } as TNode
+      repairedNodes.push(group)
+      nodesById.set(groupId, group)
+      desiredParent.set(groupId, begin.parentId)
+      repaired = true
+    }
+
+    loopGroupIds.add(groupId)
+    for (const marker of [begin, end, metaId ? nodesById.get(metaId) : undefined]) {
+      if (!marker) continue
+      if (marker.parentId !== groupId) repaired = true
+      desiredParent.set(marker.id, groupId)
+    }
+  }
+
+  if (!repaired) return nodes
+
+  const seededNodes = layoutGroups(repairedNodes, loopGroupIds, desiredParent)
+  return reconcileForLoopGroups(seededNodes, edges)
 }


### PR DESCRIPTION
#### Background

Projects created before ForLoop body IDs became unique can contain multiple valid loop chains but only one oversized visual group, with the loop markers and body nodes left unparented. Without visual definitions, nested scope pairing and layout cannot be repaired reliably at runtime.

#### Change List

- Add schema migration 016 to identify legacy Begin and End operators by type and pair them by directed graph reachability, independent of node names.
- Pair nested loops from the inside out with the nearest unambiguous reachable End; leave incomplete, disconnected, or ambiguous boundaries unchanged.
- Reuse or create a unique `/for-loop-body-N` group for each confirmed pair, associate its Meta operator, and derive body membership from the connected subgraph.
- Preserve absolute node positions and advance bundled examples to schema version 16.

#### Test Plan

- Migration regression modeled on a legacy project with three renamed loop triplets, one oversized group, and no parent memberships.
- Verify nested loops pair inside-out and incomplete or disconnected boundaries are not guessed.
- Validate the attached 73-node project reconstructs three groups with the expected connected children and unchanged canvas positions.
- Full editor test suite, lint, format check, and production build.
