### PR TITLE
fix: Improve geocoder map selection UX

### DIFF
--- a/noodles-editor/src/noodles/components/__tests__/geocoding-dialog-interactions.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/geocoding-dialog-interactions.test.tsx
@@ -1,0 +1,134 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getKeysStore, useKeysStore } from '../../keys-store'
+import { CARTO_VOYAGER, GeocodingDialog } from '../geocoding-dialog'
+
+const mocks = vi.hoisted(() => ({
+  flyTo: vi.fn(),
+  geocodeWithGooglePlaces: vi.fn(),
+  geocodeWithMapbox: vi.fn(),
+  geocodeWithPhoton: vi.fn(),
+}))
+
+vi.mock('../../../utils/geocoding', () => ({
+  geocodeWithGooglePlaces: mocks.geocodeWithGooglePlaces,
+  geocodeWithMapbox: mocks.geocodeWithMapbox,
+  geocodeWithPhoton: mocks.geocodeWithPhoton,
+}))
+
+vi.mock('react-map-gl/maplibre', () => ({
+  Map: ({ children, mapStyle, onClick, onMove }: any) => (
+    <div data-testid="geocoder-map" data-map-style={mapStyle}>
+      <button
+        type="button"
+        onClick={() =>
+          onMove({ viewState: { longitude: 10, latitude: 20, zoom: 8 } })
+        }
+      >
+        Pan map
+      </button>
+      <button
+        type="button"
+        onClick={() => onClick({ lngLat: { lng: -122.4194, lat: 37.7749 } })}
+      >
+        Click map
+      </button>
+      {children}
+    </div>
+  ),
+  Marker: ({ longitude, latitude }: any) => (
+    <div data-testid="selected-marker" data-longitude={longitude} data-latitude={latitude} />
+  ),
+  NavigationControl: () => null,
+  useMap: () => ({ 'geocoding-map': { flyTo: mocks.flyTo } }),
+}))
+
+describe('GeocodingDialog interactions', () => {
+  const initialValue = { longitude: -74.006, latitude: 40.7128 }
+  const originalGetKey = getKeysStore().getKey
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useKeysStore.setState({
+      browserKeys: {},
+      projectKeys: undefined,
+      saveInProject: false,
+      getKey: () => undefined,
+    })
+    mocks.geocodeWithPhoton.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    useKeysStore.setState({ getKey: originalGetKey })
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  function renderDialog(onLocationSelected = vi.fn()) {
+    render(
+      <GeocodingDialog
+        open
+        onOpenChange={vi.fn()}
+        onLocationSelected={onLocationSelected}
+        initialValue={initialValue}
+        mode="update-field"
+      />
+    )
+    return onLocationSelected
+  }
+
+  it('uses the Voyager street style', () => {
+    renderDialog()
+
+    expect(screen.getByTestId('geocoder-map')).toHaveAttribute('data-map-style', CARTO_VOYAGER)
+  })
+
+  it('does not move the selected pin when the camera pans', () => {
+    const onLocationSelected = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pan map' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Update Field' }))
+
+    expect(onLocationSelected).toHaveBeenCalledWith(initialValue)
+  })
+
+  it('moves the selected pin when the map is clicked', () => {
+    const onLocationSelected = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Click map' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Update Field' }))
+
+    expect(onLocationSelected).toHaveBeenCalledWith({
+      longitude: -122.4194,
+      latitude: 37.7749,
+    })
+  })
+
+  it('shows the fallback provider and selects a search result', async () => {
+    const onLocationSelected = renderDialog()
+    mocks.geocodeWithPhoton.mockResolvedValue([
+      {
+        place_name: 'Bordeaux',
+        coordinates: { longitude: -0.5792, latitude: 44.8378 },
+        context: 'France',
+      },
+    ])
+
+    fireEvent.change(screen.getByPlaceholderText('Search places or paste coordinates...'), {
+      target: { value: 'Bordeaux' },
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+
+    expect(screen.getByLabelText('Geocoding provider: Photon')).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByRole('button', { name: /Bordeaux/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Update Field' }))
+
+    expect(mocks.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: [-0.5792, 44.8378] })
+    )
+    expect(onLocationSelected).toHaveBeenCalledWith({ longitude: -0.5792, latitude: 44.8378 })
+  })
+})

