### PR TITLE
fix: Preserve project API keys across handoff

### DIFF
--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -65,7 +65,7 @@ Access API key settings via the gear icon in the top menu bar.
 
 Keys are resolved in priority order:
 1. **Browser** - Stored in localStorage, persists across sessions
-2. **Project** - Saved in project file (if "Save in project" is enabled)
+2. **Project** - Loaded from and retained in the project file until explicitly removed
 3. **Environment** - Set via environment variables
 
 The first source with a valid key is used automatically.
@@ -80,7 +80,7 @@ The first source with a valid key is used automatically.
 
 ### Privacy
 
-API keys are stored locally and never sent to Noodles.gl servers. Browser keys are stored in localStorage; project keys are stored in the project's noodles.json file.
+API keys are stored locally and never sent to Noodles.gl servers. Browser keys are stored in localStorage. Enabling **Add browser keys to this project** copies them into `noodles.json`, where they are stored in plain text and travel with the project. Only share projects containing keys with trusted collaborators. Loaded project keys remain in subsequent saves until removed from App Settings.
 
 ### Environment Variables
 

--- a/noodles-editor/src/components/settings-dialog.module.css
+++ b/noodles-editor/src/components/settings-dialog.module.css
@@ -328,7 +328,7 @@
 /* Individual source row */
 .keySource {
   display: grid;
-  grid-template-columns: 140px 1fr auto;
+  grid-template-columns: 140px minmax(0, 1fr) auto auto;
   align-items: center;
   min-width: 0;
 }

--- a/noodles-editor/src/components/settings-dialog.tsx
+++ b/noodles-editor/src/components/settings-dialog.tsx
@@ -311,8 +311,8 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                   <div className={s.settingName}>Add browser keys to this project</div>
                   <div className={s.settingDescription}>
                     Include browser keys when saving. Keys already loaded from this project remain
-                    until you remove them above. Only share with trusted collaborators: project
-                    keys are stored in plain text.
+                    until you remove them above. Only share with trusted collaborators: project keys
+                    are stored in plain text.
                   </div>
                 </div>
               </label>

--- a/noodles-editor/src/components/settings-dialog.tsx
+++ b/noodles-editor/src/components/settings-dialog.tsx
@@ -21,6 +21,7 @@ interface KeyGroupProps {
   activeSource: 'browser' | 'project' | 'env' | null
   onBrowserChange: (value: string) => void
   onBrowserClear: () => void
+  onProjectRemove: () => void
 }
 
 const KeyGroup = ({
@@ -33,6 +34,7 @@ const KeyGroup = ({
   activeSource,
   onBrowserChange,
   onBrowserClear,
+  onProjectRemove,
 }: KeyGroupProps) => {
   const handleCopy = (value: string, source: 'project' | 'env') => {
     navigator.clipboard.writeText(value)
@@ -82,6 +84,9 @@ const KeyGroup = ({
             >
               Copy
             </button>
+            <button type="button" onClick={onProjectRemove} className={s.clearButton}>
+              Remove
+            </button>
           </div>
         )}
 
@@ -116,6 +121,7 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
   const saveInProject = useKeysStore(state => state.saveInProject)
   const projectKeys = useKeysStore(state => state.projectKeys || {})
   const setBrowserKey = useKeysStore(state => state.setBrowserKey)
+  const removeProjectKey = useKeysStore(state => state.removeProjectKey)
   const setSaveInProjectAction = useKeysStore(state => state.setSaveInProject)
   const getActiveSource = useKeysStore(state => state.getActiveSource)
 
@@ -228,6 +234,10 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                   setBrowserKey('mapbox', undefined)
                   analytics.track('key_cleared', { key: 'mapbox' })
                 }}
+                onProjectRemove={() => {
+                  removeProjectKey('mapbox')
+                  analytics.track('project_key_removed', { key: 'mapbox' })
+                }}
               />
 
               <KeyGroup
@@ -242,6 +252,10 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                 onBrowserClear={() => {
                   setBrowserKey('googleMaps', undefined)
                   analytics.track('key_cleared', { key: 'googleMaps' })
+                }}
+                onProjectRemove={() => {
+                  removeProjectKey('googleMaps')
+                  analytics.track('project_key_removed', { key: 'googleMaps' })
                 }}
               />
 
@@ -258,6 +272,10 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                   setBrowserKey('cesium', undefined)
                   analytics.track('key_cleared', { key: 'cesium' })
                 }}
+                onProjectRemove={() => {
+                  removeProjectKey('cesium')
+                  analytics.track('project_key_removed', { key: 'cesium' })
+                }}
               />
 
               <KeyGroup
@@ -273,6 +291,10 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                   setBrowserKey('anthropic', undefined)
                   analytics.track('key_cleared', { key: 'anthropic' })
                 }}
+                onProjectRemove={() => {
+                  removeProjectKey('anthropic')
+                  analytics.track('project_key_removed', { key: 'anthropic' })
+                }}
               />
             </div>
 
@@ -286,10 +308,11 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                   className={s.checkbox}
                 />
                 <div className={s.settingContent}>
-                  <div className={s.settingName}>Save browser keys in project file</div>
+                  <div className={s.settingName}>Add browser keys to this project</div>
                   <div className={s.settingDescription}>
-                    Include your browser keys in the project file when saving. Only enable this if
-                    you want to share your keys with collaborators. Keys are stored in plain text.
+                    Include browser keys when saving. Keys already loaded from this project remain
+                    until you remove them above. Only share with trusted collaborators: project
+                    keys are stored in plain text.
                   </div>
                 </div>
               </label>

