### PR TITLE
Refactor: make graph model own reference dependencies

### DIFF
--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -138,14 +138,16 @@ The executor maintains a topologically sorted execution order:
 
 ### Reference Dependencies
 
-The graph model in `reference-dependencies.ts` owns dependencies declared inside field text with
-`op()` or mustache syntax. It derives ephemeral reference edges, maintains field subscriptions and
-operator dependencies, and updates the executor when reference text changes. This works independently
-of whether an editor component is mounted, including for children of collapsed containers.
+The graph model in `reference-dependencies.ts` owns dependencies declared with `op()` or mustache
+syntax. For literal code fields it reads the field value; for expression-driven fields it reads and
+watches `field.expression`, while `field.value` remains the evaluated result. The model derives
+ephemeral reference edges, maintains field subscriptions and operator dependencies, and updates the
+executor when source text changes. This works independently of whether an editor component is mounted,
+including for children of collapsed containers.
 
 React Flow state contains only persisted value edges. Reference edges are exposed to the editor as a
 read-only visual projection and must not be created or synchronized by field components. The field
-text is the source of truth.
+source text is the source of truth.
 
 ### Operator Dirty Tracking
 

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -136,6 +136,17 @@ The executor maintains a topologically sorted execution order:
 - Parallel execution levels allow independent operators to run concurrently
 - Changes only re-execute affected downstream operators
 
+### Reference Dependencies
+
+The graph model in `reference-dependencies.ts` owns dependencies declared inside field text with
+`op()` or mustache syntax. It derives ephemeral reference edges, maintains field subscriptions and
+operator dependencies, and updates the executor when reference text changes. This works independently
+of whether an editor component is mounted, including for children of collapsed containers.
+
+React Flow state contains only persisted value edges. Reference edges are exposed to the editor as a
+read-only visual projection and must not be created or synchronized by field components. The field
+text is the source of truth.
+
 ### Operator Dirty Tracking
 
 Operators track their execution status:

--- a/noodles-editor/src/noodles/components/__tests__/expression-driven-field.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/expression-driven-field.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NumberOp } from '../../operators'
+import { referenceDependencyModel } from '../../reference-dependencies'
 import { clearOps, setOp } from '../../store'
 import { FieldComponent } from '../field-components'
 
