### PR TITLE
feat: enable keyframing for TableEditorOp cell values

### DIFF
--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -33,9 +33,17 @@ import { createPortal } from 'react-dom'
 import { Temporal } from 'temporal-polyfill'
 
 import { analytics } from '../../utils/analytics'
-import { ArrayField, type Field, type IField, ListField } from '../fields'
+import { ArrayField, CompoundPropsField, type Field, type IField, ListField } from '../fields'
 import { useKeysStore } from '../keys-store'
 import s from '../noodles.module.css'
+import {
+  convertValue,
+  createTableCompoundField,
+  flattenTableField,
+  getDefaultValue,
+  inferSchema,
+  type TableSchema,
+} from '../table-schema'
 import type { ExecutionState, IOperator, OpType } from '../operators'
 import {
   type ContainerOp,
@@ -64,7 +72,6 @@ import {
   useOperatorStore,
   useUIStore,
 } from '../store'
-import { inferSchema, type TableSchema } from '../table-schema'
 import type { NodeDataJSON } from '../transform-graph'
 import { canConnect } from '../utils/can-connect'
 import {
@@ -1782,51 +1789,105 @@ export function TableEditorOpComponent({
   const locked = useLocked(op)
   useFieldVisibility(op)
 
-  const [data, setData] = useState((op?.inputs.data.value ?? []) as unknown[])
   const [schema, setSchema] = useState<TableSchema>(() => {
-    // Get schema from output or infer from data
-    const outputSchema = op?.outputs.schema.value
-    if (outputSchema && typeof outputSchema === 'object' && 'columns' in outputSchema) {
-      return outputSchema as TableSchema
+    // Get schema from input or infer
+    const inputSchema = op?.inputs.schema.value
+    if (inputSchema && typeof inputSchema === 'object' && 'columns' in inputSchema) {
+      return inputSchema as TableSchema
     }
-    return inferSchema((op?.inputs.data.value ?? []) as unknown[])
+    return { columns: [] }
+  })
+
+  // Convert CompoundPropsField to array for display
+  const [data, setData] = useState(() => {
+    if (!op || !schema || schema.columns.length === 0) {
+      return []
+    }
+    return flattenTableField(op.inputs.data as unknown as CompoundPropsField, schema)
   })
 
   // Subscribe to data and schema changes
   useEffect(() => {
     if (!op) return
-    const dataSub = op.inputs.data.subscribe(newData => {
-      setData(newData as unknown[])
+    const dataSub = op.inputs.data.subscribe(() => {
+      if (schema && schema.columns.length > 0) {
+        const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, schema)
+        setData(flatData)
+      }
     })
-    const schemaSub = op.outputs.schema.subscribe(newSchema => {
+    const schemaSub = op.inputs.schema.subscribe((newSchema) => {
       if (newSchema && typeof newSchema === 'object' && 'columns' in newSchema) {
-        setSchema(newSchema as TableSchema)
+        const tableSchema = newSchema as TableSchema
+        setSchema(tableSchema)
+        // Update data display when schema changes
+        const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, tableSchema)
+        setData(flatData)
       }
     })
     return () => {
       dataSub.unsubscribe()
       schemaSub.unsubscribe()
     }
-  }, [op])
+  }, [op, schema])
 
   if (!op) return null
 
   const handleDataChange = (newData: unknown[], description = 'Edit table data') => {
+    if (!schema) {
+      return
+    }
+
     const before = captureOperatorInputs()
-    op.inputs.data.setValue(newData)
-    op.outputs.data.setValue(newData)
+
+    // Convert flat array back to CompoundPropsField structure
+    const compoundField = createTableCompoundField(newData, schema)
+
+    // Update the subschema directly to preserve the CompoundPropsField instance
+    const dataField = op.inputs.data as unknown as CompoundPropsField
+    dataField.subschema = compoundField.subschema
+
+    // Trigger change notification
+    op.markDirty()
+
     firePropertyMutation(description, before)
   }
 
   const handleSchemaChange = (newSchema: TableSchema, newData?: unknown[]) => {
     const before = captureOperatorInputs()
+
+    // When schema changes, rebuild the CompoundPropsField structure
+    const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, schema)
+
+    // Update data to match new schema (convert column types)
+    const updatedData = (newData ?? flatData).map((row) => {
+      if (typeof row !== 'object' || row === null || Array.isArray(row)) {
+        return row
+      }
+
+      const newRow: Record<string, unknown> = { _rowId: (row as Record<string, unknown>)._rowId }
+      for (const col of newSchema.columns) {
+        const existingValue = (row as Record<string, unknown>)[col.name]
+        if (existingValue !== undefined) {
+          newRow[col.name] = convertValue(existingValue, col.type)
+        } else {
+          newRow[col.name] = col.defaultValue ?? getDefaultValue(col)
+        }
+      }
+      return newRow
+    })
+
+    // Rebuild CompoundPropsField with new schema
+    const compoundField = createTableCompoundField(updatedData, newSchema)
+    const dataField = op.inputs.data as unknown as CompoundPropsField
+    dataField.subschema = compoundField.subschema
+
+    // Update schema field
     op.inputs.schema.setValue(newSchema)
-    op.outputs.schema.setValue(newSchema)
     setSchema(newSchema)
-    if (newData) {
-      op.inputs.data.setValue(newData)
-      op.outputs.data.setValue(newData)
-    }
+
+    // Trigger change notification
+    op.markDirty()
+
     firePropertyMutation('Edit table schema', before)
   }
 

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -1784,111 +1784,171 @@ export function TableEditorOpComponent({
   selected,
 }: ReactFlowNodeProps<NodeDataJSON<TableEditorOp>> & { type: 'TableEditorOp' }) {
   const op = getOp(id as string)
+  const [error, setError] = useState<Error | null>(null)
 
   const isDimmed = useNodeDimmed(id)
   const locked = useLocked(op)
   useFieldVisibility(op)
 
   const [schema, setSchema] = useState<TableSchema>(() => {
-    // Get schema from input or infer
-    const inputSchema = op?.inputs.schema.value
-    if (inputSchema && typeof inputSchema === 'object' && 'columns' in inputSchema) {
-      return inputSchema as TableSchema
+    try {
+      // Get schema from input or infer
+      const inputSchema = op?.inputs.schema.value
+      if (inputSchema && typeof inputSchema === 'object' && 'columns' in inputSchema) {
+        return inputSchema as TableSchema
+      }
+      return { columns: [] }
+    } catch (err) {
+      console.error('Error initializing schema:', err)
+      setError(err as Error)
+      return { columns: [] }
     }
-    return { columns: [] }
   })
 
   // Convert CompoundPropsField to array for display
-  const [data, setData] = useState(() => {
-    if (!op || !schema || schema.columns.length === 0) {
+  const [data, setData] = useState<unknown[]>(() => {
+    try {
+      if (!op) {
+        return []
+      }
+      // Get schema directly from op, not from state
+      const inputSchema = op.inputs.schema.value
+      if (!inputSchema || typeof inputSchema !== 'object' || !('columns' in inputSchema)) {
+        return []
+      }
+      const tableSchema = inputSchema as TableSchema
+      if (tableSchema.columns.length === 0) {
+        return []
+      }
+      return flattenTableField(op.inputs.data as unknown as CompoundPropsField, tableSchema)
+    } catch (err) {
+      console.error('Error initializing data:', err)
+      setError(err as Error)
       return []
     }
-    return flattenTableField(op.inputs.data as unknown as CompoundPropsField, schema)
   })
 
   // Subscribe to data and schema changes
   useEffect(() => {
-    if (!op) return
-    const dataSub = op.inputs.data.subscribe(() => {
-      if (schema && schema.columns.length > 0) {
-        const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, schema)
-        setData(flatData)
+    try {
+      if (!op) return
+      const dataSub = op.inputs.data.subscribe(() => {
+        try {
+          if (schema && schema.columns.length > 0) {
+            const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, schema)
+            setData(flatData)
+          }
+        } catch (err) {
+          console.error('Error updating data:', err)
+          setError(err as Error)
+        }
+      })
+      const schemaSub = op.inputs.schema.subscribe((newSchema) => {
+        try {
+          if (newSchema && typeof newSchema === 'object' && 'columns' in newSchema) {
+            const tableSchema = newSchema as TableSchema
+            setSchema(tableSchema)
+            // Update data display when schema changes
+            const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, tableSchema)
+            setData(flatData)
+          }
+        } catch (err) {
+          console.error('Error updating schema:', err)
+          setError(err as Error)
+        }
+      })
+      return () => {
+        dataSub.unsubscribe()
+        schemaSub.unsubscribe()
       }
-    })
-    const schemaSub = op.inputs.schema.subscribe((newSchema) => {
-      if (newSchema && typeof newSchema === 'object' && 'columns' in newSchema) {
-        const tableSchema = newSchema as TableSchema
-        setSchema(tableSchema)
-        // Update data display when schema changes
-        const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, tableSchema)
-        setData(flatData)
-      }
-    })
-    return () => {
-      dataSub.unsubscribe()
-      schemaSub.unsubscribe()
+    } catch (err) {
+      console.error('Error setting up subscriptions:', err)
+      setError(err as Error)
     }
   }, [op, schema])
 
   if (!op) return null
 
+  if (error) {
+    return (
+      <div className={cx(s.wrapper, { [s.wrapperDimmed]: isDimmed })}>
+        <NodeHeader id={id} type={type} op={op} />
+        <div className={s.content} style={{ padding: '20px', color: '#ff6b6b' }}>
+          <h3>Error in TableEditorOp</h3>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: '12px' }}>{error.message}</pre>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: '10px', marginTop: '10px' }}>{error.stack}</pre>
+        </div>
+      </div>
+    )
+  }
+
   const handleDataChange = (newData: unknown[], description = 'Edit table data') => {
-    if (!schema) {
-      return
+    try {
+      if (!schema) {
+        return
+      }
+
+      const before = captureOperatorInputs()
+
+      // Convert flat array back to CompoundPropsField structure
+      const compoundField = createTableCompoundField(newData, schema)
+
+      // Update the subschema directly to preserve the CompoundPropsField instance
+      const dataField = op.inputs.data as unknown as CompoundPropsField
+      dataField.subschema = compoundField.subschema
+
+      // Trigger change notification
+      op.markDirty()
+
+      firePropertyMutation(description, before)
+    } catch (err) {
+      console.error('Error handling data change:', err)
+      setError(err as Error)
     }
-
-    const before = captureOperatorInputs()
-
-    // Convert flat array back to CompoundPropsField structure
-    const compoundField = createTableCompoundField(newData, schema)
-
-    // Update the subschema directly to preserve the CompoundPropsField instance
-    const dataField = op.inputs.data as unknown as CompoundPropsField
-    dataField.subschema = compoundField.subschema
-
-    // Trigger change notification
-    op.markDirty()
-
-    firePropertyMutation(description, before)
   }
 
   const handleSchemaChange = (newSchema: TableSchema, newData?: unknown[]) => {
-    const before = captureOperatorInputs()
+    try {
+      const before = captureOperatorInputs()
 
-    // When schema changes, rebuild the CompoundPropsField structure
-    const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, schema)
+      // When schema changes, rebuild the CompoundPropsField structure
+      const flatData = flattenTableField(op.inputs.data as unknown as CompoundPropsField, schema)
 
-    // Update data to match new schema (convert column types)
-    const updatedData = (newData ?? flatData).map((row) => {
-      if (typeof row !== 'object' || row === null || Array.isArray(row)) {
-        return row
-      }
-
-      const newRow: Record<string, unknown> = { _rowId: (row as Record<string, unknown>)._rowId }
-      for (const col of newSchema.columns) {
-        const existingValue = (row as Record<string, unknown>)[col.name]
-        if (existingValue !== undefined) {
-          newRow[col.name] = convertValue(existingValue, col.type)
-        } else {
-          newRow[col.name] = col.defaultValue ?? getDefaultValue(col)
+      // Update data to match new schema (convert column types)
+      const updatedData = (newData ?? flatData).map((row) => {
+        if (typeof row !== 'object' || row === null || Array.isArray(row)) {
+          return row
         }
-      }
-      return newRow
-    })
 
-    // Rebuild CompoundPropsField with new schema
-    const compoundField = createTableCompoundField(updatedData, newSchema)
-    const dataField = op.inputs.data as unknown as CompoundPropsField
-    dataField.subschema = compoundField.subschema
+        const newRow: Record<string, unknown> = { _rowId: (row as Record<string, unknown>)._rowId }
+        for (const col of newSchema.columns) {
+          const existingValue = (row as Record<string, unknown>)[col.name]
+          if (existingValue !== undefined) {
+            newRow[col.name] = convertValue(existingValue, col.type)
+          } else {
+            newRow[col.name] = col.defaultValue ?? getDefaultValue(col)
+          }
+        }
+        return newRow
+      })
 
-    // Update schema field
-    op.inputs.schema.setValue(newSchema)
-    setSchema(newSchema)
+      // Rebuild CompoundPropsField with new schema
+      const compoundField = createTableCompoundField(updatedData, newSchema)
+      const dataField = op.inputs.data as unknown as CompoundPropsField
+      dataField.subschema = compoundField.subschema
 
-    // Trigger change notification
-    op.markDirty()
+      // Update schema field
+      op.inputs.schema.setValue(newSchema)
+      setSchema(newSchema)
 
-    firePropertyMutation('Edit table schema', before)
+      // Trigger change notification
+      op.markDirty()
+
+      firePropertyMutation('Edit table schema', before)
+    } catch (err) {
+      console.error('Error handling schema change:', err)
+      setError(err as Error)
+    }
   }
 
   return (

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -192,7 +192,12 @@ import {
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE, safeMode } from './globals'
 import { getKeysStore } from './keys-store'
 import { getAllOps, getOp } from './store'
-import { prepareTableDataForOutput, type TableSchema } from './table-schema'
+import {
+  flattenTableField,
+  migrateTableData,
+  prepareTableDataForOutput,
+  type TableSchema,
+} from './table-schema'
 import type { ExtensionConstructorArgs, LayerPropsValue } from './types'
 import { composeAccessor, isAccessor } from './utils/accessor-helpers'
 import { deepEqual } from './utils/deep-equal'
@@ -2424,7 +2429,9 @@ export class TableEditorOp extends Operator<TableEditorOp> {
 
   createInputs() {
     return {
-      data: new DataField(),
+      // Nested CompoundPropsField structure: { row_<uuid>: { colName: Field, ... }, ... }
+      // Each cell is individually keyframeable in the timeline
+      data: new CompoundPropsField({ subschema: {} }),
       schema: new UnknownField(null), // TableSchema | null - optional schema override
     }
   }
@@ -2437,13 +2444,47 @@ export class TableEditorOp extends Operator<TableEditorOp> {
   }
 
   execute({ data, schema }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    if (!schema) {
+      return {
+        data: [],
+        schema: null,
+      }
+    }
+
+    const tableSchema = schema as TableSchema
+
+    // Flatten nested CompoundPropsField back to array format
+    const flatData = flattenTableField(data, tableSchema)
+
     // Convert dateTime strings to Temporal.ZonedDateTime for output
     // This happens at the operator boundary: internal storage = strings, output = Temporal
-    const outputData = schema ? prepareTableDataForOutput(data, schema as TableSchema) : data
+    const outputData = prepareTableDataForOutput(flatData, tableSchema)
 
     return {
       data: outputData,
-      schema: schema || null,
+      schema: tableSchema,
+    }
+  }
+
+  // Migration: detect old DataField array format and convert to CompoundPropsField
+  onDeserialize() {
+    const dataInput = this.inputs.data
+    const schemaInput = this.inputs.schema
+
+    // Check if data is in old format (DataField was accidentally used before)
+    // In the old format, data.value would be an array directly
+    const oldValue = (dataInput as unknown as DataField).value
+
+    if (Array.isArray(oldValue) && schemaInput.value) {
+      const tableSchema = schemaInput.value as TableSchema
+
+      // Migrate to new CompoundPropsField format
+      const migratedField = migrateTableData(oldValue, tableSchema)
+
+      // Replace the data field's subschema with the migrated structure
+      ;(dataInput as CompoundPropsField).subschema = migratedField.subschema
+
+      console.log(`Migrated TableEditorOp ${this.id} from DataField to CompoundPropsField format`)
     }
   }
 }

--- a/noodles-editor/src/noodles/table-schema.ts
+++ b/noodles-editor/src/noodles/table-schema.ts
@@ -392,3 +392,161 @@ export function validateTableData(data: unknown[], schema: TableSchema): unknown
     return validatedRow
   })
 }
+
+// Map ColumnType to Field constructor for keyframeable fields
+export function columnTypeToFieldConstructor(
+  colSchema: ColumnSchema
+): (value?: unknown) => import('./fields').Field<unknown> {
+  const {
+    NumberField,
+    StringField,
+    BooleanField,
+    ColorField,
+    Point2DField,
+    Vec2Field,
+    Vec3Field,
+    DateField,
+    StringLiteralField,
+    UnknownField,
+  } = require('./fields')
+
+  switch (colSchema.type) {
+    case 'number':
+      return (value = 0) =>
+        new NumberField(value as number, {
+          min: colSchema.options?.min,
+          max: colSchema.options?.max,
+          step: colSchema.options?.step,
+          softMin: colSchema.options?.softMin,
+          softMax: colSchema.options?.softMax,
+        })
+    case 'string':
+      return (value = '') => new StringField(value as string)
+    case 'boolean':
+      return (value = false) => new BooleanField(value as boolean)
+    case 'color':
+      return (value = '#000000') => new ColorField(value as string)
+    case 'point2d':
+      return (value = [0, 0]) =>
+        new Point2DField(value as [number, number], {
+          geocoder: colSchema.options?.geocoder,
+        })
+    case 'point3d':
+      return (value = [0, 0, 0]) => new Vec3Field(value as [number, number, number])
+    case 'vec2':
+      return (value = [0, 0]) => new Vec2Field(value as [number, number])
+    case 'vec3':
+      return (value = [0, 0, 0]) => new Vec3Field(value as [number, number, number])
+    case 'date':
+      return (value = new Date().toISOString().split('T')[0]) => new DateField(value as string)
+    case 'dateTime':
+      // DateTime cells store DateTimeValue objects, use UnknownField
+      return (value = getDefaultValue(colSchema)) => new UnknownField(value)
+    case 'stringLiteral':
+      return (value = colSchema.options?.values?.[0] ?? '') =>
+        new StringLiteralField(value as string, {
+          values: colSchema.options?.values ?? [],
+        })
+    default:
+      return (value = null) => new UnknownField(value)
+  }
+}
+
+// Create CompoundPropsField structure from array data and schema
+// Returns nested field with structure: { row_<uuid>: { colName: Field, ... }, ... }
+export function createTableCompoundField(
+  data: unknown[],
+  schema: TableSchema
+): import('./fields').CompoundPropsField {
+  const { CompoundPropsField } = require('./fields')
+
+  const rowsSubschema: Record<string, import('./fields').Field<unknown>> = {}
+
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i]
+    if (typeof row !== 'object' || row === null || Array.isArray(row)) {
+      continue
+    }
+
+    const rowData = row as Record<string, unknown>
+
+    // Generate or use existing row ID
+    let rowId = rowData._rowId as string | undefined
+    if (!rowId) {
+      rowId = `row_${crypto.randomUUID()}`
+    }
+
+    // Create CompoundPropsField for this row
+    const cellSubschema: Record<string, import('./fields').Field<unknown>> = {}
+
+    for (const col of schema.columns) {
+      const fieldConstructor = columnTypeToFieldConstructor(col)
+      const cellValue = rowData[col.name] ?? getDefaultValue(col)
+      cellSubschema[col.name] = fieldConstructor(cellValue)
+    }
+
+    rowsSubschema[rowId] = new CompoundPropsField({ subschema: cellSubschema })
+  }
+
+  return new CompoundPropsField({ subschema: rowsSubschema })
+}
+
+// Flatten CompoundPropsField back to array format
+// Extracts row data from nested structure for output compatibility
+export function flattenTableField(
+  field: import('./fields').CompoundPropsField,
+  schema: TableSchema
+): unknown[] {
+  const rows: unknown[] = []
+
+  // Iterate over row fields (row_<uuid>)
+  for (const [rowId, rowField] of Object.entries(field.subschema)) {
+    if (!(rowField instanceof require('./fields').CompoundPropsField)) {
+      continue
+    }
+
+    const rowData: Record<string, unknown> = {
+      _rowId: rowId, // Preserve row ID
+    }
+
+    // Extract cell values
+    for (const col of schema.columns) {
+      const cellField = rowField.subschema[col.name]
+      if (cellField) {
+        rowData[col.name] = cellField.value
+      }
+    }
+
+    rows.push(rowData)
+  }
+
+  return rows
+}
+
+// Migrate old DataField array format to new CompoundPropsField format
+export function migrateTableData(
+  oldData: unknown[],
+  schema: TableSchema
+): import('./fields').CompoundPropsField {
+  // Validate and normalize the data first
+  const validatedData = validateTableData(oldData, schema)
+
+  // Add row IDs if missing
+  const dataWithRowIds = validatedData.map((row, _i) => {
+    if (typeof row !== 'object' || row === null || Array.isArray(row)) {
+      return row
+    }
+
+    const rowData = row as Record<string, unknown>
+
+    // Generate row ID if missing
+    if (!rowData._rowId) {
+      rowData._rowId = `row_${crypto.randomUUID()}`
+    }
+
+    return rowData
+  })
+
+  // Create CompoundPropsField structure
+  return createTableCompoundField(dataWithRowIds, schema)
+}


### PR DESCRIPTION
#### Background

TableEditorOp previously stored table data as a flat DataField array, which prevented individual cell values from being keyframed in the timeline. This limited the ability to create animated data visualizations where table values change over time.

#### Change List
- Transform TableEditorOp data model from flat DataField array to nested CompoundPropsField structure (`{ row_<uuid>: { colName: Field, ... } }`)
- Each cell becomes an individually keyframeable Field instance with proper type-based interpolation (numbers interpolate smoothly, colors via RGBA, points via lng/lat)
- Add stable row IDs (UUIDs) that preserve keyframes through row reordering
- Implement helper functions in table-schema.ts: `columnTypeToFieldConstructor()`, `createTableCompoundField()`, `flattenTableField()`, `migrateTableData()`
- Add automatic migration in `TableEditorOp.onDeserialize()` to convert old DataField format to new CompoundPropsField structure
- Update TableEditorOpComponent to translate between nested fields (for keyframing) and flat arrays (for UI display)

This leverages existing timeline infrastructure (CompoundPropsField support) rather than creating special cases, resulting in a clean, maintainable solution that integrates seamlessly with the keyframing system.