### PR TITLE
fix: Fit fixed previews to the map panel

### DIFF
--- a/noodles-editor/src/noodles/components/render-settings-panel.test.tsx
+++ b/noodles-editor/src/noodles/components/render-settings-panel.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { OutOp } from '../operators'
+import { RenderSettingsPanel } from './render-settings-panel'
+
+describe('RenderSettingsPanel preview scale', () => {
+  it('defaults to Fit and preserves manual scale while its slider is hidden', () => {
+    const op = new OutOp('/out')
+    render(<RenderSettingsPanel op={op} />)
+
+    const previewMode = screen.getByLabelText('Preview')
+    expect(previewMode).toHaveValue('fit')
+    expect(screen.queryByLabelText('Scale')).not.toBeInTheDocument()
+
+    fireEvent.change(previewMode, { target: { value: 'manual' } })
+    const manualScale = screen.getByLabelText('Scale')
+    fireEvent.change(manualScale, { target: { value: '0.65' } })
+    expect(op.inputs.scaleControl.value).toBe(0.65)
+
+    fireEvent.change(previewMode, { target: { value: 'fit' } })
+    expect(screen.queryByLabelText('Scale')).not.toBeInTheDocument()
+    expect(op.inputs.scaleControl.value).toBe(0.65)
+
+    fireEvent.change(previewMode, { target: { value: 'manual' } })
+    expect(screen.getByLabelText('Scale')).toHaveValue('0.65')
+  })
+})

--- a/noodles-editor/src/noodles/components/render-settings-panel.tsx
+++ b/noodles-editor/src/noodles/components/render-settings-panel.tsx
@@ -33,6 +33,7 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
   const [width, setWidth] = useState(op.inputs.width.value)
   const [height, setHeight] = useState(op.inputs.height.value)
   const [lod, setLod] = useState(op.inputs.lod.value)
+  const [scaleMode, setScaleMode] = useState(op.inputs.scaleMode.value)
   const [scaleControl, setScaleControl] = useState(op.inputs.scaleControl.value)
   const [codec, setCodec] = useState(op.inputs.codec.value)
   const [framerate, setFramerate] = useState(op.inputs.framerate.value)
@@ -48,6 +49,7 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
       op.inputs.width.subscribe(v => setWidth(v)),
       op.inputs.height.subscribe(v => setHeight(v)),
       op.inputs.lod.subscribe(v => setLod(v)),
+      op.inputs.scaleMode.subscribe(v => setScaleMode(v)),
       op.inputs.scaleControl.subscribe(v => setScaleControl(v)),
       op.inputs.codec.subscribe(v => setCodec(v)),
       op.inputs.framerate.subscribe(v => setFramerate(v)),
@@ -76,6 +78,7 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
     op.inputs.width.setValue(DEFAULT_RENDER_SETTINGS.resolution.width)
     op.inputs.height.setValue(DEFAULT_RENDER_SETTINGS.resolution.height)
     op.inputs.lod.setValue(DEFAULT_RENDER_SETTINGS.lod)
+    op.inputs.scaleMode.setValue(DEFAULT_RENDER_SETTINGS.scaleMode)
     op.inputs.scaleControl.setValue(DEFAULT_RENDER_SETTINGS.scaleControl)
     op.inputs.codec.setValue(DEFAULT_RENDER_SETTINGS.codec)
     op.inputs.framerate.setValue(DEFAULT_RENDER_SETTINGS.framerate)
@@ -165,21 +168,38 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
             </div>
 
             <div className={s.settingRow}>
-              <label htmlFor="render-scale-control" className={s.label}>
-                Scale
+              <label htmlFor="render-scale-mode" className={s.label}>
+                Preview
               </label>
-              <input
-                id="render-scale-control"
-                type="range"
-                min="0.1"
-                max="1"
-                step="0.05"
-                value={scaleControl}
-                onChange={e => op.inputs.scaleControl.setValue(Number(e.target.value))}
-                className={s.slider}
-              />
-              <span className={s.value}>{Math.round(scaleControl * 100)}%</span>
+              <select
+                id="render-scale-mode"
+                className={s.select}
+                value={scaleMode}
+                onChange={e => op.inputs.scaleMode.setValue(e.target.value as 'fit' | 'manual')}
+              >
+                <option value="fit">Fit to panel</option>
+                <option value="manual">Manual scale</option>
+              </select>
             </div>