@@ -45,6 +46,7 @@ describe('per-field expression mode UI', () => {
 
   afterEach(() => {
     cleanup()
+    referenceDependencyModel.reset()
     clearOps()
   })
 
@@ -156,12 +158,30 @@ describe('per-field expression mode UI', () => {
     expect(op.inputs.val.value).toEqual(5)
   })
 
-  it('syncs reference edges for cross-op expressions', () => {
+  it('projects cross-op expression edges from the graph model', () => {
     const source = new NumberOp('/source')
-    source.outputs.val.setValue(1)
+    source.inputs.val.setValue(1)
     setOp('/source', source)
     const op = new NumberOp('/num')
     setOp('/num', op)
+    referenceDependencyModel.configure({
+      nodes: [
+        {
+          id: '/source',
+          type: 'NumberOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: { val: 1 } },
+        },
+        {
+          id: '/num',
+          type: 'NumberOp',
+          position: { x: 100, y: 0 },
+          data: { inputs: { val: 0 } },
+        },
+      ],
+      executionEdges: [],
+      operators: [source, op],
+    })
     renderField(op)
 
     fireEvent.contextMenu(screen.getByText('val'))
@@ -170,18 +190,15 @@ describe('per-field expression mode UI', () => {
     fireEvent.change(input, { target: { value: "op('/source').out.val + 1" } })
     fireEvent.blur(input)
 
-    // The reference-edge sync effect should have been asked to update edges
-    expect(setEdgesSpy).toHaveBeenCalled()
-    const updater = setEdgesSpy.mock.calls.at(-1)?.[0]
-    const newEdges = updater([])
-    expect(newEdges).toHaveLength(1)
-    expect(newEdges[0]).toMatchObject({
+    expect(referenceDependencyModel.getSnapshot()).toHaveLength(1)
+    expect(referenceDependencyModel.getSnapshot()[0]).toMatchObject({
       type: 'ReferenceEdge',
       source: '/source',
       target: '/num',
       sourceHandle: 'out.val',
       targetHandle: 'par.val',
     })
+    expect(setEdgesSpy).not.toHaveBeenCalled()
   })
 
   it('does not offer expression mode for expression-type fields', async () => {

--- a/noodles-editor/src/noodles/components/__tests__/field-components.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/field-components.test.tsx
@@ -4,11 +4,11 @@ import type { Node as ReactFlowNode } from '@xyflow/react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CodeField } from '../../fields'
-import type { CodeOp } from '../../operators'
+import type { CodeOp, NumberOp } from '../../operators'
 import { referenceDependencyModel } from '../../reference-dependencies'
 import { clearOps, getOp } from '../../store'
 import { transformGraph } from '../../transform-graph'
-import { CodeFieldComponent } from '../field-components'
+import { CodeFieldComponent, ExpressionDrivenInput } from '../field-components'
 
 const setEdgesSpy = vi.fn()
 const getNodeSpy = vi.fn()
@@ -108,6 +108,46 @@ describe('CodeFieldComponent reference ownership', () => {
         </div>
       </ReactFlowProvider>
     )
+
+    expect(referenceDependencyModel.getSnapshot()[0].source).toBe('/source2')
+    expect(setEdgesSpy).not.toHaveBeenCalled()
+  })
+
+  it('leaves expression-driven field dependencies in the graph model', () => {
+    const nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[] = [
+      {
+        id: '/source1',
+        type: 'NumberOp',
+        position: { x: 0, y: 0 },
+        data: { inputs: { val: 5 } },
+      },
+      {
+        id: '/source2',
+        type: 'NumberOp',
+        position: { x: 0, y: 100 },
+        data: { inputs: { val: 10 } },
+      },
+      {
+        id: '/target',
+        type: 'NumberOp',
+        position: { x: 200, y: 0 },
+        data: { inputs: { val: { $expr: "op('/source1').par.val * 2" } } },
+      },
+    ]
+
+    transformGraph({ nodes: nodes as never, edges: [] })
+    const target = getOp('/target') as NumberOp
+
+    render(
+      <ReactFlowProvider>
+        <ExpressionDrivenInput id="val" field={target.inputs.val} disabled={false} />
+      </ReactFlowProvider>
+    )
+
+    expect(referenceDependencyModel.getSnapshot()[0].source).toBe('/source1')
+    expect(setEdgesSpy).not.toHaveBeenCalled()
+
+    target.inputs.val.setExpression("op('/source2').par.val * 3")
 
     expect(referenceDependencyModel.getSnapshot()[0].source).toBe('/source2')
     expect(setEdgesSpy).not.toHaveBeenCalled()

--- a/noodles-editor/src/noodles/components/__tests__/field-components.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/field-components.test.tsx
@@ -1,20 +1,19 @@
-// Integration tests for field components, especially CodeFieldComponent edge management
+// Integration tests for the CodeField editor's graph ownership boundary.
 import { render } from '@testing-library/react'
-import type { Edge, Node as ReactFlowNode } from '@xyflow/react'
+import type { Node as ReactFlowNode } from '@xyflow/react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CodeField } from '../../fields'
-import type { DuckDbOp } from '../../operators'
+import type { CodeOp } from '../../operators'
+import { referenceDependencyModel } from '../../reference-dependencies'
 import { clearOps, getOp } from '../../store'
 import { transformGraph } from '../../transform-graph'
 import { CodeFieldComponent } from '../field-components'
 
-// Create a spy that will be used across all tests
 const setEdgesSpy = vi.fn()
 const getNodeSpy = vi.fn()
 const getEdgesSpy = vi.fn(() => [])
 
-// Mock useReactFlow to return our spy
 vi.mock('@xyflow/react', async () => {
   const actual = await vi.importActual('@xyflow/react')
   return {
@@ -46,279 +45,71 @@ vi.mock('@xyflow/react', async () => {
   }
 })
 
-// Mock CodeiumEditor to avoid loading Monaco in tests
 vi.mock('@codeium/react-code-editor', () => ({
-  CodeiumEditor: ({ defaultValue }: { defaultValue: string }) => {
-    return <textarea data-testid="mock-code-editor" defaultValue={defaultValue} readOnly />
-  },
+  CodeiumEditor: ({ defaultValue }: { defaultValue: string }) => (
+    <textarea data-testid="mock-code-editor" defaultValue={defaultValue} readOnly />
+  ),
 }))
 
-describe('CodeFieldComponent edge management', () => {
+describe('CodeFieldComponent reference ownership', () => {
   beforeEach(() => {
     clearOps()
-    // Clear the spy before each test
     setEdgesSpy.mockClear()
     getEdgesSpy.mockClear()
   })
 
   afterEach(() => {
+    referenceDependencyModel.reset()
     clearOps()
   })
 
-  // Helper to setup a graph with operators
-  const setupGraph = (nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[]) => {
-    return transformGraph({ nodes, edges: [] })
-  }
+  it('never synchronizes reference edges into React Flow state', () => {
+    const nodes: ReactFlowNode<{ inputs: Record<string, unknown> }>[] = [
+      {
+        id: '/source1',
+        type: 'NumberOp',
+        position: { x: 0, y: 0 },
+        data: { inputs: { val: 5 } },
+      },
+      {
+        id: '/source2',
+        type: 'NumberOp',
+        position: { x: 0, y: 100 },
+        data: { inputs: { val: 10 } },
+      },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        position: { x: 200, y: 0 },
+        data: { inputs: { code: 'return op("./source1").out.val' } },
+      },
+    ]
 
-  // Helper to render CodeFieldComponent within the required contexts
-  const renderCodeFieldComponent = (field: CodeField, disabled = false) => {
-    return render(
+    transformGraph({ nodes: nodes as never, edges: [] })
+    const codeOp = getOp('/code') as CodeOp
+    const codeField = codeOp.inputs.code as CodeField
+
+    const { rerender } = render(
       <ReactFlowProvider>
-        <div data-node-id={field.op.id}>
-          <CodeFieldComponent id={field.pathToProps.join('.')} field={field} disabled={disabled} />
+        <div data-node-id={codeField.op.id}>
+          <CodeFieldComponent id="code" field={codeField} disabled={false} />
         </div>
       </ReactFlowProvider>
     )
-  }
 
-  it('creates ReferenceEdges when field value contains mustache templates', () => {
-    const nodes = [
-      {
-        id: '/bounds',
-        type: 'NumberOp',
-        position: { x: 0, y: 0 },
-        data: { inputs: { val: 5 } },
-      },
-      {
-        id: '/duckdb-query',
-        type: 'DuckDbOp',
-        position: { x: 200, y: 0 },
-        data: {
-          inputs: {
-            query: 'SELECT * FROM data WHERE x = {{./bounds.out.val}}',
-          },
-        },
-      },
-    ]
+    expect(referenceDependencyModel.getSnapshot()).toHaveLength(1)
+    expect(setEdgesSpy).not.toHaveBeenCalled()
 
-    setupGraph(nodes)
-
-    const queryOp = getOp('/duckdb-query') as DuckDbOp
-    expect(queryOp).toBeDefined()
-
-    const queryField = queryOp.inputs.query as CodeField
-
-    renderCodeFieldComponent(queryField)
-
-    // setEdges should have been called during component mount
-    expect(setEdgesSpy).toHaveBeenCalled()
-
-    // Get the updater function that was passed to setEdges
-    const lastCall = setEdgesSpy.mock.calls[setEdgesSpy.mock.calls.length - 1][0]
-
-    // Call the updater function with an empty edges array
-    const newEdges = typeof lastCall === 'function' ? lastCall([]) : []
-
-    // Should have created one ReferenceEdge
-    const referenceEdges = newEdges.filter((e: Edge) => e.type === 'ReferenceEdge')
-    expect(referenceEdges).toHaveLength(1)
-    expect(referenceEdges[0].source).toBe('/bounds')
-    expect(referenceEdges[0].sourceHandle).toBe('out.val')
-    expect(referenceEdges[0].target).toBe('/duckdb-query')
-  })
-
-  it('creates only one ReferenceEdge for multiple references to the same field with different array accessors', () => {
-    // This is the key test case: multiple mustache templates with array accessors
-    // should create only ONE ReferenceEdge (deduplication happens in getFieldReferences)
-    const query = `SELECT * FROM data
-WHERE
-  bbox.xmin >= {{./bounds.out.bounds.0.0}}
-  AND bbox.xmax <= {{./bounds.out.bounds.1.0}}
-  AND bbox.ymin >= {{./bounds.out.bounds.0.1}}
-  AND bbox.ymax <= {{./bounds.out.bounds.1.1}}`
-
-    const nodes = [
-      {
-        id: '/bounds',
-        type: 'NumberOp',
-        position: { x: 0, y: 0 },
-        data: { inputs: { val: 5 } },
-      },
-      {
-        id: '/duckdb-query',
-        type: 'DuckDbOp',
-        position: { x: 200, y: 0 },
-        data: { inputs: { query } },
-      },
-    ]
-
-    setupGraph(nodes)
-
-    const queryOp = getOp('/duckdb-query') as DuckDbOp
-    const queryField = queryOp.inputs.query as CodeField
-
-    renderCodeFieldComponent(queryField)
-
-    expect(setEdgesSpy).toHaveBeenCalled()
-
-    const lastCall = setEdgesSpy.mock.calls[setEdgesSpy.mock.calls.length - 1][0]
-    const newEdges = typeof lastCall === 'function' ? lastCall([]) : []
-
-    const referenceEdges = newEdges.filter((e: Edge) => e.type === 'ReferenceEdge')
-
-    // CRITICAL: Should create only ONE edge, not four!
-    expect(referenceEdges).toHaveLength(1)
-    expect(referenceEdges[0].sourceHandle).toBe('out.bounds')
-    expect(referenceEdges[0].id).toBe('/bounds.out.bounds->/duckdb-query.par.query')
-  })
-
-  it('creates multiple ReferenceEdges when templates reference different fields', () => {
-    const query = `SELECT * FROM data
-WHERE id = {{./source1.out.val}}
-  AND name = {{./source2.out.val}}`
-
-    const nodes = [
-      {
-        id: '/source1',
-        type: 'NumberOp',
-        position: { x: 0, y: 0 },
-        data: { inputs: { val: 5 } },
-      },
-      {
-        id: '/source2',
-        type: 'NumberOp',
-        position: { x: 0, y: 100 },
-        data: { inputs: { val: 10 } },
-      },
-      {
-        id: '/duckdb-query',
-        type: 'DuckDbOp',
-        position: { x: 200, y: 0 },
-        data: { inputs: { query } },
-      },
-    ]
-
-    setupGraph(nodes)
-
-    const queryOp = getOp('/duckdb-query') as DuckDbOp
-    const queryField = queryOp.inputs.query as CodeField
-
-    renderCodeFieldComponent(queryField)
-
-    expect(setEdgesSpy).toHaveBeenCalled()
-
-    const lastCall = setEdgesSpy.mock.calls[setEdgesSpy.mock.calls.length - 1][0]
-    const newEdges = typeof lastCall === 'function' ? lastCall([]) : []
-
-    const referenceEdges = newEdges.filter((e: Edge) => e.type === 'ReferenceEdge')
-
-    // Should create edges for both fields
-    expect(referenceEdges).toHaveLength(2)
-
-    const sourceHandles = referenceEdges.map((e: Edge) => e.sourceHandle).sort()
-    expect(sourceHandles).toEqual(['out.val', 'out.val'])
-
-    const sources = referenceEdges.map((e: Edge) => e.source).sort()
-    expect(sources).toEqual(['/source1', '/source2'])
-  })
-
-  it('updates edges when field value changes', () => {
-    const initialQuery = 'SELECT {{./source1.out.val}}'
-
-    const nodes = [
-      {
-        id: '/source1',
-        type: 'NumberOp',
-        position: { x: 0, y: 0 },
-        data: { inputs: { val: 5 } },
-      },
-      {
-        id: '/source2',
-        type: 'NumberOp',
-        position: { x: 0, y: 100 },
-        data: { inputs: { val: 10 } },
-      },
-      {
-        id: '/duckdb-query',
-        type: 'DuckDbOp',
-        position: { x: 200, y: 0 },
-        data: { inputs: { query: initialQuery } },
-      },
-    ]
-
-    setupGraph(nodes)
-
-    const queryOp = getOp('/duckdb-query') as DuckDbOp
-    const queryField = queryOp.inputs.query as CodeField
-
-    const { rerender } = renderCodeFieldComponent(queryField)
-
-    const initialCallCount = setEdgesSpy.mock.calls.length
-
-    // Update the field value to reference a different field
-    queryField.setValue('SELECT {{./source2.out.val}}')
-
-    // Re-render to trigger the effect
+    codeField.setValue('return op("./source2").out.val')
     rerender(
       <ReactFlowProvider>
-        <div data-node-id={queryField.op.id}>
-          <CodeFieldComponent
-            id={queryField.pathToProps.join('.')}
-            field={queryField}
-            disabled={false}
-          />
+        <div data-node-id={codeField.op.id}>
+          <CodeFieldComponent id="code" field={codeField} disabled={false} />
         </div>
       </ReactFlowProvider>
     )
 
-    // setEdges should have been called again after the value change
-    expect(setEdgesSpy.mock.calls.length).toBeGreaterThan(initialCallCount)
-  })
-
-  it('does not call setEdges excessively on multiple re-renders with same value', () => {
-    const query = 'SELECT {{./bounds.out.val}}'
-
-    const nodes = [
-      {
-        id: '/bounds',
-        type: 'NumberOp',
-        position: { x: 0, y: 0 },
-        data: { inputs: { val: 5 } },
-      },
-      {
-        id: '/duckdb-query',
-        type: 'DuckDbOp',
-        position: { x: 200, y: 0 },
-        data: { inputs: { query } },
-      },
-    ]
-
-    setupGraph(nodes)
-
-    const queryOp = getOp('/duckdb-query') as DuckDbOp
-    const queryField = queryOp.inputs.query as CodeField
-
-    const { rerender } = renderCodeFieldComponent(queryField)
-
-    const initialCallCount = setEdgesSpy.mock.calls.length
-
-    // Re-render multiple times without changing the field value
-    for (let i = 0; i < 3; i++) {
-      rerender(
-        <ReactFlowProvider>
-          <div data-node-id={queryField.op.id}>
-            <CodeFieldComponent
-              id={queryField.pathToProps.join('.')}
-              field={queryField}
-              disabled={false}
-            />
-          </div>
-        </ReactFlowProvider>
-      )
-    }
-
-    // setEdges should not be called excessively (React should batch/optimize)
-    const finalCallCount = setEdgesSpy.mock.calls.length
-    expect(finalCallCount - initialCallCount).toBeLessThan(10)
+    expect(referenceDependencyModel.getSnapshot()[0].source).toBe('/source2')
+    expect(setEdgesSpy).not.toHaveBeenCalled()
   })
 })

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -597,8 +597,8 @@ function formatEvaluatedValue(value: unknown): string {
   }
 }
 
-// Canvas variant of the expression input: also syncs dashed ReferenceEdges to referenced
-// operators and derives autocomplete context from the live graph. Requires ReactFlow context.
+// Canvas variant of the expression input: derives autocomplete context from the live graph.
+// The graph-owned reference dependency model projects dashed edges for visualization.
 export function ExpressionDrivenInput({
   id,
   field,
@@ -608,13 +608,9 @@ export function ExpressionDrivenInput({
   field: Field
   disabled: boolean
 }) {
-  const expression = useObservable(field.expression$, field.expression) ?? ''
   // Outside a node (e.g. the Properties Panel) useNodeId is null; the field knows its op
   const nodeId = useNodeId() ?? field.op?.id ?? ''
   const edges = useEdges()
-
-  // Dashed dependency edges to referenced operators
-  useReferenceEdgeSync(field, expression)
 
   const graphEdges = useMemo(
     () =>

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -44,7 +44,6 @@ import {
   type ExpressionField,
   type Field,
   type FileUrlField,
-  getFieldReferences,
   type IField,
   ListField,
   type MapStyleField,
@@ -58,15 +57,14 @@ import {
 import { useFileSystemStore } from '../filesystem-store'
 import type { Edge as GraphEdge } from '../graph-executor'
 import { useObservable } from '../hooks/use-observable'
-import type { Edge } from '../noodles'
 import s from '../noodles.module.css'
-import { getFriendlyErrorMessage, type IOperator, type Operator } from '../operators'
+import { getFriendlyErrorMessage } from '../operators'
 import { checkAssetExists, getAssetFileHandle, writeAsset } from '../storage'
 import { extensionOf } from './tools/import-pipelines'
 import { getOp, useEdgeConnectionStore } from '../store'
 import { type ExpressionContext, getExpressionContext } from '../utils/expression-context'
 import { projectScheme } from '../utils/filesystem'
-import { edgeId, type OpId } from '../utils/id-utils'
+import type { OpId } from '../utils/id-utils'
 import { computeRelativePath } from '../utils/path-utils'
 import {
   captureOperatorInputs,
@@ -959,82 +957,6 @@ export function VectorFieldComponent({
   )
 }
 
-// Sync ReferenceEdges for a field whose text contains operator references
-// ({{/path.out.val}} or op('/path').out.val). transform-graph wires these edges as
-// 'reference' connections, which is what makes referencing fields reactive.
-// Used by CodeFieldComponent and expression-driven fields.
-function useReferenceEdgeSync(field: Field, text: string) {
-  const { setEdges } = useReactFlow()
-
-  // We assume the field name is the last in the pathToProps, but that may not hold true for nested fields.
-  // We don't use any nested CodeFields at the moment so this is fine
-  const fieldName = field.pathToProps[field.pathToProps.length - 1]
-  const thisFieldId = `par.${fieldName}`
-  const thisOpId = field.op.id
-
-  // This effect should NOT depend on edges to avoid infinite loops
-  const fieldReferences = useMemo(() => getFieldReferences(text, thisOpId), [text, thisOpId])
-
-  useEffect(() => {
-    setEdges(oldEdges => {
-      // Find existing ReferenceEdges targeting this field
-      const existingReferenceEdges = oldEdges.filter(
-        e => e.target === thisOpId && e.targetHandle === thisFieldId && e.type === 'ReferenceEdge'
-      )
-
-      // Determine which edges to add and remove
-      const existingHandleIds = new Set(existingReferenceEdges.map(e => e.sourceHandle))
-      const referencedHandleIds = new Set(fieldReferences.map(ref => ref.handleId))
-
-      const toAdd = fieldReferences.filter(ref => !existingHandleIds.has(ref.handleId))
-      const idsToRemove = new Set(
-        existingReferenceEdges
-          .filter(e => !referencedHandleIds.has(e.sourceHandle || ''))
-          .map(e => e.id)
-      )
-
-      if (toAdd.length === 0 && idsToRemove.size === 0) {
-        return oldEdges // No changes needed
-      }
-
-      let newEdges = oldEdges
-
-      // Remove edges that are no longer referenced
-      if (idsToRemove.size > 0) {
-        newEdges = newEdges.filter(e => !idsToRemove.has(e.id))
-      }
-
-      // Add new reference edges
-      if (toAdd.length > 0) {
-        const newReferenceEdges = toAdd.map(({ opId, handleId }) => {
-          const connection = {
-            source: opId,
-            sourceHandle: handleId,
-            target: thisOpId,
-            targetHandle: thisFieldId,
-          }
-          return {
-            id: edgeId(connection),
-            type: 'ReferenceEdge',
-            selectable: false,
-            deletable: false,
-            focusable: false,
-            reconnectable: false,
-            source: opId,
-            target: thisOpId,
-            sourceHandle: handleId,
-            targetHandle: thisFieldId,
-          } as Edge<Operator<IOperator>, Operator<IOperator>>
-        })
-
-        newEdges = [...newEdges, ...newReferenceEdges]
-      }
-
-      return newEdges
-    })
-  }, [fieldReferences, thisOpId, thisFieldId, setEdges])
-}
-
 export function CodeFieldComponent({
   field,
   disabled,
@@ -1052,7 +974,6 @@ export function CodeFieldComponent({
   const nodeId = useNodeId() as string
   const node = getNode(nodeId)
   const nodeHeight = node?.height || 300
-
   const handleEditorChange = useCallback(
     (value: string | undefined, _event) => {
       if (disabled || value === undefined) return
@@ -1082,7 +1003,6 @@ export function CodeFieldComponent({
     },
     [field.language]
   )
-
   // Force layout update on load and when node height changes
   useLayoutEffect(() => {
     if (editorRef.current) {
@@ -1096,9 +1016,6 @@ export function CodeFieldComponent({
     })
     return () => sub.unsubscribe()
   }, [field])
-
-  // Sync reference edges when field value changes
-  useReferenceEdgeSync(field, value)
 
   return (
     <div className={cx(s.fieldWrapper, s.fieldWrapperCode)} ref={containerRef}>

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -24,7 +24,16 @@ import type { LayerExtension } from 'deck.gl'
 import * as deck from 'deck.gl'
 import type { JSZipObject } from 'jszip'
 import { PrimeReactProvider } from 'primereact/api'
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import { useLocation, useParams } from 'wouter'
 import { globalContextManager } from '../ai-chat/global-context-manager'
 import type { NoodlesProject } from '../ai-chat/types'
@@ -78,6 +87,7 @@ import { useNodeDropOnEdge } from './hooks/use-node-drop-on-edge'
 import { useProjectModifications } from './hooks/use-project-modifications'
 import type { DeckRendererOp, IOperator, Operator, OutOp } from './operators'
 import { extensionMap } from './operators'
+import { referenceDependencyModel } from './reference-dependencies'
 import {
   copyDataDirectory,
   copyExampleAssetsToMemory,
@@ -212,7 +222,18 @@ export function getNoodles(): Visualization {
 
   const [nodes, setNodes, onNodesChangeBase] = useNodesState<AnyNodeJSON>([])
   const [edges, setEdges, onEdgesChangeBase] = useEdgesState<ReactFlowEdge<unknown>>([])
+  const referenceEdges = useSyncExternalStore(
+    referenceDependencyModel.subscribe,
+    referenceDependencyModel.getSnapshot,
+    referenceDependencyModel.getSnapshot
+  )
+  const modelEdges = useMemo<ReactFlowEdge[]>(
+    () => [...(edges as ReactFlowEdge[]), ...referenceEdges],
+    [edges, referenceEdges]
+  )
   const [defaultViewport, setDefaultViewport] = useState({ x: 0, y: 0, zoom: 1 })
+
+  useEffect(() => () => referenceDependencyModel.reset(), [])
 
   // Single ref providing synchronous access to the full graph state.
   // Used by CopyControls, UndoRedoHandler, and hooks that need all nodes/edges
@@ -230,10 +251,10 @@ export function getNoodles(): Visualization {
     }
 
     // Rebuild index if nodes/edges changed
-    if (spatialIndexRef.current.needsRebuild(nodes, edges)) {
-      spatialIndexRef.current.build(nodes, edges)
+    if (spatialIndexRef.current.needsRebuild(nodes, modelEdges)) {
+      spatialIndexRef.current.build(nodes, modelEdges)
     }
-  }, [nodes, edges])
+  }, [nodes, modelEdges])
   const [showChatPanel, setShowChatPanel] = useState(false)
   const [chatInitialMessage, setChatInitialMessage] = useState<string | undefined>(undefined)
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
@@ -345,18 +366,18 @@ export function getNoodles(): Visualization {
       )
       .sort()
       .join(',')
-    const connectivity = edges
+    const connectivity = modelEdges
       .map(edge => `${edge.source}->${edge.target}`)
       .sort()
       .join(',')
     return `${nodeState}|${connectivity}`
-  }, [nodes, edges])
+  }, [nodes, modelEdges])
 
   // nodes/edges are represented by forLoopLayoutKey; position-only updates intentionally
   // do not trigger this effect because drag-stop performs the fit once per gesture.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional key-based reconciliation
   useEffect(() => {
-    setNodes(currentNodes => reconcileForLoopGroups(currentNodes, edges))
+    setNodes(currentNodes => reconcileForLoopGroups(currentNodes, modelEdges))
   }, [forLoopLayoutKey, setNodes])
 
   // `transformGraph` needs all nodes to build the opMap and resolve connections
@@ -385,7 +406,7 @@ export function getNoodles(): Visualization {
     // operators exist in the store (covers undo/redo restores, keyboard deletes, and AI/paste
     // paths that added edges before their operators were instantiated). Returns the same
     // array reference when nothing changed, so this doesn't loop.
-    setEdges(eds => normalizeMultiInputEdges(eds))
+    setEdges(eds => normalizeMultiInputEdges(eds.filter(edge => edge.type !== 'ReferenceEdge')))
   }, [graphStructureKey])
 
   // Reset isProjectLoadRef after every render so the flag never gets stuck when
@@ -611,7 +632,12 @@ export function getNoodles(): Visualization {
   const onNodeDragStop = useCallback(
     (event: React.MouseEvent, node: ReactFlowNode) => {
       const result = onNodeDragStopBase(event, node)
-      setNodes(currentNodes => reconcileForLoopGroups(currentNodes, graphRef.current.edges))
+      setNodes(currentNodes =>
+        reconcileForLoopGroups(currentNodes, [
+          ...graphRef.current.edges,
+          ...referenceDependencyModel.getSnapshot(),
+        ])
+      )
       // Mark as unsaved if a node was inserted into an edge
       if (result) {
         setHasUnsavedChanges(true)
@@ -849,7 +875,11 @@ export function getNoodles(): Visualization {
       // lookup) derives multi-input slot rendering caches from the file's edge order —
       // project files never store them.
       setNodes(nodes)
-      setEdges(normalizeMultiInputEdges(edges as ReactFlowEdge[]))
+      setEdges(
+        normalizeMultiInputEdges(
+          (edges as ReactFlowEdge[]).filter(edge => edge.type !== 'ReferenceEdge')
+        )
+      )
 
       // Load editor settings from project with defaults
       setShowOverlay(editorSettings?.showOverlay ?? true)
@@ -1034,13 +1064,13 @@ export function getNoodles(): Visualization {
   }, [displayedNodes])
 
   const activeEdges = useMemo(() => {
-    return edges
+    return modelEdges
       .filter(edge => visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target))
       .map(edge => ({
         ...edge,
         sourceHandle: edge.type === 'ReferenceEdge' ? null : edge.sourceHandle,
       }))
-  }, [edges, visibleNodeIds])
+  }, [modelEdges, visibleNodeIds])
 
   // File menu callbacks
   const getNoodlesProjectJson = useCallback((): NoodlesProjectJSON => {

--- a/noodles-editor/src/noodles/reference-dependencies.ts
+++ b/noodles-editor/src/noodles/reference-dependencies.ts
@@ -1,5 +1,5 @@
 import type { Subscription } from 'rxjs'
-import { type Field, getFieldReferences } from './fields'
+import { type Field, getFieldReferences, isSerializedExpression } from './fields'
 import { type Edge as ExecutorEdge, updateGraph } from './graph-executor'
 import type { IOperator, Operator } from './operators'
 import type { GraphNode } from './utils/for-loop-group-utils'
@@ -35,12 +35,17 @@ type ConfigureOptions = {
 }
 
 function serializedValueToReferenceText(value: unknown): string | null {
+  if (isSerializedExpression(value)) return value.$expr
   if (typeof value === 'string') return value
   if (Array.isArray(value)) {
     const strings = value.filter((item): item is string => typeof item === 'string')
     return strings.length > 0 ? strings.join('\n') : null
   }
   return null
+}
+
+function fieldReferenceText(field: Field): string | null {
+  return field.expression ?? serializedValueToReferenceText(field.value)
 }
 
 function connectionKey(
@@ -176,7 +181,7 @@ class ReferenceDependencyModel {
       if (!op) continue
 
       for (const [fieldName, field] of Object.entries(op.inputs)) {
-        const text = typeof field.value === 'string' ? field.value : null
+        const text = fieldReferenceText(field)
         if (!text || !(text.includes('op(') || text.includes('{{'))) continue
 
         for (const ref of getFieldReferences(text, node.id)) {
@@ -209,22 +214,17 @@ class ReferenceDependencyModel {
   private watchInputFields(): void {
     for (const op of this.operators.values()) {
       for (const field of Object.values(op.inputs)) {
-        if (typeof field.value !== 'string') continue
-        this.fieldTexts.set(field, field.value)
-        let initialEmission = true
-        const subscription = field.subscribe(() => {
-          if (initialEmission) {
-            initialEmission = false
-            return
-          }
+        this.fieldTexts.set(field, fieldReferenceText(field))
+        const refreshIfSourceChanged = () => {
           if (this.refreshing) return
 
-          const text = typeof field.value === 'string' ? field.value : null
+          const text = fieldReferenceText(field)
           if (text === this.fieldTexts.get(field)) return
           this.fieldTexts.set(field, text)
           this.refresh()
-        })
-        this.fieldWatchers.push(subscription)
+        }
+        this.fieldWatchers.push(field.subscribe(refreshIfSourceChanged))
+        this.fieldWatchers.push(field.expression$.subscribe(refreshIfSourceChanged))
       }
     }
   }

--- a/noodles-editor/src/noodles/reference-dependencies.ts
+++ b/noodles-editor/src/noodles/reference-dependencies.ts
@@ -1,0 +1,329 @@
+import type { Subscription } from 'rxjs'
+import { type Field, getFieldReferences } from './fields'
+import { type Edge as ExecutorEdge, updateGraph } from './graph-executor'
+import type { IOperator, Operator } from './operators'
+import type { GraphNode } from './utils/for-loop-group-utils'
+import { edgeId } from './utils/id-utils'
+import { parseHandleId } from './utils/path-utils'
+
+export type ReferenceEdge = ExecutorEdge & {
+  type: 'ReferenceEdge'
+  selectable: false
+  deletable: false
+  focusable: false
+  reconnectable: false
+}
+
+export type ReferenceNode = GraphNode & {
+  data?: { inputs?: Record<string, unknown> }
+}
+
+type BoundReference = {
+  edge: ReferenceEdge
+  targetField: Field
+}
+
+type ConfigureOptions = {
+  nodes: ReferenceNode[]
+  /**
+   * Non-reference edges used by the executor. This deliberately accepts more
+   * than persisted React Flow edges so structural dependencies (for example,
+   * container output bridges) remain intact when a live reference changes.
+   */
+  executionEdges: ExecutorEdge[]
+  operators: Operator<IOperator>[]
+}
+
+function serializedValueToReferenceText(value: unknown): string | null {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    const strings = value.filter((item): item is string => typeof item === 'string')
+    return strings.length > 0 ? strings.join('\n') : null
+  }
+  return null
+}
+
+function connectionKey(
+  edge: Pick<ExecutorEdge, 'source' | 'sourceHandle' | 'target' | 'targetHandle'>
+) {
+  return `${edge.source}.${edge.sourceHandle}->${edge.target}.${edge.targetHandle}`
+}
+
+function relationKey(edge: Pick<ExecutorEdge, 'source' | 'target'>) {
+  return `${edge.source}->${edge.target}`
+}
+
+function isPullDependency(edge: Pick<ExecutorEdge, 'source' | 'sourceHandle' | 'target'>) {
+  const source = parseHandleId(edge.sourceHandle)
+  return !(
+    source?.namespace === 'par' &&
+    (edge.source === edge.target || edge.target.startsWith(`${edge.source}/`))
+  )
+}
+
+/** Derive ephemeral reference edges from serialized node input values. */
+export function deriveReferenceEdges(
+  nodes: ReadonlyArray<ReferenceNode>,
+  existingEdges: ReadonlyArray<
+    Pick<ExecutorEdge, 'source' | 'sourceHandle' | 'target' | 'targetHandle'>
+  >
+): ReferenceEdge[] {
+  const nodeIds = new Set(nodes.map(node => node.id))
+  const seen = new Set(existingEdges.map(connectionKey))
+  const derived: ReferenceEdge[] = []
+
+  for (const node of nodes) {
+    for (const [fieldName, value] of Object.entries(node.data?.inputs ?? {})) {
+      const text = serializedValueToReferenceText(value)
+      if (!text || !(text.includes('op(') || text.includes('{{'))) continue
+
+      for (const ref of getFieldReferences(text, node.id)) {
+        if (!nodeIds.has(ref.opId)) continue
+        const connection = {
+          source: ref.opId,
+          sourceHandle: ref.handleId,
+          target: node.id,
+          targetHandle: `par.${fieldName}`,
+        }
+        const key = connectionKey(connection)
+        if (seen.has(key)) continue
+        seen.add(key)
+        derived.push({
+          id: edgeId(connection),
+          type: 'ReferenceEdge',
+          selectable: false,
+          deletable: false,
+          focusable: false,
+          reconnectable: false,
+          ...connection,
+        })
+      }
+    }
+  }
+
+  return derived
+}
+
+/**
+ * Owns the complete lifecycle of reactive `op()` / mustache dependencies.
+ * React components subscribe only to its edge snapshot for visualization.
+ */
+class ReferenceDependencyModel {
+  private nodes: ReferenceNode[] = []
+  private executionEdges: ExecutorEdge[] = []
+  private operators = new Map<string, Operator<IOperator>>()
+  private edges: ReferenceEdge[] = []
+  private boundReferences = new Map<string, BoundReference>()
+  private ownedRelations = new Map<
+    string,
+    { sourceOp: Operator<IOperator>; targetOp: Operator<IOperator> }
+  >()
+  private fieldWatchers: Subscription[] = []
+  private fieldTexts = new Map<Field, string | null>()
+  private listeners = new Set<() => void>()
+  private refreshing = false
+
+  getSnapshot = (): ReferenceEdge[] => this.edges
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  configure({ nodes, executionEdges, operators }: ConfigureOptions): ReferenceEdge[] {
+    this.clearFieldWatchers()
+    this.nodes = nodes
+    this.executionEdges = executionEdges.filter(
+      edge => (edge as ExecutorEdge & { type?: string }).type !== 'ReferenceEdge'
+    )
+    this.operators = new Map(operators.map(op => [op.id, op]))
+
+    const nextEdges = this.deriveFromFields()
+    this.replaceEdges(nextEdges, false)
+    this.watchInputFields()
+    updateGraph(this.nodes, [...this.executionEdges, ...this.edges])
+    return this.edges
+  }
+
+  reset(): void {
+    this.clearFieldWatchers()
+    for (const bound of this.boundReferences.values()) {
+      bound.targetField.removeConnection(bound.edge.id, 'reference')
+    }
+    this.boundReferences.clear()
+    const executionRelations = new Set(
+      this.executionEdges.filter(isPullDependency).map(edge => relationKey(edge))
+    )
+    for (const [relation, { sourceOp, targetOp }] of this.ownedRelations) {
+      if (executionRelations.has(relation)) continue
+      sourceOp.removeDownstreamDependent(targetOp)
+      targetOp.removeUpstreamDependency(sourceOp)
+    }
+    this.ownedRelations.clear()
+    this.nodes = []
+    this.executionEdges = []
+    this.operators.clear()
+    this.publish([])
+  }
+
+  private deriveFromFields(): ReferenceEdge[] {
+    const nodeIds = new Set(this.nodes.map(node => node.id))
+    const seen = new Set(this.executionEdges.map(connectionKey))
+    const result: ReferenceEdge[] = []
+
+    for (const node of this.nodes) {
+      const op = this.operators.get(node.id)
+      if (!op) continue
+
+      for (const [fieldName, field] of Object.entries(op.inputs)) {
+        const text = typeof field.value === 'string' ? field.value : null
+        if (!text || !(text.includes('op(') || text.includes('{{'))) continue
+
+        for (const ref of getFieldReferences(text, node.id)) {
+          if (!nodeIds.has(ref.opId)) continue
+          const connection = {
+            source: ref.opId,
+            sourceHandle: ref.handleId,
+            target: node.id,
+            targetHandle: `par.${fieldName}`,
+          }
+          const key = connectionKey(connection)
+          if (seen.has(key)) continue
+          seen.add(key)
+          result.push({
+            id: edgeId(connection),
+            type: 'ReferenceEdge',
+            selectable: false,
+            deletable: false,
+            focusable: false,
+            reconnectable: false,
+            ...connection,
+          })
+        }
+      }
+    }
+
+    return result
+  }
+
+  private watchInputFields(): void {
+    for (const op of this.operators.values()) {
+      for (const field of Object.values(op.inputs)) {
+        if (typeof field.value !== 'string') continue
+        this.fieldTexts.set(field, field.value)
+        let initialEmission = true
+        const subscription = field.subscribe(() => {
+          if (initialEmission) {
+            initialEmission = false
+            return
+          }
+          if (this.refreshing) return
+
+          const text = typeof field.value === 'string' ? field.value : null
+          if (text === this.fieldTexts.get(field)) return
+          this.fieldTexts.set(field, text)
+          this.refresh()
+        })
+        this.fieldWatchers.push(subscription)
+      }
+    }
+  }
+
+  private refresh(): void {
+    this.refreshing = true
+    try {
+      const nextEdges = this.deriveFromFields()
+      if (this.hasSameEdges(nextEdges)) return
+      this.replaceEdges(nextEdges, true)
+      updateGraph(this.nodes, [...this.executionEdges, ...this.edges])
+    } finally {
+      this.refreshing = false
+    }
+  }
+
+  private replaceEdges(nextEdges: ReferenceEdge[], markTargetsDirty: boolean): void {
+    const oldRelations = new Set(this.edges.filter(isPullDependency).map(edge => relationKey(edge)))
+    const nextRelations = new Set(nextEdges.filter(isPullDependency).map(edge => relationKey(edge)))
+    const executionRelations = new Set(
+      this.executionEdges.filter(isPullDependency).map(edge => relationKey(edge))
+    )
+
+    for (const bound of this.boundReferences.values()) {
+      bound.targetField.removeConnection(bound.edge.id, 'reference')
+    }
+    this.boundReferences.clear()
+
+    for (const relation of oldRelations) {
+      const owned = this.ownedRelations.get(relation)
+      const separator = relation.indexOf('->')
+      const currentSource = this.operators.get(relation.slice(0, separator))
+      const currentTarget = this.operators.get(relation.slice(separator + 2))
+      const sameOperators = owned?.sourceOp === currentSource && owned?.targetOp === currentTarget
+      const relationStillExists = nextRelations.has(relation) || executionRelations.has(relation)
+      if (owned && (!relationStillExists || !sameOperators)) {
+        const { sourceOp, targetOp } = owned
+        sourceOp.removeDownstreamDependent(targetOp)
+        targetOp.removeUpstreamDependency(sourceOp)
+      }
+      this.ownedRelations.delete(relation)
+    }
+
+    for (const edge of nextEdges) {
+      const sourceOp = this.operators.get(edge.source)
+      const targetOp = this.operators.get(edge.target)
+      const sourceHandle = parseHandleId(edge.sourceHandle)
+      const targetHandle = parseHandleId(edge.targetHandle)
+      if (!sourceOp || !targetOp || !sourceHandle || !targetHandle) continue
+
+      const sourceField =
+        sourceOp[sourceHandle.namespace === 'par' ? 'inputs' : 'outputs'][sourceHandle.fieldName]
+      const targetField =
+        targetOp[targetHandle.namespace === 'par' ? 'inputs' : 'outputs'][targetHandle.fieldName]
+      if (!sourceField || !targetField) continue
+
+      // A field already invalidates its own operator; subscribing it to itself
+      // would recursively emit forever.
+      if (sourceField !== targetField) {
+        targetField.addConnection(edge.id, sourceField, 'reference')
+        this.boundReferences.set(edge.id, { edge, targetField })
+      }
+
+      if (isPullDependency(edge)) {
+        sourceOp.addDownstreamDependent(targetOp)
+        targetOp.addUpstreamDependency(sourceOp)
+        this.ownedRelations.set(relationKey(edge), { sourceOp, targetOp })
+      }
+    }
+
+    if (markTargetsDirty) {
+      const oldIds = new Set(this.edges.map(edge => edge.id))
+      const nextIds = new Set(nextEdges.map(edge => edge.id))
+      for (const edge of [...this.edges, ...nextEdges]) {
+        if (oldIds.has(edge.id) === nextIds.has(edge.id)) continue
+        this.operators.get(edge.target)?.markDirty()
+      }
+    }
+
+    this.publish(nextEdges)
+  }
+
+  private hasSameEdges(nextEdges: ReferenceEdge[]): boolean {
+    if (nextEdges.length !== this.edges.length) return false
+    const ids = new Set(this.edges.map(edge => edge.id))
+    return nextEdges.every(edge => ids.has(edge.id))
+  }
+
+  private publish(edges: ReferenceEdge[]): void {
+    if (this.hasSameEdges(edges)) return
+    this.edges = edges
+    for (const listener of this.listeners) listener()
+  }
+
+  private clearFieldWatchers(): void {
+    for (const watcher of this.fieldWatchers) watcher.unsubscribe()
+    this.fieldWatchers = []
+    this.fieldTexts.clear()
+  }
+}
+
+export const referenceDependencyModel = new ReferenceDependencyModel()

--- a/noodles-editor/src/noodles/transform-graph.test.ts
+++ b/noodles-editor/src/noodles/transform-graph.test.ts
@@ -12,9 +12,14 @@ import {
   NumberOp,
   type Operator,
 } from './operators'
+import { referenceDependencyModel } from './reference-dependencies'
 import { clearOps, getOpStore, hasOp } from './store'
 import { deriveReferenceEdges, transformGraph } from './transform-graph'
 import { edgeId } from './utils/id-utils'
+
+afterEach(() => {
+  referenceDependencyModel.reset()
+})
 
 describe('transform-graph topological sort with missing upstream nodes', () => {
   afterEach(() => {
@@ -508,7 +513,7 @@ describe('transform-graph', () => {
     expect(id).toBe('/container/operator1.out.data->/container/operator2.par.input')
   })
 
-  it('handles ReferenceEdges with standard handles', () => {
+  it('ignores legacy ReferenceEdges that are not backed by a field reference', () => {
     const graph: {
       nodes: ReactFlowNode<Record<string, unknown>>[]
       edges: (Edge<Operator<IOperator>, Operator<IOperator>> & { type?: string })[]
@@ -538,13 +543,13 @@ describe('transform-graph', () => {
     const result = transformGraph(graph)
     expect(result.operators).toHaveLength(2)
 
-    const [num, add] = result.operators
+    const num = result.operators.find(op => op.id === '/num')!
+    const add = result.operators.find(op => op.id === '/add') as MathOp
     expect(num).toBeInstanceOf(NumberOp)
     expect(add).toBeInstanceOf(MathOp)
 
-    // Verify that the reference connection was established
-    expect(add.inputs.a.subscriptions.size).toBe(1)
-    expect(add.inputs.a.subscriptions.has('/num.out.val->/add.par.a')).toBe(true)
+    // The field text is authoritative; ephemeral editor edges are not graph input.
+    expect(add.inputs.a.subscriptions.has('/num.out.val->/add.par.a')).toBe(false)
   })
 
   it('does not report type mismatch errors for ReferenceEdges', () => {
@@ -1294,11 +1299,8 @@ describe('derived reference edges (unmounted nodes)', () => {
   })
 
   it('wires an op() reference in a container child that has no persisted edge', () => {
-    // Reference edges are synced by the CodeField editor component, which never
-    // mounts for collapsed container children. transformGraph must derive them
-    // from the code text so the child re-executes when the referenced operator
-    // produces data (previously it executed once against undefined and went
-    // permanently stale — an empty layer with zero console errors).
+    // The graph model derives dependencies without requiring a mounted editor,
+    // including for collapsed container children.
     const nodes = [
       { id: '/num', type: 'NumberOp', data: { inputs: { val: 7 } }, position: { x: 0, y: 0 } },
       { id: '/box', type: 'ContainerOp', data: { inputs: {} }, position: { x: 100, y: 0 } },
@@ -1384,7 +1386,7 @@ describe('derived reference edges (unmounted nodes)', () => {
     })
   })
 
-  it('does not duplicate a reference edge the component already synced', () => {
+  it('does not duplicate an existing equivalent edge', () => {
     const nodes = [
       { id: '/a', type: 'NumberOp', data: { inputs: { val: 1 } }, position: { x: 0, y: 0 } },
       {
@@ -1405,6 +1407,99 @@ describe('derived reference edges (unmounted nodes)', () => {
       },
     ]
     expect(deriveReferenceEdges(nodes, existing)).toHaveLength(0)
+  })
+
+  it('moves a live reference without a mounted CodeField component', () => {
+    const nodes = [
+      { id: '/a', type: 'NumberOp', data: { inputs: { val: 1 } }, position: { x: 0, y: 0 } },
+      { id: '/b', type: 'NumberOp', data: { inputs: { val: 2 } }, position: { x: 0, y: 0 } },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: "return op('/a').out.val" } },
+        position: { x: 50, y: 0 },
+      },
+    ]
+
+    transformGraph({ nodes, edges: [] })
+
+    const code = getOpStore().getOp('/code') as CodeOp
+    const b = getOpStore().getOp('/b') as NumberOp
+    const executor = getExecutor()!
+    const onProjectionChange = vi.fn()
+    const unsubscribe = referenceDependencyModel.subscribe(onProjectionChange)
+    expect(code.inputs.code.subscriptions.has('/a.out.val->/code.par.code')).toBe(true)
+    expect(executor.getUpstream('/code')).toEqual(new Set(['/a']))
+    expect(referenceDependencyModel.getSnapshot().map(edge => edge.id)).toEqual([
+      '/a.out.val->/code.par.code',
+    ])
+
+    code.inputs.code.setValue("return op('/b').out.val")
+
+    expect(code.inputs.code.subscriptions.has('/a.out.val->/code.par.code')).toBe(false)
+    expect(code.inputs.code.subscriptions.has('/b.out.val->/code.par.code')).toBe(true)
+    expect(executor.getUpstream('/code')).toEqual(new Set(['/b']))
+    expect(referenceDependencyModel.getSnapshot().map(edge => edge.id)).toEqual([
+      '/b.out.val->/code.par.code',
+    ])
+    expect(onProjectionChange).toHaveBeenCalledOnce()
+
+    // Referenced values invalidate the target without rebuilding unchanged topology.
+    onProjectionChange.mockClear()
+    b.outputs.val.setValue(3)
+    expect(onProjectionChange).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('removes live reference subscriptions and executor dependencies', () => {
+    const nodes = [
+      { id: '/a', type: 'NumberOp', data: { inputs: { val: 1 } }, position: { x: 0, y: 0 } },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: "return op('/a').out.val" } },
+        position: { x: 50, y: 0 },
+      },
+    ]
+
+    transformGraph({ nodes, edges: [] })
+    const code = getOpStore().getOp('/code') as CodeOp
+
+    code.inputs.code.setValue('return 0')
+
+    expect(code.inputs.code.subscriptions.has('/a.out.val->/code.par.code')).toBe(false)
+    expect(getExecutor()!.getUpstream('/code')).toEqual(new Set())
+    expect(referenceDependencyModel.getSnapshot()).toEqual([])
+  })
+
+  it('preserves non-reference executor edges when a live reference is removed', () => {
+    const nodes = [
+      { id: '/a', type: 'NumberOp', data: { inputs: { val: 1 } }, position: { x: 0, y: 0 } },
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: { inputs: { code: "return op('/a').out.val" } },
+        position: { x: 50, y: 0 },
+      },
+    ]
+    const edges = [
+      {
+        id: '/a.out.val->/code.par.data',
+        source: '/a',
+        sourceHandle: 'out.val',
+        target: '/code',
+        targetHandle: 'par.data',
+      },
+    ]
+
+    transformGraph({ nodes, edges })
+    const code = getOpStore().getOp('/code') as CodeOp
+    expect(getExecutor()!.getUpstream('/code')).toEqual(new Set(['/a']))
+
+    code.inputs.code.setValue('return 0')
+
+    expect(getExecutor()!.getUpstream('/code')).toEqual(new Set(['/a']))
+    expect(referenceDependencyModel.getSnapshot()).toEqual([])
   })
 
   it('does not make an enclosing-container param reference a pull dependency (false cycle)', () => {

--- a/noodles-editor/src/noodles/transform-graph.test.ts
+++ b/noodles-editor/src/noodles/transform-graph.test.ts
@@ -1386,6 +1386,52 @@ describe('derived reference edges (unmounted nodes)', () => {
     })
   })
 
+  it('derives and watches dependencies from non-string field expression source', () => {
+    const nodes = [
+      { id: '/a', type: 'NumberOp', data: { inputs: { val: 1 } }, position: { x: 0, y: 0 } },
+      { id: '/b', type: 'NumberOp', data: { inputs: { val: 2 } }, position: { x: 0, y: 50 } },
+      {
+        id: '/target',
+        type: 'NumberOp',
+        data: { inputs: { val: { $expr: "op('/a').par.val * 2" } } },
+        position: { x: 100, y: 0 },
+      },
+    ]
+
+    expect(deriveReferenceEdges(nodes, [])).toMatchObject([
+      {
+        id: '/a.par.val->/target.par.val',
+        source: '/a',
+        sourceHandle: 'par.val',
+        target: '/target',
+        targetHandle: 'par.val',
+      },
+    ])
+
+    transformGraph({ nodes, edges: [] })
+
+    const target = getOpStore().getOp('/target') as NumberOp
+    const b = getOpStore().getOp('/b') as NumberOp
+    expect(target.inputs.val.expression).toBe("op('/a').par.val * 2")
+    expect(target.inputs.val.value).toBe(2)
+    expect(getExecutor()!.getUpstream('/target')).toEqual(new Set(['/a']))
+
+    target.inputs.val.setExpression("op('/b').par.val * 3")
+
+    expect(referenceDependencyModel.getSnapshot().map(edge => edge.id)).toEqual([
+      '/b.par.val->/target.par.val',
+    ])
+    expect(getExecutor()!.getUpstream('/target')).toEqual(new Set(['/b']))
+    expect(target.inputs.val.value).toBe(6)
+
+    b.inputs.val.setValue(4)
+    expect(target.inputs.val.value).toBe(12)
+
+    target.inputs.val.clearExpression()
+    expect(referenceDependencyModel.getSnapshot()).toEqual([])
+    expect(getExecutor()!.getUpstream('/target')).toEqual(new Set())
+  })
+
   it('does not duplicate an existing equivalent edge', () => {
     const nodes = [
       { id: '/a', type: 'NumberOp', data: { inputs: { val: 1 } }, position: { x: 0, y: 0 } },

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -1,8 +1,8 @@
 import { getIncomers, type Node as ReactFlowNode } from '@xyflow/react'
 import { analytics } from '../utils/analytics'
 import { debugExecutor } from '../utils/debug'
-import { type Field, getFieldReferences, ListField } from './fields'
-import { type Edge as ExecutorEdge, updateGraph } from './graph-executor'
+import { type Field, ListField } from './fields'
+import type { Edge as ExecutorEdge } from './graph-executor'
 import type { Edge } from './noodles'
 import type { IOperator, Operator, OpType } from './operators'
 import {
@@ -13,9 +13,9 @@ import {
   opTypes,
   type SpecialNodeType,
 } from './operators'
+import { deriveReferenceEdges, referenceDependencyModel } from './reference-dependencies'
 import { getOpStore } from './store'
 import { validateConnection } from './utils/can-connect'
-import { edgeId } from './utils/id-utils'
 import { getParentPath, isDirectChild, parseHandleId } from './utils/path-utils'
 import { computeVisibilityHeuristic } from './utils/visibility-heuristic'
 
@@ -102,74 +102,7 @@ function topologicalSort<N extends Operator<IOperator>>(
   return sortedNodes.reverse()
 }
 
-/** Reference edges derived from `op()` / mustache references inside
- * string-valued inputs. The CodeField editor component keeps these in sync
- * for MOUNTED nodes, but reference edges are never persisted and container
- * children aren't mounted while collapsed — without this pass, a child whose
- * only upstream link is an `op()` reference is invisible to the executor: it
- * executes once before async upstream data arrives and never re-executes,
- * silently producing empty output. Derived edges use the same id/handle
- * shape as the component's, so the component's sync (which matches on
- * target + targetHandle + sourceHandle) treats them as already present. */
-export function deriveReferenceEdges(
-  nodes: ReadonlyArray<{ id: string; data?: { inputs?: Record<string, unknown> } }>,
-  existingEdges: ReadonlyArray<{
-    source: string
-    sourceHandle?: string | null
-    target: string
-    targetHandle?: string | null
-  }>
-): Array<{
-  id: string
-  type: 'ReferenceEdge'
-  selectable: false
-  deletable: false
-  focusable: false
-  reconnectable: false
-  source: string
-  sourceHandle: string
-  target: string
-  targetHandle: string
-}> {
-  const nodeIds = new Set(nodes.map(n => n.id))
-  const seen = new Set(
-    existingEdges.map(e => `${e.source}.${e.sourceHandle}->${e.target}.${e.targetHandle}`)
-  )
-  const derived: Array<Record<string, unknown>> = []
-  for (const node of nodes) {
-    for (const [fieldName, value] of Object.entries(node.data?.inputs ?? {})) {
-      const text = Array.isArray(value)
-        ? value.filter((v): v is string => typeof v === 'string').join('\n')
-        : typeof value === 'string'
-          ? value
-          : null
-      // Cheap prefilter — reference syntaxes are `op('...')` and `{{...}}`.
-      if (!text || !(text.includes('op(') || text.includes('{{'))) continue
-      for (const ref of getFieldReferences(text, node.id)) {
-        if (!nodeIds.has(ref.opId)) continue
-        const connection = {
-          source: ref.opId,
-          sourceHandle: ref.handleId,
-          target: node.id,
-          targetHandle: `par.${fieldName}`,
-        }
-        const key = `${connection.source}.${connection.sourceHandle}->${connection.target}.${connection.targetHandle}`
-        if (seen.has(key)) continue
-        seen.add(key)
-        derived.push({
-          id: edgeId(connection),
-          type: 'ReferenceEdge',
-          selectable: false,
-          deletable: false,
-          focusable: false,
-          reconnectable: false,
-          ...connection,
-        })
-      }
-    }
-  }
-  return derived
-}
+export { deriveReferenceEdges } from './reference-dependencies'
 
 export interface GraphLoadError {
   type: 'unknown-operator' | 'stale-edge'
@@ -195,12 +128,13 @@ export function transformGraph<
 } {
   const errors: GraphLoadError[] = []
   const nodes = _nodes.filter(n => opTypes[n.type as T] !== undefined) as NodeJSON<OpType>[]
-  // Reference edges for every node — mounted or not (see deriveReferenceEdges).
+  const dataEdges = _edges.filter(edge => (edge as E & { type?: string }).type !== 'ReferenceEdge')
+  // Reference dependencies are model-owned and derived for every node, mounted or not.
   const edges = [
-    ..._edges,
+    ...dataEdges,
     ...(deriveReferenceEdges(
       _nodes as ReadonlyArray<{ id: string; data?: { inputs?: Record<string, unknown> } }>,
-      _edges
+      dataEdges
     ) as unknown as E[]),
   ]
   // A container's output boundary is structural, not a persisted React Flow edge.
@@ -229,7 +163,7 @@ export function transformGraph<
       },
     ]
   })
-  const executionEdges = [...edges, ...implicitContainerOutputEdges]
+  const executorEdges = [...(edges as unknown as ExecutorEdge[]), ...implicitContainerOutputEdges]
   const store = getOpStore()
 
   // Error about unknown node types — nodes present in the project file that aren't registered
@@ -277,7 +211,7 @@ export function transformGraph<
     }
   }
 
-  const sortedNodes = topologicalSort(nodes, executionEdges as unknown as E[])
+  const sortedNodes = topologicalSort(nodes, executorEdges as unknown as E[])
   const created: Operator<IOperator>[] = []
   let instances: OP[] = []
 
@@ -324,8 +258,8 @@ export function transformGraph<
           // ReferenceEdges are filtered because they're operator references in code,
           // not data connections that should affect field visibility
           const connectedFields = new Set(
-            edges
-              .filter(edge => edge.target === id && edge.type !== 'ReferenceEdge')
+            dataEdges
+              .filter(edge => edge.target === id)
               .map(edge => parseHandleId(String(edge.targetHandle))?.fieldName)
               .filter((name): name is string => name !== undefined)
           )
@@ -344,9 +278,6 @@ export function transformGraph<
       return op
     }) as OP[]
   })
-
-  // Update dependency graph
-  updateGraph(_nodes, executionEdges as unknown as ExecutorEdge[])
 
   // Remove any connections that are not in the edges array.
   // Also clear connection errors for removed edges.
@@ -369,7 +300,7 @@ export function transformGraph<
     }
   }
 
-  for (const edge of edges) {
+  for (const edge of dataEdges) {
     const sourceOp = instances.find(n => n.id === edge.source)
     const targetOp = instances.find(n => n.id === edge.target)
     if (sourceOp && targetOp) {
@@ -402,49 +333,35 @@ export function transformGraph<
         continue
       }
 
-      // Check if edge has type property and if it's a ReferenceEdge
-      const connectionType =
-        (edge as Edge<OP, OP> & { type?: string }).type === 'ReferenceEdge' ? 'reference' : 'value'
-      targetField.addConnection(edge.id, sourceField, connectionType)
+      targetField.addConnection(edge.id, sourceField, 'value')
 
       // Auto-show fields when they receive data connections (for programmatic/AI connections)
-      // ReferenceEdges are operator references in code, not data flow, so don't auto-show
-      if (connectionType === 'value') {
-        targetOp.showField(targetFieldName)
+      targetOp.showField(targetFieldName)
 
-        // ReferenceEdges mark reactive dependencies only — type checking doesn't apply
-        // Only validate when the source field has produced a value; skip if the operator hasn't
-        // executed yet (value === undefined) to avoid false "type mismatch" errors on initial load
-        const validation = validateConnection(sourceField, targetField)
-        if (!validation.valid && validation.error && sourceField.value !== undefined) {
-          targetOp.addConnectionError(edge.id, validation.error)
-          // Only track if this edge hasn't been reported yet to avoid duplicates on graph rebuilds
-          const errorMap = targetOp.connectionErrors.value
-          const isNewError = !errorMap.has(edge.id)
-          if (isNewError) {
-            // Don't send constraint details - may contain user values
-            analytics.track('connection_failed', {
-              failureType:
-                validation.severity === 'warning' ? 'constraint_violation' : 'type_mismatch',
-              sourceType: (sourceField.constructor as typeof Field).type,
-              targetType: (targetField.constructor as typeof Field).type,
-            })
-          }
-        } else {
-          // Clear any existing error for this edge if it's now valid (or not yet computed)
-          targetOp.removeConnectionError(edge.id)
+      // Only validate when the source field has produced a value; skip if the operator hasn't
+      // executed yet (value === undefined) to avoid false "type mismatch" errors on initial load
+      const validation = validateConnection(sourceField, targetField)
+      if (!validation.valid && validation.error && sourceField.value !== undefined) {
+        targetOp.addConnectionError(edge.id, validation.error)
+        // Only track if this edge hasn't been reported yet to avoid duplicates on graph rebuilds
+        const errorMap = targetOp.connectionErrors.value
+        const isNewError = !errorMap.has(edge.id)
+        if (isNewError) {
+          // Don't send constraint details - may contain user values
+          analytics.track('connection_failed', {
+            failureType:
+              validation.severity === 'warning' ? 'constraint_violation' : 'type_mismatch',
+            sourceType: (sourceField.constructor as typeof Field).type,
+            targetType: (targetField.constructor as typeof Field).type,
+          })
         }
+      } else {
+        // Clear any existing error for this edge if it's now valid (or not yet computed)
+        targetOp.removeConnectionError(edge.id)
       }
 
-      // Update operator dependencies for pull-based execution.
-      // Skip parameter-sourced references that stay inside the operator they
-      // read: self-references, and a container child reading an enclosing
-      // container's promoted param (op('/parent').par.x). Reading an input
-      // value never requires executing its owner — and the owner's execution
-      // already encompasses the child — so as a pull dependency the edge
-      // closes a false cycle (parent → child → GraphOutput → parent) that
-      // _pullUpstreamDependencies recurses on until the stack overflows. The
-      // field connection added above still delivers param changes reactively.
+      // Parameter-sourced edges that stay inside their owner don't require
+      // executing that owner and would create a false container cycle.
       const isEnclosedParameterReference =
         sourceNamespace === 'par' &&
         (edge.source === edge.target || edge.target.startsWith(`${edge.source}/`))
@@ -470,7 +387,7 @@ export function transformGraph<
     for (const [name, field] of Object.entries(op.inputs)) {
       if (field instanceof ListField) {
         field.setConnectionOrder(
-          edges
+          dataEdges
             .filter(e => e.target === op.id && String(e.targetHandle) === `par.${name}`)
             .map(e => e.id)
         )
@@ -547,6 +464,12 @@ export function transformGraph<
       }
     }
   }
+
+  referenceDependencyModel.configure({
+    nodes: _nodes,
+    executionEdges: executorEdges,
+    operators: instances,
+  })
 
   return { operators: instances, errors }
 }

--- a/noodles-editor/src/noodles/utils/field-expressions.ts
+++ b/noodles-editor/src/noodles/utils/field-expressions.ts
@@ -3,9 +3,9 @@
 // its value is computed from a JavaScript expression referencing other operators.
 //
 // Reactivity model:
-// - Cross-op refs (`op('/x').out.val`, `{{/x.out.val}}`) become ReferenceEdges (synced by the
-//   UI, like CodeField), which transform-graph wires as 'reference' connections. When the
-//   referenced field emits, Field.addConnection calls evaluateExpression on the driven field.
+// - Cross-op refs (`op('/x').out.val`, `{{/x.out.val}}`) become graph-model-owned
+//   ReferenceEdges, which are wired as 'reference' connections. When the referenced field
+//   emits, Field.addConnection calls evaluateExpression on the driven field.
 // - Bare sibling refs (`par.foo`) are subscribed to directly here — siblings share the owning
 //   operator's lifecycle, so these subscriptions can't go stale across renames/deletes.
 // - Timeline refs (`sequenceTime`, `frame`, ...) subscribe to the timeline store.


### PR DESCRIPTION
## Stack

Depends on #559. The reference model preserves the implicit GraphOutput-to-Container execution edge added there when live references change. After #559 merges, this PR can be rebased onto `main`. #560 remains independent and is not included.

## Summary

Make field text the sole source of truth for `op()` and mustache reference dependencies. The graph model now owns their field subscriptions, operator dependencies, executor topology, and visual edge snapshot; editor components no longer synchronize duplicate React Flow edges.

## Changes

- Add a `ReferenceDependencyModel` that derives, binds, updates, and removes reference dependencies without requiring mounted nodes.
- Keep persisted React Flow state limited to value edges and expose reference edges as a read-only visual projection.
- Remove `CodeFieldComponent` edge synchronization and ignore legacy reference edges that are not backed by field text.
- Preserve non-reference and structural executor edges during live reference edits.
- Document the ownership boundary in the architecture guide.

## Testing

### Automated

- `npm test -- --run src/noodles/transform-graph.test.ts` (48 passed)
- `npm test -- --run src/noodles/components/__tests__/field-components.test.tsx` (1 passed)
- `npm test -- --run src/noodles/__tests__/noodles-graph-integration.test.tsx` (6 passed)
- `npm test -- --run src/noodles/container-integration.test.ts` (12 passed)
- `npm run build`
- Biome format/lint passes for the changed model, graph, editor, and test files.

### Manual runbook

1. Create `/a` and `/b` Number operators with different values, plus a Code operator whose code returns `op("/a").out.val`.
2. Connect the Code output to a Viewer. Confirm the reference edge points from `/a` and the Viewer shows its value.
3. Change the code reference from `/a` to `/b`. Confirm the visual reference edge and Viewer output move to `/b` immediately.
4. Put the Code operator inside a container, collapse it, and change the referenced source value. Confirm the container output still updates without opening or editing the child.

## Documentation

- Added the reference-dependency ownership model to `dev-docs/architecture.md`.

## Related

- Follow-up to #514
- Stacked on #559