### PR TITLE
feat: edit defaults in table schemas

### DIFF
--- a/noodles-editor/src/noodles/components/schema-editor-dialog.module.css
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.module.css
@@ -121,6 +121,44 @@
   border-top: 1px solid var(--surface-border);
 }
 
+.defaultValueRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--surface-border);
+}
+
+.optionLabel {
+  min-width: 52px;
+  font-size: 0.75rem;
+  color: var(--text-color-secondary);
+}
+
+.defaultInput {
+  width: min(260px, 100%);
+}
+
+.vectorDefaultInputs,
+.dateTimeDefaultInputs {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.vectorDefaultInputs label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.75rem;
+  color: var(--text-color-secondary);
+}
+
+.timezoneDropdown {
+  width: 220px;
+}
+
 .typeOptions label {
   display: flex;
   flex-direction: column;

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { TableSchema } from '../table-schema'
 import { SchemaEditorDialog } from './schema-editor-dialog'
@@ -160,6 +160,93 @@ describe('SchemaEditorDialog', () => {
     // StringLiteral type shows values input
     expect(screen.queryByText('Values (comma-separated):')).toBeDefined()
     expect(screen.queryByDisplayValue('active, inactive')).toBeDefined()
+  })
+
+  it('should render a default value editor for every column type', () => {
+    const allTypesSchema: TableSchema = {
+      columns: [
+        { name: 'number', type: 'number', defaultValue: 1 },
+        { name: 'string', type: 'string', defaultValue: 'text' },
+        { name: 'boolean', type: 'boolean', defaultValue: true },
+        { name: 'color', type: 'color', defaultValue: '#ff0000' },
+        { name: 'point2d', type: 'point2d', defaultValue: [1, 2] },
+        { name: 'point3d', type: 'point3d', defaultValue: [1, 2, 3] },
+        { name: 'vec2', type: 'vec2', defaultValue: [1, 2] },
+        { name: 'vec3', type: 'vec3', defaultValue: [1, 2, 3] },
+        { name: 'date', type: 'date', defaultValue: '2026-08-07' },
+        {
+          name: 'dateTime',
+          type: 'dateTime',
+          defaultValue: { datetime: '2026-08-07T12:00:00.000', timezone: 'UTC' },
+        },
+        {
+          name: 'literal',
+          type: 'stringLiteral',
+          defaultValue: 'start',
+          options: { values: ['start', 'end'] },
+        },
+      ],
+    }
+
+    render(<SchemaEditorDialog schema={allTypesSchema} onChange={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    for (const column of allTypesSchema.columns) {
+      expect(
+        screen.getByRole('group', { name: `Default value for ${column.name}` })
+      ).toBeDefined()
+    }
+  })
+
+  it('should save an edited column default value', () => {
+    const onChange = vi.fn()
+    render(<SchemaEditorDialog schema={mockSchema} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    const defaultEditor = screen.getByRole('group', { name: 'Default value for name' })
+    fireEvent.change(within(defaultEditor).getByRole('textbox'), {
+      target: { value: 'Unknown' },
+    })
+    fireEvent.click(screen.getByText('Save'))
+
+    expect(onChange).toHaveBeenCalledWith({
+      columns: [
+        { name: 'name', type: 'string', defaultValue: 'Unknown' },
+        { name: 'age', type: 'number', defaultValue: 0 },
+      ],
+    })
+  })
+
+  it('should replace an invalid StringLiteral default with its first option', () => {
+    const onChange = vi.fn()
+    const schema: TableSchema = {
+      columns: [
+        {
+          name: 'anchor',
+          type: 'stringLiteral',
+          defaultValue: '',
+          options: { values: ['start', 'end', 'middle'] },
+        },
+      ],
+    }
+
+    render(<SchemaEditorDialog schema={schema} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    const defaultEditor = screen.getByRole('group', { name: 'Default value for anchor' })
+    expect(defaultEditor).toHaveTextContent('start')
+
+    fireEvent.click(screen.getByText('Save'))
+    expect(onChange).toHaveBeenCalledWith({
+      columns: [
+        {
+          name: 'anchor',
+          type: 'stringLiteral',
+          defaultValue: 'start',
+          options: { values: ['start', 'end', 'middle'] },
+        },
+      ],
+    })
   })
 
   it('should call onChange with updated schema when Save is clicked', () => {

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
@@ -5,8 +5,10 @@ import { InputNumber } from 'primereact/inputnumber'
 import { InputSwitch } from 'primereact/inputswitch'
 import { InputText } from 'primereact/inputtext'
 import { useEffect, useState } from 'react'
-import type { ColumnSchema, ColumnType, TableSchema } from '../table-schema'
-import { getDefaultValue } from '../table-schema'
+import type { ColumnSchema, ColumnType, DateTimeValue, TableSchema } from '../table-schema'
+import { getDefaultValue, validateValue } from '../table-schema'
+import { getTimezoneOptions } from '../utils/timezone-utils'
+import { ColorSwatch } from './color-swatch'
 import s from './schema-editor-dialog.module.css'
 
 interface SchemaEditorDialogProps {
@@ -35,6 +37,18 @@ interface ColumnEditorProps {
   onDelete: () => void
   onMoveUp?: () => void
   onMoveDown?: () => void
+}
+
+function normalizeColumnDefault(column: ColumnSchema): ColumnSchema {
+  if (column.defaultValue !== undefined && validateValue(column.defaultValue, column)) {
+    return column
+  }
+
+  return { ...column, defaultValue: getDefaultValue(column) }
+}
+
+function normalizeSchemaDefaults(schema: TableSchema): TableSchema {
+  return { columns: schema.columns.map(normalizeColumnDefault) }
 }
 
 function StringLiteralValuesInput({
@@ -67,6 +81,147 @@ function StringLiteralValuesInput({
       className={s.fullWidthInput}
     />
   )
+}
+
+function VectorDefaultEditor({
+  column,
+  dimensions,
+  onChange,
+}: {
+  column: ColumnSchema
+  dimensions: 2 | 3
+  onChange: (defaultValue: number[]) => void
+}) {
+  const fallback = getDefaultValue(column) as number[]
+  const value =
+    Array.isArray(column.defaultValue) && column.defaultValue.length === dimensions
+      ? column.defaultValue
+      : fallback
+  const axes = dimensions === 2 ? ['x', 'y'] : ['x', 'y', 'z']
+
+  return (
+    <div className={s.vectorDefaultInputs}>
+      {axes.map((axis, index) => (
+        <label key={axis}>
+          {axis.toUpperCase()}:
+          <InputNumber
+            value={value[index] as number}
+            onValueChange={event => {
+              const nextValue = [...value]
+              nextValue[index] = event.value ?? 0
+              onChange(nextValue)
+            }}
+            aria-label={`Default ${axis} for ${column.name}`}
+            className={s.optionInput}
+          />
+        </label>
+      ))}
+    </div>
+  )
+}
+
+function DefaultValueEditor({
+  column,
+  onChange,
+}: {
+  column: ColumnSchema
+  onChange: (defaultValue: unknown) => void
+}) {
+  const defaultValue = column.defaultValue ?? getDefaultValue(column)
+
+  switch (column.type) {
+    case 'number':
+      return (
+        <InputNumber
+          value={defaultValue as number}
+          min={column.options?.min}
+          max={column.options?.max}
+          step={column.options?.step ?? 1}
+          onValueChange={event => onChange(event.value ?? getDefaultValue(column))}
+          aria-label={`Default value for ${column.name}`}
+          className={s.defaultInput}
+        />
+      )
+    case 'string':
+      return (
+        <InputText
+          value={defaultValue as string}
+          onChange={event => onChange(event.target.value)}
+          aria-label={`Default value for ${column.name}`}
+          className={s.defaultInput}
+        />
+      )
+    case 'stringLiteral': {
+      const values = column.options?.values ?? []
+      return values.length > 0 && !column.options?.freeform ? (
+        <Dropdown
+          value={defaultValue as string}
+          options={values}
+          onChange={event => onChange(event.value)}
+          appendTo="self"
+          aria-label={`Default value for ${column.name}`}
+          className={s.defaultInput}
+        />
+      ) : (
+        <InputText
+          value={defaultValue as string}
+          onChange={event => onChange(event.target.value)}
+          aria-label={`Default value for ${column.name}`}
+          className={s.defaultInput}
+        />
+      )
+    }
+    case 'boolean':
+      return (
+        <InputSwitch
+          checked={defaultValue as boolean}
+          onChange={event => onChange(event.value)}
+          aria-label={`Default value for ${column.name}`}
+        />
+      )
+    case 'color':
+      return <ColorSwatch value={defaultValue as string} onChange={onChange} />
+    case 'point2d':
+    case 'vec2':
+      return <VectorDefaultEditor column={column} dimensions={2} onChange={onChange} />
+    case 'point3d':
+    case 'vec3':
+      return <VectorDefaultEditor column={column} dimensions={3} onChange={onChange} />
+    case 'date':
+      return (
+        <InputText
+          type="date"
+          value={defaultValue as string}
+          onChange={event => onChange(event.target.value)}
+          aria-label={`Default value for ${column.name}`}
+          className={s.defaultInput}
+        />
+      )
+    case 'dateTime': {
+      const dateTimeValue = defaultValue as DateTimeValue
+      return (
+        <div className={s.dateTimeDefaultInputs}>
+          <InputText
+            type="datetime-local"
+            step={0.001}
+            value={dateTimeValue.datetime}
+            onChange={event => onChange({ ...dateTimeValue, datetime: event.target.value })}
+            aria-label={`Default date and time for ${column.name}`}
+            className={s.defaultInput}
+          />
+          <Dropdown
+            value={dateTimeValue.timezone}
+            options={getTimezoneOptions()}
+            onChange={event => onChange({ ...dateTimeValue, timezone: event.value })}
+            filter
+            appendTo="self"
+            aria-label={`Default timezone for ${column.name}`}
+            className={s.timezoneDropdown}
+          />
+        </div>
+      )
+    }
+  }
 }
 
 function ColumnEditor({ column, onChange, onDelete, onMoveUp, onMoveDown }: ColumnEditorProps) {
@@ -119,6 +274,18 @@ function ColumnEditor({ column, onChange, onDelete, onMoveUp, onMoveDown }: Colu
             onClick={onDelete}
           />
         </div>
+      </div>
+
+      <div
+        className={s.defaultValueRow}
+        role="group"
+        aria-label={`Default value for ${column.name}`}
+      >
+        <span className={s.optionLabel}>Default:</span>
+        <DefaultValueEditor
+          column={column}
+          onChange={defaultValue => onChange({ ...column, defaultValue })}
+        />
       </div>
 
       {column.type === 'number' && (
@@ -220,10 +387,12 @@ function ColumnEditor({ column, onChange, onDelete, onMoveUp, onMoveDown }: Colu
 
 export function SchemaEditorDialog({ schema, onChange, onClose }: SchemaEditorDialogProps) {
   const [open, setOpen] = useState(false)
-  const [localSchema, setLocalSchema] = useState<TableSchema>(schema)
+  const [localSchema, setLocalSchema] = useState<TableSchema>(() =>
+    normalizeSchemaDefaults(schema)
+  )
 
   const handleOpen = () => {
-    setLocalSchema(schema) // Reset to current schema
+    setLocalSchema(normalizeSchemaDefaults(schema)) // Reset to current schema
     setOpen(true)
   }
 
@@ -246,7 +415,7 @@ export function SchemaEditorDialog({ schema, onChange, onClose }: SchemaEditorDi
 
   const updateColumn = (index: number, updates: ColumnSchema) => {
     const newColumns = [...localSchema.columns]
-    newColumns[index] = updates
+    newColumns[index] = normalizeColumnDefault(updates)
     setLocalSchema({ columns: newColumns })
   }
 

--- a/noodles-editor/src/noodles/table-schema.test.ts
+++ b/noodles-editor/src/noodles/table-schema.test.ts
@@ -142,6 +142,30 @@ describe('validateValue', () => {
     expect(validateValue(42, schema)).toBe(false)
   })
 
+  it('should validate StringLiteral choices without treating an empty choice list as restrictive', () => {
+    expect(
+      validateValue('start', {
+        name: 'anchor',
+        type: 'stringLiteral',
+        options: { values: ['start', 'end'] },
+      })
+    ).toBe(true)
+    expect(
+      validateValue('', {
+        name: 'anchor',
+        type: 'stringLiteral',
+        options: { values: ['start', 'end'] },
+      })
+    ).toBe(false)
+    expect(
+      validateValue('custom', {
+        name: 'anchor',
+        type: 'stringLiteral',
+        options: { values: [] },
+      })
+    ).toBe(true)
+  })
+
   it('should validate boolean values', () => {
     const schema = { name: 'test', type: 'boolean' as const }
     expect(validateValue(true, schema)).toBe(true)

--- a/noodles-editor/src/noodles/table-schema.ts
+++ b/noodles-editor/src/noodles/table-schema.ts
@@ -275,7 +275,7 @@ export function validateValue(value: unknown, schema: ColumnSchema): boolean {
       if (schema.options?.freeform) {
         return true
       }
-      if (schema.options?.values) {
+      if (schema.options?.values && schema.options.values.length > 0) {
         return schema.options.values.includes(value)
       }
       return true


### PR DESCRIPTION
## Summary
- add schema default editors for every TableEditor column type
- use configured choices for strict StringLiteral defaults and freeform text when enabled
- normalize invalid or missing defaults before saving the schema
- preserve unrestricted StringLiteral behavior when no choices are configured

## GitHub Stack #548
- #442 (merged) ← #545 (this PR)
- former layer #547 was closed as unnecessary
- review only commit 31fc4a0b for this layer

## Tests
- npm test -- --run src/noodles/components/schema-editor-dialog.test.tsx src/noodles/table-schema.test.ts src/noodles/components/table-editor.test.tsx src/noodles/components/table-editor-edit-flow.test.tsx
- npm run lint