--- a/noodles-editor/src/noodles/components/geocoding-dialog.module.css
+++ b/noodles-editor/src/noodles/components/geocoding-dialog.module.css
@@ -9,16 +9,16 @@
 
 .dialogContent {
   position: fixed;
-  top: 10vh;
+  top: 5vh;
   left: 50%;
   transform: translateX(-50%);
   background-color: #1a1a1a;
   color: var(--color-text-primary);
   border-radius: 12px;
   padding: 1.5rem;
-  max-width: 650px;
+  max-width: 900px;
   width: 90vw;
-  max-height: 85vh;
+  max-height: 90vh;
   overflow-y: auto;
   z-index: var(--z-index-modal);
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
@@ -152,10 +152,16 @@
 
 /* Provider indicator shown after a place search */
 .providerBadge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
   font-size: 0.8rem;
   color: var(--color-text-secondary);
   margin-bottom: 0.75rem;
-  opacity: 0.8;
+  padding: 0.35rem 0.6rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
 }
 
 .providerSettingsLink {
@@ -176,6 +182,7 @@
 
 /* Map Section */
 .mapContainer {
+  height: clamp(420px, 55vh, 600px);
   margin-bottom: 1rem;
   border-radius: 8px;
   overflow: hidden;

--- a/noodles-editor/src/noodles/components/geocoding-dialog.tsx
+++ b/noodles-editor/src/noodles/components/geocoding-dialog.tsx
@@ -22,7 +22,7 @@ import { useUIStore } from '../store'
 import s from './geocoding-dialog.module.css'
 
 const DEFAULT_LOCATION = { longitude: -74.006, latitude: 40.7128, zoom: 12 } // NYC
-const CARTO_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json'
+export const CARTO_VOYAGER = 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json'
 
 interface GeocodingDialogProps {
   open: boolean
@@ -135,9 +135,9 @@ export function GeocodingDialog({
   initialValue,
   mode,
 }: GeocodingDialogProps) {
-  const [mapCoordinates, setMapCoordinates] = useState<MapCoordinates>(
-    initialValue || DEFAULT_LOCATION
-  )
+  const initialLocation = initialValue || DEFAULT_LOCATION
+  const [selectedLocation, setSelectedLocation] = useState(initialLocation)
+  const [viewState, setViewState] = useState<MapCoordinates>(initialLocation)
   const [inputValue, setInputValue] = useState('')
   const [suggestions, setSuggestions] = useState<GeocodingSuggestion[]>([])
   const [showDropdown, setShowDropdown] = useState(false)
@@ -153,10 +153,11 @@ export function GeocodingDialog({
   // Access the map instance for flyTo animations
   const { [MAP_ID]: mapInstance } = useMap()
 
-  // Reset map coordinates when dialog opens with new initial value
+  // Reset both the pin and camera when editing a different value.
   useEffect(() => {
     if (open && initialValue) {
-      setMapCoordinates(initialValue)
+      setSelectedLocation(initialValue)
+      setViewState({ ...initialValue, zoom: 12 })
     }
   }, [open, initialValue])
 
@@ -180,7 +181,8 @@ export function GeocodingDialog({
           essential: true,
         })
       }
-      setMapCoordinates({ ...coordinates, zoom })
+      setSelectedLocation(coordinates)
+      setViewState({ ...coordinates, zoom })
     },
     [mapInstance]
   )
@@ -285,32 +287,30 @@ export function GeocodingDialog({
     [flyToLocation]
   )
 
-  // Handle map click (preserve zoom level)
+  // A click chooses a point. Camera movement alone never changes the selection.
   const handleMapClick = useCallback((event: MapLayerMouseEvent) => {
-    setMapCoordinates(prev => ({
-      ...prev,
+    setSelectedLocation({
       longitude: event.lngLat.lng,
       latitude: event.lngLat.lat,
-    }))
+    })
     analytics.track('geocoding_map_clicked')
   }, [])
 
   // Handle map movement (zoom/pan)
   const handleMove = useCallback((event: ViewStateChangeEvent) => {
-    setMapCoordinates(prev => ({
-      ...prev,
+    setViewState({
       longitude: event.viewState.longitude,
       latitude: event.viewState.latitude,
       zoom: event.viewState.zoom,
-    }))
+    })
   }, [])
 
   // Handle location confirmation
   const handleConfirm = useCallback(() => {
-    onLocationSelected(mapCoordinates)
+    onLocationSelected(selectedLocation)
     analytics.track('geocoding_confirmed', { mode })
     onOpenChange(false)
-  }, [mapCoordinates, onLocationSelected, mode, onOpenChange])
+  }, [selectedLocation, onLocationSelected, mode, onOpenChange])
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -362,7 +362,16 @@ export function GeocodingDialog({
 
           {/* Provider indicator — shown after a place search */}
           {lastSearchProvider && (
-            <div className={s.providerBadge}>
+            <div
+              className={s.providerBadge}
+              aria-label={`Geocoding provider: ${
+                lastSearchProvider === 'google_places'
+                  ? 'Google Places'
+                  : lastSearchProvider === 'mapbox'
+                    ? 'Mapbox'
+                    : 'Photon'
+              }`}
+            >
               {lastSearchProvider === 'photon' ? (
                 <>
                   Using Photon (free, OpenStreetMap).{' '}
@@ -384,22 +393,22 @@ export function GeocodingDialog({
           )}
 
           {/* Map */}
-          {mapCoordinates.longitude != null && mapCoordinates.latitude != null && (
+          {selectedLocation.longitude != null && selectedLocation.latitude != null && (
             <div className={s.mapContainer}>
               <MapLibre
                 id={MAP_ID}
-                mapStyle={CARTO_DARK}
-                style={{ width: '100%', height: '400px' }}
-                longitude={mapCoordinates.longitude}
-                latitude={mapCoordinates.latitude}
-                zoom={mapCoordinates.zoom || 12}
+                mapStyle={CARTO_VOYAGER}
+                style={{ width: '100%', height: '100%' }}
+                longitude={viewState.longitude}
+                latitude={viewState.latitude}
+                zoom={viewState.zoom || 12}
                 onMove={handleMove}
                 onClick={handleMapClick}
               >
                 <NavigationControl position="top-right" showCompass={false} />
                 <Marker
-                  longitude={mapCoordinates.longitude}
-                  latitude={mapCoordinates.latitude}
+                  longitude={selectedLocation.longitude}
+                  latitude={selectedLocation.latitude}
                   anchor="center"
                 />
               </MapLibre>
@@ -409,8 +418,8 @@ export function GeocodingDialog({
           {/* Footer */}
           <div className={s.dialogFooter}>
             <div className={s.coordinateDisplay}>
-              {mapCoordinates.longitude != null && mapCoordinates.latitude != null
-                ? `${mapCoordinates.latitude.toFixed(5)}, ${mapCoordinates.longitude.toFixed(5)}`
+              {selectedLocation.longitude != null && selectedLocation.latitude != null
+                ? `${selectedLocation.latitude.toFixed(5)}, ${selectedLocation.longitude.toFixed(5)}`
                 : 'Loading...'}
             </div>
             <button type="button" className={s.confirmButton} onClick={handleConfirm}>


### PR DESCRIPTION
## Summary
- separate the exploratory map camera from the selected pin
- select coordinates only on map click or search-result selection
- switch the larger responsive preview to Carto Voyager streets
- make the active Google, Mapbox, or Photon provider explicit and accessible

## Tests
- `npm test -- --run src/noodles/components/__tests__/geocoding-dialog.test.ts src/noodles/components/__tests__/geocoding-dialog-interactions.test.tsx`
- `npm run lint`
- `npm run format:check`
- `npm run build`