+
+            {scaleMode === 'manual' && (
+              <div className={s.settingRow}>
+                <label htmlFor="render-scale-control" className={s.label}>
+                  Scale
+                </label>
+                <input
+                  id="render-scale-control"
+                  type="range"
+                  min="0.1"
+                  max="1"
+                  step="0.05"
+                  value={scaleControl}
+                  onChange={e => op.inputs.scaleControl.setValue(Number(e.target.value))}
+                  className={s.slider}
+                />
+                <span className={s.value}>{Math.round(scaleControl * 100)}%</span>
+              </div>
+            )}
           </>
         )}
 

--- a/noodles-editor/src/noodles/hooks/use-render-settings.ts
+++ b/noodles-editor/src/noodles/hooks/use-render-settings.ts
@@ -28,6 +28,7 @@ export function useRenderSettings(): RenderSettings {
       outOp.inputs.width.subscribe(() => updateSettings()),
       outOp.inputs.height.subscribe(() => updateSettings()),
       outOp.inputs.lod.subscribe(() => updateSettings()),
+      outOp.inputs.scaleMode.subscribe(() => updateSettings()),
       outOp.inputs.waitForData.subscribe(() => updateSettings()),
       outOp.inputs.codec.subscribe(() => updateSettings()),
       outOp.inputs.bitrateMbps.subscribe(() => updateSettings()),
@@ -65,6 +66,7 @@ export function getRenderSettingsFromOutOp(outOp: OutOp): RenderSettings {
       height: outOp.inputs.height.value,
     },
     lod: outOp.inputs.lod.value,
+    scaleMode: outOp.inputs.scaleMode.value as RenderSettings['scaleMode'],
     waitForData: outOp.inputs.waitForData.value,
     codec: outOp.inputs.codec.value as RenderSettings['codec'],
     bitrateMbps: outOp.inputs.bitrateMbps.value,
@@ -88,6 +90,9 @@ export function setRenderSettingsOnOutOp(outOp: OutOp, settings: Partial<RenderS
   }
   if (settings.lod !== undefined) {
     outOp.inputs.lod.setValue(settings.lod)
+  }
+  if (settings.scaleMode !== undefined) {
+    outOp.inputs.scaleMode.setValue(settings.scaleMode)
   }
   if (settings.waitForData !== undefined) {
     outOp.inputs.waitForData.setValue(settings.waitForData)

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4894,6 +4894,7 @@ export class OutOp extends Operator<OutOp> {
       width: new NumberField(1920, { min: 1, max: 8192, step: 1 }),
       height: new NumberField(1080, { min: 1, max: 8192, step: 1 }),
       lod: new NumberField(2, { min: 0.1, max: 4, step: 0.1 }),
+      scaleMode: new StringLiteralField('fit', ['fit', 'manual']),
       waitForData: new BooleanField(true),
       codec: new StringLiteralField('avc', ['avc', 'hevc', 'vp9', 'av1']),
       bitrateMbps: new NumberField(10, { min: 1, max: 100, step: 1 }),

--- a/noodles-editor/src/noodles/utils/render-settings-constants.ts
+++ b/noodles-editor/src/noodles/utils/render-settings-constants.ts
@@ -5,6 +5,7 @@ export type RenderSettings = {
   display: 'fixed' | 'responsive'
   resolution: { width: number; height: number }
   lod: number
+  scaleMode: 'fit' | 'manual'
   waitForData: boolean
   codec: 'avc' | 'hevc' | 'vp9' | 'av1'
   bitrateMbps: number
@@ -19,6 +20,7 @@ export const DEFAULT_RENDER_SETTINGS: RenderSettings = {
   display: 'fixed',
   resolution: { width: 1920, height: 1080 },
   lod: 2,
+  scaleMode: 'fit',
   waitForData: true,
   codec: 'avc',
   bitrateMbps: 10,

--- a/noodles-editor/src/render/transform-scale.test.ts
+++ b/noodles-editor/src/render/transform-scale.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from 'vitest'
-import { getTransformScaleFactor } from './transform-scale'
+import { act, render } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { calculateFitScale, getTransformScaleFactor, TransformScale } from './transform-scale'
+
+describe('calculateFitScale', () => {
+  it('fits within the panel content box with 8px on each side', () => {
+    expect(calculateFitScale(1000, 600, 1920, 1080)).toBeCloseTo(984 / 1920)
+    expect(calculateFitScale(500, 1000, 1920, 1080)).toBeCloseTo(484 / 1920)
+  })
+
+  it('never enlarges the fixed-resolution surface', () => {
+    expect(calculateFitScale(2000, 1200, 800, 600)).toBe(1)
+  })
+})
 
 describe('getTransformScaleFactor', () => {
   it('returns {x: 1, y: 1} for elements with no transform', () => {
@@ -27,5 +40,71 @@ describe('getTransformScaleFactor', () => {
     element.style.transform = 'scaleX(1.5) scaleY(2)'
     document.body.appendChild(element)
     expect(getTransformScaleFactor(element)).toEqual({ x: 1.5, y: 2 })
+  })
+})
+
+describe('TransformScale', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('observes the panel and untransformed surface and recomputes Fit scale', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback)
+      }
+      observe() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+
+    const { container } = render(
+      createElement(
+        'div',
+        { style: { position: 'relative', width: 1000, height: 600 } },
+        createElement(
+          TransformScale,
+          { scale: 0.3, scaleMode: 'fit' },
+          createElement('div', { style: { width: 1920, height: 1080 } })
+        )
+      )
+    )
+
+    const stage = container.querySelector<HTMLElement>('.transform-scale-stage')!
+    const surface = container.querySelector<HTMLElement>('.transform-scale')!
+    let panelWidth = 1000
+    Object.defineProperties(stage, {
+      clientWidth: { get: () => panelWidth },
+      clientHeight: { get: () => 600 },
+    })
+    Object.defineProperties(surface, {
+      offsetWidth: { get: () => 1920 },
+      offsetHeight: { get: () => 1080 },
+    })
+    act(() => callbacks[0]([], {} as ResizeObserver))
+    expect(surface.style.transform).toBe(`scale(${984 / 1920})`)
+
+    panelWidth = 500
+    act(() => callbacks[0]([], {} as ResizeObserver))
+    expect(Number(surface.style.transform.match(/scale\(([^)]+)\)/)?.[1])).toBeCloseTo(484 / 1920)
+    expect(stage.dataset.scaleMode).toBe('fit')
+    expect(surface.style.transformOrigin).toBe('center center')
+  })
+
+  it('uses the saved manual scale without fitting', () => {
+    const { container } = render(
+      createElement(
+        'div',
+        { style: { position: 'relative', width: 1000, height: 600 } },
+        createElement(
+          TransformScale,
+          { scale: 0.65, scaleMode: 'manual' },
+          createElement('div', { style: { width: 1920, height: 1080 } })
+        )
+      )
+    )
+
+    const surface = container.querySelector<HTMLElement>('.transform-scale')!
+    expect(surface.style.transform).toBe('scale(0.65)')
+    expect(surface.style.transformOrigin).toBe('left top')
   })
 })

--- a/noodles-editor/src/render/transform-scale.tsx
+++ b/noodles-editor/src/render/transform-scale.tsx
@@ -1,4 +1,20 @@
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
+
+const FIT_PADDING_PX = 16
+
+export function calculateFitScale(
+  panelWidth: number,
+  panelHeight: number,
+  surfaceWidth: number,
+  surfaceHeight: number
+): number {
+  return Math.min(
+    (panelWidth - FIT_PADDING_PX) / surfaceWidth,
+    (panelHeight - FIT_PADDING_PX) / surfaceHeight,
+    1
+  )
+}
 
 // Get CSS scale of an element, e.g. CSS transform: "scale(2)" returns { x: 2, y: 2 }
 export function getTransformScaleFactor(target: Element): { x: number; y: number } {
@@ -21,16 +37,72 @@ export function getTransformScaleFactor(target: Element): { x: number; y: number
   return { x: scaleX, y: scaleY }
 }
 
-export function TransformScale({ scale, children }: { scale: number; children: ReactNode }) {
+export function TransformScale({
+  scale,
+  scaleMode = 'manual',
+  children,
+}: {
+  scale: number
+  scaleMode?: 'fit' | 'manual'
+  children: ReactNode
+}) {
+  const stageRef = useRef<HTMLDivElement>(null)
+  const surfaceRef = useRef<HTMLDivElement>(null)
+  const [fitScale, setFitScale] = useState(1)
+  const isFit = scaleMode === 'fit'
+
+  useLayoutEffect(() => {
+    if (!isFit) return
+
+    const stage = stageRef.current
+    const surface = surfaceRef.current
+    if (!stage || !surface) return
+
+    const updateScale = () => {
+      // client/offset dimensions are CSS layout boxes and exclude CSS transforms.
+      const panelWidth = stage.clientWidth
+      const panelHeight = stage.clientHeight
+      const surfaceWidth = surface.offsetWidth
+      const surfaceHeight = surface.offsetHeight
+      if (panelWidth <= FIT_PADDING_PX || panelHeight <= FIT_PADDING_PX) return
+      if (surfaceWidth <= 0 || surfaceHeight <= 0) return
+      setFitScale(calculateFitScale(panelWidth, panelHeight, surfaceWidth, surfaceHeight))
+    }
+
+    updateScale()
+    const observer = new ResizeObserver(updateScale)
+    observer.observe(stage)
+    observer.observe(surface)
+    return () => observer.disconnect()
+  }, [isFit])
+
+  const stageStyle: CSSProperties = {
+    position: 'absolute',
+    inset: 0,
+    overflow: 'hidden',
+    ...(isFit ? { display: 'flex', alignItems: 'center', justifyContent: 'center' } : undefined),
+  }
+
   return (
     <div
-      className="transform-scale"
-      style={{
-        transform: `scale(${scale})`,
-        transformOrigin: 'top left',
-      }}
+      className="transform-scale-stage"
+      data-scale-mode={scaleMode}
+      ref={stageRef}
+      style={stageStyle}
     >
-      {children}
+      <div
+        ref={surfaceRef}
+        className="transform-scale"
+        style={{
+          flex: '0 0 auto',
+          width: 'max-content',
+          height: 'max-content',
+          transform: `scale(${isFit ? fitScale : scale})`,
+          transformOrigin: isFit ? 'center center' : 'top left',
+        }}
+      >
+        {children}
+      </div>
     </div>
   )
 }

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -622,7 +622,10 @@ export default function TimelineEditor() {
             spreadsheet={<SpreadsheetPane selectedNodeIds={selectedNodeIds ?? []} />}
           >
             {isFixedMode ? (
-              <TransformScale scale={renderSettings.scaleControl}>
+              <TransformScale
+                scale={renderSettings.scaleControl}
+                scaleMode={renderSettings.scaleMode}
+              >
                 <ErrorBoundary title="Visualization Error">{renderContent()}</ErrorBoundary>
               </TransformScale>
             ) : (


### PR DESCRIPTION
## Summary

Before/After

https://github.com/user-attachments/assets/76f442fc-cf76-44d1-a29e-aaa5cc7f5f6b

- add `OutOp.scaleMode` with an absent-field default of `fit`, while retaining the existing saved `scaleControl` for Manual mode
- measure the available panel content box and fixed visualization surface's untransformed DOM box with `ResizeObserver`
- calculate `min((panelWidth - 16) / surfaceWidth, (panelHeight - 16) / surfaceHeight, 1)` and apply it only through the existing CSS transform
- center the surface in a dedicated stage so transformed dimensions cannot push it off-screen
- hide the Manual slider in Fit mode without changing its value; preview scale remains independent of export dimensions

## Scope

This PR is now standalone on `main`. The closed #557 documentation/effective-canvas branch and its screenshots, evidence, helper, and documentation changes are not included. Fit observes `clientWidth/clientHeight` and `offsetWidth/offsetHeight` directly.

## Test plan

- [x] Fit formula, cap-at-1, and ResizeObserver recomputation
- [x] Fit/Manual switching and saved slider preservation
- [x] absent `scaleMode` uses the OutOp default (`fit`)
- [x] legacy render-settings migration suite
- [x] `npm test -- --run src/render/transform-scale.test.ts src/noodles/components/render-settings-panel.test.tsx src/noodles/__migrations__/012-render-settings-to-outop.test.ts`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
