### PR TITLE
Fix tiny Measure and Draw tool panels

### DIFF
--- a/noodles-editor/src/noodles/components/tools/map-tool-overlay.module.css
+++ b/noodles-editor/src/noodles/components/tools/map-tool-overlay.module.css
@@ -53,8 +53,8 @@
 
 /* Floating control panel, anchored top-left of the map the way GIS tools usually are */
 .panel {
-  position: absolute;
-  top: 12px;
+  position: fixed;
+  top: 42px;
   left: 12px;
   width: 220px;
   display: flex;

--- a/noodles-editor/src/noodles/components/tools/map-tool-overlay.tsx
+++ b/noodles-editor/src/noodles/components/tools/map-tool-overlay.tsx
@@ -1,5 +1,6 @@
 import type { Map as MapLibre } from 'maplibre-gl'
 import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { analytics } from '../../../utils/analytics'
 import s from './map-tool-overlay.module.css'
 import { type DistanceUnit, type DrawMode, useMapToolStore } from './map-tool-store'
@@ -322,7 +323,8 @@ export function MapToolOverlay({ mapRef, onSaveDrawing, onSaveMeasurement }: Map
         </svg>
       </div>
 
-      <div className={s.panel}>
+      {createPortal(
+        <div className={s.panel}>
         <div className={s.panelHeader}>
           <i className={activeTool === 'measure' ? 'pi pi-arrows-h' : 'pi pi-pencil'} />
           <span className={s.panelTitle}>{activeTool === 'measure' ? 'Measure' : 'Draw'}</span>
@@ -473,7 +475,9 @@ export function MapToolOverlay({ mapRef, onSaveDrawing, onSaveMeasurement }: Map
             </button>
           )}
         </div>
-      </div>
+        </div>,
+        document.body
+      )}
     </>
   )
 }


### PR DESCRIPTION
Fixes the Measure and Draw tool panels rendering at ~30% size (unreadable text and buttons).

## Problem
The panels used `position: absolute` and were rendered inside a `TransformScale` wrapper that applies `scale(0.3)` by default. All pixel-based font sizes (10-15px) were scaled down to 3-4.5px.

## Solution
- Render panel via `createPortal` to `document.body` (escapes the transform hierarchy)
- Changed `position` from `absolute` to `fixed`
- Adjusted `top` from `12px` to `42px` to clear the toolbar

## Testing
1. Open http://localhost:5173/examples/nyc-taxis
2. Click "Measure" button - panel renders at full readable size
3. Click "Draw" button - panel renders at full readable size
4. Verify Distance/Area toggles and mode buttons are clickable
5. Test creating measurements and drawings

The Point and Draw wizards already used this pattern (portal + fixed positioning) and work correctly.


Before:
<img width="613" height="105" alt="Screenshot 2026-08-20 at 10 40 14 PM" src="https://github.com/user-attachments/assets/b5860dc5-f929-4b24-8601-9123e72940ce" />


After:

<img width="589" height="251" alt="Screenshot 2026-08-20 at 11 00 27 PM" src="https://github.com/user-attachments/assets/95aab2fe-7087-447f-9c08-cd63ce397a61" />
