### PR TITLE
Fix: initial container output publication

### DIFF
--- a/noodles-editor/src/noodles/container-integration.test.ts
+++ b/noodles-editor/src/noodles/container-integration.test.ts
@@ -254,6 +254,78 @@ describe('Container Integration with Transform Graph', () => {
     expect(viewer.inputs.data.value).toBe(14)
   })
 
+  it('uses the same GraphOutput for scheduling and execution when a container has multiple', async () => {
+    const nodes: NodeJSON<OpType>[] = [
+      {
+        id: '/analysis',
+        type: 'ContainerOp',
+        position: { x: 0, y: 0 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/analysis/selected-output',
+        type: 'GraphOutputOp',
+        position: { x: 300, y: 0 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/analysis/other-output',
+        type: 'GraphOutputOp',
+        position: { x: 300, y: 100 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/selected-value',
+        type: 'NumberOp',
+        position: { x: 100, y: 0 },
+        data: { inputs: { val: 10 } },
+      },
+      {
+        id: '/other-value',
+        type: 'NumberOp',
+        position: { x: 100, y: 100 },
+        data: { inputs: { val: 20 } },
+      },
+      {
+        id: '/viewer',
+        type: 'ViewerOp',
+        position: { x: 400, y: 0 },
+        data: { inputs: {} },
+      },
+    ]
+    const edges: Edge[] = [
+      {
+        id: '/selected-value.out.val->/analysis/selected-output.par.value',
+        source: '/selected-value',
+        target: '/analysis/selected-output',
+        sourceHandle: 'out.val',
+        targetHandle: 'par.value',
+      },
+      {
+        id: '/other-value.out.val->/analysis/other-output.par.value',
+        source: '/other-value',
+        target: '/analysis/other-output',
+        sourceHandle: 'out.val',
+        targetHandle: 'par.value',
+      },
+      {
+        id: '/analysis.out.out->/viewer.par.data',
+        source: '/analysis',
+        target: '/viewer',
+        sourceHandle: 'out.out',
+        targetHandle: 'par.data',
+      },
+    ]
+
+    transformGraph({ nodes, edges })
+    await getExecutor()!.executeFrame(performance.now())
+
+    const container = getOp('/analysis') as ContainerOp
+    const viewer = getOp('/viewer') as ViewerOp
+    expect(container.outputs.out.value).toBe(10)
+    expect(viewer.inputs.data.value).toBe(10)
+  })
+
   describe('Container Custom Field Integration', () => {
     it('GraphInputOp mirrors container custom parameters as outputs', () => {
       const nodes: NodeJSON<OpType>[] = [

--- a/noodles-editor/src/noodles/container-integration.test.ts
+++ b/noodles-editor/src/noodles/container-integration.test.ts
@@ -1,8 +1,9 @@
 import type { NodeJSON } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getExecutor } from './graph-executor'
 import type { Edge } from './noodles'
 import type { OpType } from './operators'
-import { ContainerOp, GraphInputOp, GraphOutputOp } from './operators'
+import { ContainerOp, GraphInputOp, GraphOutputOp, type ViewerOp } from './operators'
 import { clearOps, getOp } from './store'
 import { transformGraph } from './transform-graph'
 
@@ -177,6 +178,80 @@ describe('Container Integration with Transform Graph', () => {
 
     // The container should return the value from its child GraphOutputOp
     expect(result.out).toBe('container-output-value')
+  })
+
+  it('pulls the child GraphOutput before publishing the initial container output', async () => {
+    const nodes: NodeJSON<OpType>[] = [
+      {
+        id: '/analysis',
+        type: 'ContainerOp',
+        position: { x: 0, y: 0 },
+        data: { inputs: { in: 5 } },
+      },
+      {
+        id: '/analysis/input',
+        type: 'GraphInputOp',
+        position: { x: 100, y: 0 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/analysis/double',
+        type: 'MathOp',
+        position: { x: 200, y: 0 },
+        data: { inputs: { operator: 'multiply', b: 2 } },
+      },
+      {
+        id: '/analysis/output',
+        type: 'GraphOutputOp',
+        position: { x: 300, y: 0 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/viewer',
+        type: 'ViewerOp',
+        position: { x: 400, y: 0 },
+        data: { inputs: {} },
+      },
+    ]
+    const edges: Edge[] = [
+      {
+        id: '/analysis/input.out.value->/analysis/double.par.a',
+        source: '/analysis/input',
+        target: '/analysis/double',
+        sourceHandle: 'out.value',
+        targetHandle: 'par.a',
+      },
+      {
+        id: '/analysis/double.out.result->/analysis/output.par.value',
+        source: '/analysis/double',
+        target: '/analysis/output',
+        sourceHandle: 'out.result',
+        targetHandle: 'par.value',
+      },
+      {
+        id: '/analysis.out.out->/viewer.par.data',
+        source: '/analysis',
+        target: '/viewer',
+        sourceHandle: 'out.out',
+        targetHandle: 'par.data',
+      },
+    ]
+
+    transformGraph({ nodes, edges })
+    await getExecutor()!.executeFrame(performance.now())
+
+    const output = getOp('/analysis/output') as GraphOutputOp
+    const container = getOp('/analysis') as ContainerOp
+    const viewer = getOp('/viewer') as ViewerOp
+    expect(output.outputs.propagatedValue.value).toBe(10)
+    expect(container.outputs.out.value).toBe(10)
+    expect(viewer.inputs.data.value).toBe(10)
+
+    container.inputs.in.setValue(7)
+    await getExecutor()!.executeFrame(performance.now())
+    expect(output.outputs.propagatedValue.value).toBe(14)
+    expect(container.outputs.out.value).toBe(14)
+    expect(viewer.inputs.data.value).toBe(14)
   })
 
   describe('Container Custom Field Integration', () => {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -6977,6 +6977,8 @@ export class ContainerOp extends Operator<ContainerOp> {
   static description = 'Encapsulates a subgraph of operators. Visually groups child nodes.'
   static supportsCustomFields = true
 
+  private graphOutputOp?: GraphOutputOp
+
   createInputs() {
     return { in: new UnknownField(null, { optional: true }) }
   }
@@ -6985,17 +6987,34 @@ export class ContainerOp extends Operator<ContainerOp> {
     return { out: new UnknownField(null, { optional: true }) }
   }
 
+  setGraphOutputOp(output?: GraphOutputOp) {
+    if (this.graphOutputOp === output) return
+
+    if (this.graphOutputOp) {
+      this.graphOutputOp.removeDownstreamDependent(this)
+      this.removeUpstreamDependency(this.graphOutputOp)
+    }
+
+    this.graphOutputOp = output
+    if (output) {
+      output.addDownstreamDependent(this)
+      this.addUpstreamDependency(output)
+    }
+    this.markDirty()
+  }
+
   execute(_: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    let outputValue = null
     // The 'in' port of ContainerOp drives its execution.
     // The 'out' port should reflect the value from a GraphOutputOp inside it.
-    for (const op of getAllOps()) {
-      if (op instanceof GraphOutputOp && isDirectChild(op.id, this.id)) {
-        outputValue = op.outputs.propagatedValue.value
-        break // Take the first one found
-      }
-    }
-    return { out: outputValue }
+    const output =
+      this.graphOutputOp ??
+      getAllOps().find(op => op instanceof GraphOutputOp && isDirectChild(op.id, this.id))
+    return { out: output?.outputs.propagatedValue.value ?? null }
+  }
+
+  dispose() {
+    this.setGraphOutputOp(undefined)
+    super.dispose()
   }
 }
 

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -54,28 +54,6 @@ export type NodeJSON<T extends OpType> = ReactFlowNode<
   type: T
 }
 
-const containerOutputDependencies = new WeakMap<ContainerOp, GraphOutputOp>()
-
-function setContainerOutputDependency(container: ContainerOp, output?: GraphOutputOp) {
-  const previousOutput = containerOutputDependencies.get(container)
-  if (previousOutput === output) return
-
-  if (previousOutput) {
-    previousOutput.removeDownstreamDependent(container)
-    container.removeUpstreamDependency(previousOutput)
-  }
-
-  if (output) {
-    output.addDownstreamDependent(container)
-    container.addUpstreamDependency(output)
-    containerOutputDependencies.set(container, output)
-  } else {
-    containerOutputDependencies.delete(container)
-  }
-
-  container.markDirty()
-}
-
 function topologicalSort<N extends Operator<IOperator>>(
   nodes: NodeJSON<OpType>[],
   edges: Edge<N, N>[]
@@ -227,11 +205,13 @@ export function transformGraph<
   // A container's output boundary is structural, not a persisted React Flow edge.
   // Include it in the executor graph so the container cannot race its child
   // GraphOutputOp as an independent root during the first frame.
+  const containerOutputNodeIds = new Map<string, string>()
   const implicitContainerOutputEdges: ExecutorEdge[] = nodes.flatMap(containerNode => {
     if (containerNode.type !== 'ContainerOp') return []
     const outputNode = nodes.find(
       node => node.type === 'GraphOutputOp' && isDirectChild(node.id, containerNode.id)
     )
+    if (outputNode) containerOutputNodeIds.set(containerNode.id, outputNode.id)
     if (
       !outputNode ||
       edges.some(edge => edge.source === outputNode.id && edge.target === containerNode.id)
@@ -521,16 +501,13 @@ export function transformGraph<
   for (const op of store.getAllOps()) {
     if (op instanceof ContainerOp) {
       const containerOp = op
-      const graphOutput = store
-        .getAllOps()
-        .find(
-          (childOp): childOp is GraphOutputOp =>
-            childOp instanceof GraphOutputOp && isDirectChild(childOp.id, containerOp.id)
-        )
+      const graphOutputId = containerOutputNodeIds.get(containerOp.id)
+      const selectedOutput = graphOutputId ? store.getOp(graphOutputId) : undefined
+      const graphOutput = selectedOutput instanceof GraphOutputOp ? selectedOutput : undefined
       // The implicit executor edge above establishes scheduling order. Mirror
       // it in Operator's pull graph so a downstream pull awaits the child
       // output and future child updates dirty the container and its consumers.
-      setContainerOutputDependency(containerOp, graphOutput)
+      containerOp.setGraphOutputOp(graphOutput)
 
       for (const childOp of store.getAllOps()) {
         if (childOp instanceof GraphInputOp && isDirectChild(childOp.id, containerOp.id)) {

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -4,7 +4,14 @@ import { getFieldReferences, ListField } from './fields'
 import { type Edge as ExecutorEdge, updateGraph } from './graph-executor'
 import type { Edge } from './noodles'
 import type { IOperator, Operator, OpType } from './operators'
-import { ContainerOp, ForLoopEndOp, GraphInputOp, opTypes, type SpecialNodeType } from './operators'
+import {
+  ContainerOp,
+  ForLoopEndOp,
+  GraphInputOp,
+  GraphOutputOp,
+  opTypes,
+  type SpecialNodeType,
+} from './operators'
 import { getOpStore } from './store'
 import { validateConnection } from './utils/can-connect'
 import { edgeId } from './utils/id-utils'
@@ -45,6 +52,28 @@ export type NodeJSON<T extends OpType> = ReactFlowNode<
   NodeDataJSON<InstanceType<(typeof opTypes)[T]>>
 > & {
   type: T
+}
+
+const containerOutputDependencies = new WeakMap<ContainerOp, GraphOutputOp>()
+
+function setContainerOutputDependency(container: ContainerOp, output?: GraphOutputOp) {
+  const previousOutput = containerOutputDependencies.get(container)
+  if (previousOutput === output) return
+
+  if (previousOutput) {
+    previousOutput.removeDownstreamDependent(container)
+    container.removeUpstreamDependency(previousOutput)
+  }
+
+  if (output) {
+    output.addDownstreamDependent(container)
+    container.addUpstreamDependency(output)
+    containerOutputDependencies.set(container, output)
+  } else {
+    containerOutputDependencies.delete(container)
+  }
+
+  container.markDirty()
 }
 
 function topologicalSort<N extends Operator<IOperator>>(
@@ -195,6 +224,31 @@ export function transformGraph<
       _edges
     ) as unknown as E[]),
   ]
+  // A container's output boundary is structural, not a persisted React Flow edge.
+  // Include it in the executor graph so the container cannot race its child
+  // GraphOutputOp as an independent root during the first frame.
+  const implicitContainerOutputEdges: ExecutorEdge[] = nodes.flatMap(containerNode => {
+    if (containerNode.type !== 'ContainerOp') return []
+    const outputNode = nodes.find(
+      node => node.type === 'GraphOutputOp' && isDirectChild(node.id, containerNode.id)
+    )
+    if (
+      !outputNode ||
+      edges.some(edge => edge.source === outputNode.id && edge.target === containerNode.id)
+    ) {
+      return []
+    }
+    return [
+      {
+        id: `${outputNode.id}.out.propagatedValue->${containerNode.id}.out.out`,
+        source: outputNode.id,
+        target: containerNode.id,
+        sourceHandle: 'out.propagatedValue',
+        targetHandle: 'out.out',
+      },
+    ]
+  })
+  const executionEdges = [...edges, ...implicitContainerOutputEdges]
   const store = getOpStore()
 
   // Error about unknown node types — nodes present in the project file that aren't registered
@@ -242,7 +296,7 @@ export function transformGraph<
     }
   }
 
-  const sortedNodes = topologicalSort(nodes, edges)
+  const sortedNodes = topologicalSort(nodes, executionEdges as unknown as E[])
   const created: Operator<IOperator>[] = []
   let instances: OP[] = []
 
@@ -311,7 +365,7 @@ export function transformGraph<
   })
 
   // Update dependency graph
-  updateGraph(_nodes, edges as unknown as ExecutorEdge[])
+  updateGraph(_nodes, executionEdges as unknown as ExecutorEdge[])
 
   // Remove any connections that are not in the edges array.
   // Also clear connection errors for removed edges.
@@ -467,6 +521,17 @@ export function transformGraph<
   for (const op of store.getAllOps()) {
     if (op instanceof ContainerOp) {
       const containerOp = op
+      const graphOutput = store
+        .getAllOps()
+        .find(
+          (childOp): childOp is GraphOutputOp =>
+            childOp instanceof GraphOutputOp && isDirectChild(childOp.id, containerOp.id)
+        )
+      // The implicit executor edge above establishes scheduling order. Mirror
+      // it in Operator's pull graph so a downstream pull awaits the child
+      // output and future child updates dirty the container and its consumers.
+      setContainerOutputDependency(containerOp, graphOutput)
+
       for (const childOp of store.getAllOps()) {
         if (childOp instanceof GraphInputOp && isDirectChild(childOp.id, containerOp.id)) {
           // Set up parent container relationship (triggers output rebuild)


### PR DESCRIPTION
## Summary

Fix the remaining container startup race after #514, #515, and #516. A container now waits for its direct child `GraphOutputOp` before publishing its initial output, so downstream viewers do not cache placeholder values until a user edits a container input.

## Changes

- Add the structural `GraphOutputOp -> ContainerOp` relationship to the executor graph without persisting a React Flow edge.
- Mirror that relationship in the operator pull graph so downstream pulls await the child output and later child updates dirty the container.
- Bind the selected direct `GraphOutputOp` to the container so scheduling, pull dependencies, and execution use the same output even when multiple output nodes exist.
- Clean up the prior implicit dependency if a container's output node changes or is removed.
- Add integration regressions covering initial publication, a later container-input update, and multi-output ordering.

## Testing

### Unit Tests

- `npm test -- --run src/noodles/container-integration.test.ts src/noodles/transform-graph.test.ts` — 57 passed.
- `npm run lint -- --no-errors-on-unmatched` — passed.
- `npm run format:check -- --no-errors-on-unmatched` — passed.
- Full normal-workspace suite — 134 files passed, 2,723 tests passed, 10 skipped.

### Manual Testing

Load a project with this pipeline:

`Container.par.in = 5 -> GraphInput -> Math(multiply by 2) -> GraphOutput -> Container.out -> Viewer`

1. Open the project fresh without editing any nodes.
2. Confirm the internal `GraphOutput` and outside viewer both immediately show `10`.
3. Change the container input from `5` to `7`.
4. Confirm both outputs update to `14`.

Before this fix, the internal output showed `10` while the container and outside viewer remained `null` until step 3.

## Documentation

No user documentation changes needed; this restores the intended container execution behavior.

## Related Issues

Follow-up to #514, #515, and #516.