--- a/noodles-editor/src/noodles/keys-store.test.ts
+++ b/noodles-editor/src/noodles/keys-store.test.ts
@@ -127,6 +127,24 @@ describe('Keys Store', () => {
       setProjectKeys(undefined)
       expect(getKeysStore().projectKeys).toBeUndefined()
     })
+
+    it('should remove one project key without clearing the others', () => {
+      const { setProjectKeys, removeProjectKey } = getKeysStore()
+      setProjectKeys({ mapbox: 'mapbox-token', googleMaps: 'google-token' })
+
+      removeProjectKey('mapbox')
+
+      expect(getKeysStore().projectKeys).toEqual({ googleMaps: 'google-token' })
+    })
+
+    it('should clear project keys after removing the final key', () => {
+      const { setProjectKeys, removeProjectKey } = getKeysStore()
+      setProjectKeys({ mapbox: 'mapbox-token' })
+
+      removeProjectKey('mapbox')
+
+      expect(getKeysStore().projectKeys).toBeUndefined()
+    })
   })
 
   describe('setBrowserKey', () => {
@@ -354,11 +372,18 @@ describe('getKeysForProject', () => {
     })
   })
 
-  it('should return undefined when saveInProject is false', () => {
+  it('should omit browser keys when saveInProject is false', () => {
     const { setBrowserKey } = getKeysStore()
     setBrowserKey('mapbox', 'test-token')
 
     expect(getKeysForProject()).toBeUndefined()
+  })
+
+  it('should preserve loaded project keys when saveInProject is false', () => {
+    const { setProjectKeys } = getKeysStore()
+    setProjectKeys({ googleMaps: 'project-token' })
+
+    expect(getKeysForProject()).toEqual({ googleMaps: 'project-token' })
   })
 
   it('should return browserKeys when saveInProject is true', () => {
@@ -378,6 +403,18 @@ describe('getKeysForProject', () => {
     const { setSaveInProject } = getKeysStore()
     setSaveInProject(true)
 
-    expect(getKeysForProject()).toEqual({})
+    expect(getKeysForProject()).toBeUndefined()
+  })
+
+  it('should merge browser keys over loaded project keys when enabled', () => {
+    const { setProjectKeys, setBrowserKeys, setSaveInProject } = getKeysStore()
+    setProjectKeys({ mapbox: 'project-mapbox', googleMaps: 'project-google' })
+    setBrowserKeys({ mapbox: 'browser-mapbox' })
+    setSaveInProject(true)
+
+    expect(getKeysForProject()).toEqual({
+      mapbox: 'browser-mapbox',
+      googleMaps: 'project-google',
+    })
   })
 })

--- a/noodles-editor/src/noodles/keys-store.tsx
+++ b/noodles-editor/src/noodles/keys-store.tsx
@@ -25,6 +25,7 @@ interface KeysActions {
   setBrowserKey: (key: KeyType, value: string | undefined) => void
   setBrowserKeys: (keys: KeysConfig) => void
   clearBrowserKey: (key: KeyType) => void
+  removeProjectKey: (key: KeyType) => void
   setSaveInProject: (enabled: boolean) => void
   setProjectKeys: (keys: KeysConfig | undefined) => void
 
@@ -68,6 +69,12 @@ export const useKeysStore = create<KeysStore>()(
         const browserKeys = { ...get().browserKeys }
         delete browserKeys[key]
         set({ browserKeys })
+      },
+
+      removeProjectKey: key => {
+        const projectKeys = { ...get().projectKeys }
+        delete projectKeys[key]
+        set({ projectKeys: Object.keys(projectKeys).length > 0 ? projectKeys : undefined })
       },
 
       setSaveInProject: enabled => {
@@ -122,7 +129,11 @@ export const useProjectKeys = () => useKeysStore(state => state.projectKeys)
 // Utility functions (no state needed)
 export function getKeysForProject(): KeysConfig | undefined {
   const state = getKeysStore()
-  return state.saveInProject ? state.browserKeys : undefined
+  const keys = {
+    ...state.projectKeys,
+    ...(state.saveInProject ? state.browserKeys : {}),
+  }
+  return Object.keys(keys).length > 0 ? keys : undefined
 }
 
 export function getEnvKeys(): KeysConfig {

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -783,6 +783,11 @@ export function getNoodles(): Visualization {
 
       currentProjectRef.current = project
 
+      // Install embedded keys before constructing operators. Key-dependent operators
+      // may inspect credentials while their fields and listeners are initialized.
+      const keysStore = getKeysStore()
+      keysStore.setProjectKeys(apiKeys)
+
       // Dispose all old operators cleanly (executionState.complete() + unsubscribeListeners)
       const store = getOpStore()
       for (const op of store.getAllOps()) {
@@ -822,10 +827,6 @@ export function getNoodles(): Visualization {
       setShowDebugInfo(editorSettings?.showDebugInfo ?? false)
 
       // Render settings are now stored as OutOp inputs (migration 012 handles conversion)
-
-      // Load API keys from project file if present
-      const keysStore = getKeysStore()
-      keysStore.setProjectKeys(apiKeys)
 
       // Restore viewport unless we're in an undo/redo restore
       if (viewport && name && !undoRedoRef.current?.isRestoring()) {


### PR DESCRIPTION
## Summary
- install embedded project keys before operator graph construction
- retain loaded project keys across saves and allow per-key removal
- clarify the browser-key sharing control and plaintext security tradeoff

## Tests
- `npm test -- --run src/noodles/keys-store.test.ts`
- `npm run lint`
- `npm run build`