### PR TITLE
feat: Control the selected MapViewState from the map

### DIFF
--- a/noodles-editor/src/noodles/utils/map-camera-control.test.ts
+++ b/noodles-editor/src/noodles/utils/map-camera-control.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { MapViewStateOp, NumberOp } from '../operators'
+import { getOpStore, setOp } from '../store'
+import {
+  createCameraGestureHistory,
+  extractCameraViewState,
+  getCameraControlState,
+  updateCameraInputs,
+} from './map-camera-control'
+
+describe('selected map camera control', () => {
+  beforeEach(() => getOpStore().clearOps())
+
+  it('enables one selected, editable MapViewStateOp', () => {
+    const camera = new MapViewStateOp('/camera')
+    setOp('/camera', camera)
+
+    expect(getCameraControlState(['/camera'], false)).toMatchObject({
+      op: camera,
+      enabled: true,
+      reason: null,
+    })
+  })
+
+  it('ignores a selected non-camera operator', () => {
+    setOp('/number', new NumberOp('/number'))
+    expect(getCameraControlState(['/number'], false)).toEqual({
+      op: null,
+      enabled: false,
+      reason: null,
+    })
+  })
+
+  it('explains multiple selection, locked nodes, exports, and connected fields', () => {
+    const camera = new MapViewStateOp('/camera')
+    const second = new MapViewStateOp('/second')
+    setOp('/camera', camera)
+    setOp('/second', second)
+
+    expect(getCameraControlState(['/camera', '/second'], false).reason).toMatch(/exactly one/)
+
+    camera.locked.next(true)
+    expect(getCameraControlState(['/camera'], false).reason).toMatch(/Unlock/)
+    camera.locked.next(false)
+
+    expect(getCameraControlState(['/camera'], true).reason).toMatch(/exporting/)
+
+    camera.inputs.longitude.addConnection('edge', new NumberOp('/source').outputs.val)
+    expect(getCameraControlState(['/camera'], false).reason).toMatch(/longitude/)
+  })
+
+  it('extracts camera state from direct and keyed Deck view states', () => {
+    const state = { longitude: 1, latitude: 2, zoom: 3, pitch: 4, bearing: 5 }
+    expect(extractCameraViewState(state)).toEqual(state)
+    expect(extractCameraViewState({ map: state })).toEqual(state)
+    expect(extractCameraViewState({ nope: true })).toBeNull()
+  })
+
+  it('writes all camera fields and refuses connected fields', () => {
+    const camera = new MapViewStateOp('/camera')
+    const state = { longitude: 1, latitude: 2, zoom: 3, pitch: 4, bearing: 5 }
+
+    expect(updateCameraInputs(camera, state)).toBe(true)
+    expect(camera.data).toMatchObject(state)
+
+    camera.inputs.zoom.addConnection('edge', new NumberOp('/source').outputs.val)
+    expect(updateCameraInputs(camera, { ...state, zoom: 10 })).toBe(false)
+    expect(camera.inputs.zoom.value).toBe(0)
+  })
+
+  it('commits one history entry for a gesture with many updates', () => {
+    let captureCount = 0
+    const commits: string[] = []
+    const history = createCameraGestureHistory(
+      () => `before-${++captureCount}`,
+      before => commits.push(before)
+    )
+
+    history.begin()
+    history.begin()
+    history.begin()
+    history.finish()
+    history.finish()
+
+    expect(captureCount).toBe(1)
+    expect(commits).toEqual(['before-1'])
+  })
+})

