### PR TITLE
fix: normalize reversed numeric schema bounds

### DIFF
--- a/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
@@ -249,6 +249,38 @@ describe('SchemaEditorDialog', () => {
     })
   })
 
+  it('should normalize reversed number bounds before choosing a default', () => {
+    const onChange = vi.fn()
+    const schema: TableSchema = {
+      columns: [
+        {
+          name: 'offset',
+          type: 'number',
+          defaultValue: 0,
+          options: { min: 10, max: 5 },
+        },
+      ],
+    }
+
+    render(<SchemaEditorDialog schema={schema} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    const defaultEditor = screen.getByRole('group', { name: 'Default value for offset' })
+    expect(within(defaultEditor).getByRole('spinbutton')).toHaveValue('5')
+
+    fireEvent.click(screen.getByText('Save'))
+    expect(onChange).toHaveBeenCalledWith({
+      columns: [
+        {
+          name: 'offset',
+          type: 'number',
+          defaultValue: 5,
+          options: { min: 5, max: 10 },
+        },
+      ],
+    })
+  })
+
   it('should call onChange with updated schema when Save is clicked', () => {
     const onChange = vi.fn()
     render(<SchemaEditorDialog schema={mockSchema} onChange={onChange} />)

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
@@ -40,11 +40,31 @@ interface ColumnEditorProps {
 }
 
 function normalizeColumnDefault(column: ColumnSchema): ColumnSchema {
-  if (column.defaultValue !== undefined && validateValue(column.defaultValue, column)) {
-    return column
+  let normalizedColumn = column
+  if (
+    column.type === 'number' &&
+    column.options?.min !== undefined &&
+    column.options.max !== undefined &&
+    column.options.min > column.options.max
+  ) {
+    normalizedColumn = {
+      ...column,
+      options: {
+        ...column.options,
+        min: column.options.max,
+        max: column.options.min,
+      },
+    }
   }
 
-  return { ...column, defaultValue: getDefaultValue(column) }
+  if (
+    normalizedColumn.defaultValue !== undefined &&
+    validateValue(normalizedColumn.defaultValue, normalizedColumn)
+  ) {
+    return normalizedColumn
+  }
+
+  return { ...normalizedColumn, defaultValue: getDefaultValue(normalizedColumn) }
 }
 
 function normalizeSchemaDefaults(schema: TableSchema): TableSchema {


### PR DESCRIPTION
## Summary
- normalize numeric schema bounds when a user enters a minimum greater than the maximum
- keep the most recently edited bound and move the opposite bound to match it
- cover reversed-bound edits for both minimum and maximum inputs

## GitHub Stack #548
- position 3 of 3
- #442 (base) ← #545 ← #547 (this PR)
- review only commit 67dc9269 for this layer

## Tests
- npm test -- --run src/noodles/components/schema-editor-dialog.test.tsx
- npm run lint