### PR TITLE
docs: backfill changelog for Feb-Aug 2026

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,140 @@
 
 All notable changes to Noodles.gl are documented here.
 
+## August 2026
+
+### Added
+- Comprehensive GIS tools and ease-of-use features ([#519](https://github.com/joby-aviation/noodles.gl/pull/519))
+- deck.gl scale widget operator ([#526](https://github.com/joby-aviation/noodles.gl/pull/526))
+- Resizable panel system replacing fixed layout modes ([#465](https://github.com/joby-aviation/noodles.gl/pull/465))
+- Freeform input support for StringLiteralField ([#442](https://github.com/joby-aviation/noodles.gl/pull/442))
+- Editable defaults in table schemas ([#545](https://github.com/joby-aviation/noodles.gl/pull/545))
+
+### Changed
+- Upgraded deck.gl to 9.3.8, then 9.3.10 ([#533](https://github.com/joby-aviation/noodles.gl/pull/533), [#546](https://github.com/joby-aviation/noodles.gl/pull/546))
+
+### Fixed
+- Unchanged for-loops rerunning unnecessarily ([#523](https://github.com/joby-aviation/noodles.gl/pull/523))
+- ForLoop visual membership synced with graph connections and execution scope, with unique group IDs and legacy group migration ([#541](https://github.com/joby-aviation/noodles.gl/pull/541), [#542](https://github.com/joby-aviation/noodles.gl/pull/542), [#539](https://github.com/joby-aviation/noodles.gl/pull/539), [#544](https://github.com/joby-aviation/noodles.gl/pull/544))
+- Layer loading errors now surfaced instead of hanging render ([#521](https://github.com/joby-aviation/noodles.gl/pull/521))
+- Connected geocoder queries not executing ([#522](https://github.com/joby-aviation/noodles.gl/pull/522))
+- TableEditor string literals now use a dropdown; active cell commits before row mutations ([#524](https://github.com/joby-aviation/noodles.gl/pull/524), [#535](https://github.com/joby-aviation/noodles.gl/pull/535))
+- JSON inputs now supported for icon mappings ([#527](https://github.com/joby-aviation/noodles.gl/pull/527))
+
+## July 2026
+
+### Added
+- Blender-style multi-input handles with order-correct data flow ([#120](https://github.com/joby-aviation/noodles.gl/pull/120))
+- WebMCP support for external control from Claude Code, with origin trial token ([#508](https://github.com/joby-aviation/noodles.gl/pull/508), [#510](https://github.com/joby-aviation/noodles.gl/pull/510))
+- Spreadsheet pane for tabular data inspection ([#466](https://github.com/joby-aviation/noodles.gl/pull/466))
+- Copy/paste support for timeline keyframes ([#388](https://github.com/joby-aviation/noodles.gl/pull/388))
+- Free API fallbacks and key nudges for AI features ([#396](https://github.com/joby-aviation/noodles.gl/pull/396))
+- Improved properties panel context menu and visual alignment ([#504](https://github.com/joby-aviation/noodles.gl/pull/504))
+- Homepage redesigned with visual-first layout and example screenshots ([#517](https://github.com/joby-aviation/noodles.gl/pull/517))
+
+### Fixed
+- Container scope-boundary bugs: copy-paste, delete cascade, undo/redo ([#503](https://github.com/joby-aviation/noodles.gl/pull/503))
+- MapLibre flickering via deep equality checks and icon caching ([#447](https://github.com/joby-aviation/noodles.gl/pull/447))
+- Node disappearing when title input blurred without changes ([#518](https://github.com/joby-aviation/noodles.gl/pull/518))
+- Crash when renaming nodes with upstream connections ([#136](https://github.com/joby-aviation/noodles.gl/pull/136))
+
+## June 2026
+
+### Added
+- Timeline MCP tools and improved AI integration guidance ([#487](https://github.com/joby-aviation/noodles.gl/pull/487))
+- Undo/redo support for TableEditorOp edits ([#499](https://github.com/joby-aviation/noodles.gl/pull/499))
+- Point2D/3DField accepts GeoJSON Point Features, with geometry-column detection for NetworkOp compatibility ([#482](https://github.com/joby-aviation/noodles.gl/pull/482), [#486](https://github.com/joby-aviation/noodles.gl/pull/486), [#498](https://github.com/joby-aviation/noodles.gl/pull/498))
+- Greyscale categorical color ramp with configurable steps ([#478](https://github.com/joby-aviation/noodles.gl/pull/478))
+- Improved op() error messages in CodeOp/ExpressionOp/AccessorOp ([#484](https://github.com/joby-aviation/noodles.gl/pull/484))
+
+### Changed
+- Operator properties panel shows all fields by default, removed pencil icon toggle ([#485](https://github.com/joby-aviation/noodles.gl/pull/485))
+
+### Fixed
+- Point field schema not transforming tuples to objects ([#500](https://github.com/joby-aviation/noodles.gl/pull/500))
+- False "unsaved changes" warnings from improved dirty-state detection ([#493](https://github.com/joby-aviation/noodles.gl/pull/493))
+- op() references with double-quoted paths ([#483](https://github.com/joby-aviation/noodles.gl/pull/483))
+
+## May 2026
+
+### Added
+- Timeline in/out points with draggable markers and loop playback, applied to rendering frame range ([#445](https://github.com/joby-aviation/noodles.gl/pull/445), [#454](https://github.com/joby-aviation/noodles.gl/pull/454), [#457](https://github.com/joby-aviation/noodles.gl/pull/457))
+- Real-time keyframe value updates while editing timeline ([#446](https://github.com/joby-aviation/noodles.gl/pull/446))
+- Timeline zoom around playhead with shift-scroll ([#443](https://github.com/joby-aviation/noodles.gl/pull/443))
+- Timeline variables in CodeOp/ExpressionField with reactive tracking ([#441](https://github.com/joby-aviation/noodles.gl/pull/441))
+- Timezone support and Temporal.ZonedDateTime output for TableEditorOp, plus a DateTime field ([#440](https://github.com/joby-aviation/noodles.gl/pull/440), [#436](https://github.com/joby-aviation/noodles.gl/pull/436))
+- File upload support for IconLayerOp icon atlas ([#437](https://github.com/joby-aviation/noodles.gl/pull/437))
+- SmoothOp for Gaussian/boxcar smoothing ([#460](https://github.com/joby-aviation/noodles.gl/pull/460))
+- Keyframe shape variations based on interpolation type ([#459](https://github.com/joby-aviation/noodles.gl/pull/459))
+- Edge bars from sequence boundaries to first/last keyframes ([#458](https://github.com/joby-aviation/noodles.gl/pull/458))
+- One-click ViewerOp to TableEditorOp conversion ([#480](https://github.com/joby-aviation/noodles.gl/pull/480))
+- Executing indicator for ops taking longer than 200ms ([#476](https://github.com/joby-aviation/noodles.gl/pull/476))
+
+### Changed
+- Optimized ReactFlow usage, reducing unnecessary re-renders ([#434](https://github.com/joby-aviation/noodles.gl/pull/434))
+
+### Fixed
+- Custom resolution selection not taking effect ([#473](https://github.com/joby-aviation/noodles.gl/pull/473))
+
+## April 2026
+
+### Added
+- TableEditorOp v2 with typed schema system ([#423](https://github.com/joby-aviation/noodles.gl/pull/423))
+- MapStyleConfigurator operator for visual map style editing, replacing MapStyleOp with typeahead on MaplibreBasemapOp ([#378](https://github.com/joby-aviation/noodles.gl/pull/378), [#393](https://github.com/joby-aviation/noodles.gl/pull/393))
+- RampOp operator with interactive curve editor ([#398](https://github.com/joby-aviation/noodles.gl/pull/398))
+- LegendWidget operator, with scale input ([#408](https://github.com/joby-aviation/noodles.gl/pull/408), [#412](https://github.com/joby-aviation/noodles.gl/pull/412))
+- Custom parameter editor for dynamic field creation ([#231](https://github.com/joby-aviation/noodles.gl/pull/231))
+- CrossOp for generating unique pairs, SimplifyOp for GeoJSON simplification ([#426](https://github.com/joby-aviation/noodles.gl/pull/426), [#424](https://github.com/joby-aviation/noodles.gl/pull/424))
+- CustomMapLibreLayer operator for custom WebGL layers ([#430](https://github.com/joby-aviation/noodles.gl/pull/430))
+- BitmapOverlayWidget for screen-space image overlays ([#428](https://github.com/joby-aviation/noodles.gl/pull/428))
+- Virtual in-memory filesystem for projects ([#432](https://github.com/joby-aviation/noodles.gl/pull/432))
+- Per-channel keyframing for Vec2, Vec3, Point2D, and Point3D fields ([#375](https://github.com/joby-aviation/noodles.gl/pull/375))
+- Debug breakpoint toggle on operator nodes ([#421](https://github.com/joby-aviation/noodles.gl/pull/421))
+- Download SVG from ViewerOp when input is a chart element ([#411](https://github.com/joby-aviation/noodles.gl/pull/411))
+
+### Changed
+- Lazy-loaded heavy dependencies to reduce initial bundle size ([#403](https://github.com/joby-aviation/noodles.gl/pull/403))
+
+### Fixed
+- ForLoop execution correctness in the pull-based system ([#429](https://github.com/joby-aviation/noodles.gl/pull/429))
+- BitmapLayerOp edit button crash, improved error boundaries ([#425](https://github.com/joby-aviation/noodles.gl/pull/425))
+- Recovery from stale edges and unknown operator types ([#417](https://github.com/joby-aviation/noodles.gl/pull/417))
+
+## March 2026
+
+### Added
+- Native timeline system replacing Theatre.js: Theatre.js-style keyframe controls, editable speed graph (After Effects style), Cavalry-style time markers, keyframed-field highlighting ([#349](https://github.com/joby-aviation/noodles.gl/pull/349), [#354](https://github.com/joby-aviation/noodles.gl/pull/354), [#359](https://github.com/joby-aviation/noodles.gl/pull/359), [#356](https://github.com/joby-aviation/noodles.gl/pull/356))
+- Undo/redo history for operator property changes ([#362](https://github.com/joby-aviation/noodles.gl/pull/362))
+- PNG sequence export capability ([#360](https://github.com/joby-aviation/noodles.gl/pull/360))
+- Reroute operator for graph organization ([#371](https://github.com/joby-aviation/noodles.gl/pull/371))
+- Swap connection on edge drop, and highlight target edge during connection drag ([#372](https://github.com/joby-aviation/noodles.gl/pull/372), [#383](https://github.com/joby-aviation/noodles.gl/pull/383))
+- Resizable timeline panel ([#384](https://github.com/joby-aviation/noodles.gl/pull/384))
+- Background rendering via worker timers ([#368](https://github.com/joby-aviation/noodles.gl/pull/368))
+- FileUrlField combining FileField and JSONUrlField with upload support ([#374](https://github.com/joby-aviation/noodles.gl/pull/374))
+- Transparent basemap support by preserving geo viewState in deckProps ([#363](https://github.com/joby-aviation/noodles.gl/pull/363))
+
+### Changed
+- Removed Theatre.js dependency entirely — render settings, project loading, and keyframing rebuilt on the native timeline ([#269](https://github.com/joby-aviation/noodles.gl/pull/269))
+- Migrated from Yarn to npm, adopted npm workspaces for faster Cloudflare builds ([#381](https://github.com/joby-aviation/noodles.gl/pull/381), [#390](https://github.com/joby-aviation/noodles.gl/pull/390))
+- Upgraded TypeScript to 6.0.2 ([#391](https://github.com/joby-aviation/noodles.gl/pull/391))
+
+### Fixed
+- Slow node dragging via O(1) edge connection lookup and fewer graph transforms ([#347](https://github.com/joby-aviation/noodles.gl/pull/347), [#232](https://github.com/joby-aviation/noodles.gl/pull/232))
+- Timeline scrub slowness ([#346](https://github.com/joby-aviation/noodles.gl/pull/346))
+- Stale frame encoded at render start ([#314](https://github.com/joby-aviation/noodles.gl/pull/314))
+
+## February 2026
+
+### Added
+- /projects page with modal routes and File menu links ([#313](https://github.com/joby-aviation/noodles.gl/pull/313))
+- TSV format support in FileOp ([#304](https://github.com/joby-aviation/noodles.gl/pull/304))
+- Fully qualified handle names shown in property list connections ([#309](https://github.com/joby-aviation/noodles.gl/pull/309))
+- depthTest parameter added to all layer operators ([#311](https://github.com/joby-aviation/noodles.gl/pull/311))
+
+### Fixed
+- Layer reordering by fixing edge handle format matching ([#310](https://github.com/joby-aviation/noodles.gl/pull/310))
+- Memory leak during video export ([#316](https://github.com/joby-aviation/noodles.gl/pull/316))
+
 ## January 2026
 
 ### Added


### PR DESCRIPTION
## Summary
- Changelog stopped at January 2026; ~400 commits have landed since then
- Added month-by-month entries for Feb through Aug 2026, matching the existing Added/Changed/Fixed format
- Highlights: native timeline system replacing Theatre.js, Blender-style multi-input handles, TableEditorOp v2, WebMCP/Claude Code external control, ForLoop scope fixes

## Test plan
- [ ] Docs-only change — no build/test impact
- [ ] Render `docs/changelog.md` on the docs site to confirm formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)