--- a/noodles-editor/src/noodles/utils/map-camera-control.ts
+++ b/noodles-editor/src/noodles/utils/map-camera-control.ts
@@ -1,0 +1,112 @@
+import { MapViewStateOp } from '../operators'
+import { getOp } from '../store'
+
+export const CAMERA_INPUT_NAMES = [
+  'longitude',
+  'latitude',
+  'zoom',
+  'pitch',
+  'bearing',
+] as const
+
+export interface CameraViewState {
+  longitude: number
+  latitude: number
+  zoom: number
+  pitch?: number
+  bearing?: number
+}
+
+export interface CameraControlState {
+  op: MapViewStateOp | null
+  enabled: boolean
+  reason: string | null
+}
+
+export function createCameraGestureHistory(
+  capture: () => string | null,
+  commit: (before: string) => void
+) {
+  let before: string | null = null
+  return {
+    begin() {
+      if (before === null) before = capture()
+    },
+    finish() {
+      if (before === null) return
+      commit(before)
+      before = null
+    },
+  }
+}
+
+export function getCameraControlState(
+  selectedNodeIds: string[],
+  isRendering: boolean
+): CameraControlState {
+  if (selectedNodeIds.length !== 1) {
+    const includesCamera = selectedNodeIds.some(id => getOp(id) instanceof MapViewStateOp)
+    return {
+      op: null,
+      enabled: false,
+      reason: includesCamera ? 'Select exactly one MapViewState node to edit the camera.' : null,
+    }
+  }
+
+  const selectedOp = getOp(selectedNodeIds[0])
+  if (!(selectedOp instanceof MapViewStateOp)) return { op: null, enabled: false, reason: null }
+  if (isRendering) {
+    return {
+      op: selectedOp,
+      enabled: false,
+      reason: 'Camera controls are disabled while exporting.',
+    }
+  }
+  if (selectedOp.locked.value) {
+    return { op: selectedOp, enabled: false, reason: 'Unlock the MapViewState node to edit it.' }
+  }
+
+  const connectedFields = CAMERA_INPUT_NAMES.filter(
+    name => selectedOp.inputs[name].subscriptions.size > 0
+  )
+  if (connectedFields.length > 0) {
+    return {
+      op: selectedOp,
+      enabled: false,
+      reason: `Disconnect camera inputs to drag the map: ${connectedFields.join(', ')}.`,
+    }
+  }
+
+  return { op: selectedOp, enabled: true, reason: null }
+}
+
+export function extractCameraViewState(value: unknown): CameraViewState | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  if (
+    typeof record.longitude === 'number' &&
+    typeof record.latitude === 'number' &&
+    typeof record.zoom === 'number'
+  ) {
+    return record as unknown as CameraViewState
+  }
+
+  for (const nested of Object.values(record)) {
+    const camera = extractCameraViewState(nested)
+    if (camera) return camera
+  }
+  return null
+}
+
+export function updateCameraInputs(op: MapViewStateOp, value: unknown): boolean {
+  const viewState = extractCameraViewState(value)
+  if (!viewState || op.locked.value) return false
+  if (CAMERA_INPUT_NAMES.some(name => op.inputs[name].subscriptions.size > 0)) return false
+
+  op.inputs.longitude.setValue(viewState.longitude)
+  op.inputs.latitude.setValue(viewState.latitude)
+  op.inputs.zoom.setValue(viewState.zoom)
+  op.inputs.pitch.setValue(viewState.pitch ?? op.inputs.pitch.value)
+  op.inputs.bearing.setValue(viewState.bearing ?? op.inputs.bearing.value)
+  return true
+}

--- a/noodles-editor/src/timeline-editor.module.css
+++ b/noodles-editor/src/timeline-editor.module.css
@@ -5,3 +5,18 @@
   display: flex;
   flex-direction: row;
 }
+
+.cameraControlStatus {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: var(--z-index-chrome);
+  max-width: min(360px, calc(100% - 16px));
+  padding: 6px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 5px;
+  background: rgba(18, 24, 34, 0.88);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  pointer-events: none;
+}

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -16,6 +16,15 @@ import { useActiveOutOp } from './noodles/hooks/use-active-outop'
 import { useRenderSettings } from './noodles/hooks/use-render-settings'
 import { getNoodles } from './noodles/noodles'
 import { fnWithSource } from './noodles/operators'
+import {
+  createCameraGestureHistory,
+  getCameraControlState,
+  updateCameraInputs,
+} from './noodles/utils/map-camera-control'
+import {
+  captureOperatorInputs,
+  firePropertyMutation,
+} from './noodles/utils/property-history'
 import type { RenderSettings } from './noodles/utils/serialization'
 import { useDeckDrawLoop } from './render/draw-loop'
 import { captureScreenshot, useRenderer } from './render/renderer'
@@ -130,6 +139,32 @@ export default function TimelineEditor() {
     })
   isRenderingRef.current = isRendering
 
+  const cameraControl = getCameraControlState(selectedNodeIds ?? [], isRendering)
+  const cameraHistoryRef = useRef(
+    createCameraGestureHistory(captureOperatorInputs, before =>
+      firePropertyMutation('Move map camera', before)
+    )
+  )
+  const deckCameraGestureActiveRef = useRef(false)
+
+  const beginCameraGesture = useCallback(() => {
+    if (!cameraControl.enabled) return
+    cameraHistoryRef.current.begin()
+  }, [cameraControl.enabled])
+
+  const updateSelectedCamera = useCallback(
+    (viewState: unknown) => {
+      if (!cameraControl.enabled || !cameraControl.op) return
+      beginCameraGesture()
+      updateCameraInputs(cameraControl.op, viewState)
+    },
+    [beginCameraGesture, cameraControl]
+  )
+
+  const finishCameraGesture = useCallback(() => {
+    cameraHistoryRef.current.finish()
+  }, [])
+
   // If the visualization doesn't supply mapProps (or has a blank mapStyle), disable basemap.
   // A blank mapStyle is treated as transparent — DeckGL renders without map tiles.
   // TODO: Detect if deck is in othorgraphic mode, and disable?
@@ -140,15 +175,35 @@ export default function TimelineEditor() {
   const lastFrameTimeRef = useRef(Date.now())
   const fpsRef = useRef(0)
 
+  const visualizationDeckProps = visualization.deckProps
   const deckProps: DeckProps = {
     ...deckRenderingDefaults,
-    ...visualization.deckProps,
+    ...visualizationDeckProps,
+    controller: !basemapEnabled && cameraControl.enabled,
+    onViewStateChange: params => {
+      const result = visualizationDeckProps?.onViewStateChange?.(params)
+      if (!basemapEnabled) updateSelectedCamera(result ?? params.viewState)
+      return result
+    },
+    onInteractionStateChange: interactionState => {
+      visualizationDeckProps?.onInteractionStateChange?.(interactionState)
+      if (basemapEnabled || !cameraControl.enabled) return
+      const active = Boolean(
+        interactionState.isDragging ||
+          interactionState.isPanning ||
+          interactionState.isRotating ||
+          interactionState.isZooming
+      )
+      if (active && !deckCameraGestureActiveRef.current) beginCameraGesture()
+      if (!active && deckCameraGestureActiveRef.current) finishCameraGesture()
+      deckCameraGestureActiveRef.current = active
+    },
     onDeviceInitialized: device => {
-      visualization.deckProps?.onDeviceInitialized?.(device)
+      visualizationDeckProps?.onDeviceInitialized?.(device)
       redraw()
     },
     onAfterRender: () => {
-      visualization.deckProps?.onAfterRender?.()
+      visualizationDeckProps?.onAfterRender?.()
 
       // Track FPS and stats for Claude AI debugging
       // Use deck.gl's built-in fps metric when available
@@ -172,7 +227,14 @@ export default function TimelineEditor() {
   }
 
   // Destructure light and sky since they're applied imperatively via setLight/setSky
-  const { light, sky, ...basemapProps } = visualization.mapProps ?? {}
+  const {
+    light,
+    sky,
+    onMove: visualizationOnMove,
+    onMoveStart: visualizationOnMoveStart,
+    onMoveEnd: visualizationOnMoveEnd,
+    ...basemapProps
+  } = visualization.mapProps ?? {}
   const mapProps: MapProps = {
     ...mapRenderingDefaults,
     onLoad: ({ target: map }) => {
@@ -182,6 +244,27 @@ export default function TimelineEditor() {
     },
     ...basemapProps,
     maxPitch: Math.min(basemapProps?.maxPitch ?? 85, 85),
+    interactive: cameraControl.enabled,
+    dragPan: cameraControl.enabled,
+    dragRotate: cameraControl.enabled,
+    scrollZoom: cameraControl.enabled,
+    boxZoom: cameraControl.enabled,
+    doubleClickZoom: cameraControl.enabled,
+    keyboard: cameraControl.enabled,
+    touchZoomRotate: cameraControl.enabled,
+    touchPitch: cameraControl.enabled,
+    onMoveStart: event => {
+      visualizationOnMoveStart?.(event)
+      beginCameraGesture()
+    },
+    onMove: event => {
+      visualizationOnMove?.(event)
+      updateSelectedCamera(event.viewState)
+    },
+    onMoveEnd: event => {
+      visualizationOnMoveEnd?.(event)
+      finishCameraGesture()
+    },
   }
 
   // Apply light and sky settings imperatively to avoid style reloading
@@ -618,6 +701,11 @@ export default function TimelineEditor() {
             flowGraph={flowGraph}
             spreadsheet={<SpreadsheetPane selectedNodeIds={selectedNodeIds ?? []} />}
           >
+            {cameraControl.reason && (
+              <div className={s.cameraControlStatus} role="status">
+                {cameraControl.reason}
+              </div>
+            )}
             {isFixedMode ? (
               <TransformScale scale={renderSettings.scaleControl}>
                 <ErrorBoundary title="Visualization Error">{renderContent()}</ErrorBoundary>


### PR DESCRIPTION
## Summary
- enable MapLibre and pure Deck camera controls when exactly one editable MapViewState node is selected
- write longitude, latitude, zoom, pitch, and bearing back to operator fields
- guard locked, connected, multi-selected, and exporting states with clear feedback
- record a complete camera gesture as one property-history entry

## Tests
- `npm test -- --run src/noodles/utils/map-camera-control.test.ts src/noodles/utils/property-history.test.ts`
- `npm run lint`
- `npm run format:check`
- `npm run build`