### PR TITLE
Fix keyboard shortcuts firing while typing in input fields

### DIFF
--- a/noodles-editor/src/noodles/components/ExpressionEditorOverlay.tsx
+++ b/noodles-editor/src/noodles/components/ExpressionEditorOverlay.tsx
@@ -147,7 +147,7 @@ export function ExpressionEditorOverlay({
   // Use createPortal to render outside of ReactFlow's transformed container
   // This ensures position: fixed works correctly relative to the viewport
   return createPortal(
-    <div ref={containerRef} className={s.expressionEditorOverlay} style={overlayStyle()}>
+    <div ref={containerRef} className={`${s.expressionEditorOverlay} nokey`} style={overlayStyle()}>
       <div className={s.expressionEditorContent}>
         <Editor
           height="60px"

--- a/noodles-editor/src/noodles/components/UndoRedoHandler.tsx
+++ b/noodles-editor/src/noodles/components/UndoRedoHandler.tsx
@@ -3,6 +3,7 @@ import { registerTimelineMutationCallback } from '../../timeline/timeline-store'
 import { analytics } from '../../utils/analytics'
 import { debugHistoryRedo, debugHistoryUndo } from '../../utils/debug'
 import type { GraphRef } from '../types'
+import { shouldBlockKeyboardShortcut } from '../utils/input-detection'
 import { registerPropertyMutationCallback } from '../utils/property-history'
 import { useUndoRedo } from '../utils/use-undo-redo'
 
@@ -64,6 +65,8 @@ export const UndoRedoHandler = forwardRef<UndoRedoHandlerRef, UndoRedoHandlerPro
   // Add keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (shouldBlockKeyboardShortcut(e)) return
+
       if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {
         e.preventDefault()
         debugHistoryUndo('Undo triggered via keyboard')

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -365,7 +365,7 @@ export function TextFieldComponent({
   }
 
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>
@@ -504,7 +504,7 @@ export function ExpressionFieldComponent({
   )
 
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>
@@ -680,7 +680,7 @@ export function VectorFieldComponent({
   )
 
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>
@@ -1801,7 +1801,7 @@ export function NumberFieldComponent({
   )
 
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>
@@ -1854,7 +1854,7 @@ export function BooleanFieldComponent({
   )
 
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>
@@ -1907,7 +1907,7 @@ export function DateFieldComponent({
   const formatted = value?.toString?.()?.substring(0, 23) || ''
 
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>
@@ -1954,7 +1954,7 @@ export function ColorFieldComponent({
   )
 
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>
@@ -2021,7 +2021,7 @@ export function ColorRampComponent({
   }, [interpolate, field, id, steps])
 
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <canvas className={s.fieldInputColorRamp} ref={canvasRef} width={steps} height={1} />
     </div>
   )
@@ -2038,7 +2038,7 @@ export function CompoundFieldComponent({
 }) {
   const [expanded, setExpanded] = useState(true)
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <button
         className={s.fieldLabel}
         type="button"
@@ -2071,7 +2071,7 @@ export function CompoundFieldComponent({
 
 export function EmptyFieldComponent({ id }: { id: OpId; field: Field<IField> }) {
   return (
-    <div className={s.fieldWrapper}>
+    <div className={cx(s.fieldWrapper, 'nokey')}>
       <div className={s.fieldLabel}>{id}</div>
     </div>
   )
@@ -2375,7 +2375,7 @@ export function BezierCurveFieldComponent({
   const gridLines = generateGridLines()
 
   return (
-    <div className={s.fieldWrapper} ref={containerRef}>
+    <div className={cx(s.fieldWrapper, 'nokey')} ref={containerRef}>
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>

--- a/noodles-editor/src/noodles/components/top-menu-bar.tsx
+++ b/noodles-editor/src/noodles/components/top-menu-bar.tsx
@@ -11,6 +11,7 @@ import { debugUI } from '../../utils/debug'
 import { ContainerOp } from '../operators'
 import { getOpStore, type MapMode, useNestingStore, useUIStore } from '../store'
 import { directoryHandleCache } from '../utils/directory-handle-cache'
+import { shouldBlockKeyboardShortcut } from '../utils/input-detection'
 import { getParentPath, splitPath } from '../utils/path-utils'
 import { Breadcrumbs } from './breadcrumbs'
 import type { CopyControlsRef } from './copy-controls'
@@ -101,6 +102,8 @@ export function TopMenuBar({
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (shouldBlockKeyboardShortcut(e)) return
+
       const isMod = e.metaKey || e.ctrlKey
 
       if (isMod && e.key === 's') {

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -104,6 +104,7 @@ import {
   selectDirectory,
   writeFileToDirectory,
 } from './utils/filesystem'
+import { shouldBlockKeyboardShortcut } from './utils/input-detection'
 import { reconcileForLoopGroups } from './utils/for-loop-group-utils'
 import { edgeId, nodeId } from './utils/id-utils'
 import { generateDraftId, memoryProjectStore } from './utils/memory-project-store'
@@ -1277,6 +1278,8 @@ export function getNoodles(): Visualization {
   // Handle mod+shift+s for Save As and mod+shift+a for Rename Project
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (shouldBlockKeyboardShortcut(e)) return
+
       const key = e.key.toLowerCase()
       const isMod = e.metaKey || e.ctrlKey
       const isShift = e.shiftKey

--- a/noodles-editor/src/noodles/utils/input-detection.test.ts
+++ b/noodles-editor/src/noodles/utils/input-detection.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { shouldBlockKeyboardShortcut } from './input-detection'
+
+describe('shouldBlockKeyboardShortcut', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  it('should block shortcuts in INPUT elements', () => {
+    const input = document.createElement('input')
+    container.appendChild(input)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    input.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should block shortcuts in TEXTAREA elements', () => {
+    const textarea = document.createElement('textarea')
+    container.appendChild(textarea)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    textarea.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should block shortcuts in SELECT elements', () => {
+    const select = document.createElement('select')
+    container.appendChild(select)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    select.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should block shortcuts in contenteditable elements', () => {
+    const div = document.createElement('div')
+    div.setAttribute('contenteditable', 'true')
+    container.appendChild(div)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    div.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should block shortcuts in .nokey containers', () => {
+    const nokeyContainer = document.createElement('div')
+    nokeyContainer.className = 'nokey'
+    const button = document.createElement('button')
+    nokeyContainer.appendChild(button)
+    container.appendChild(nokeyContainer)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    button.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should block shortcuts in nested .nokey containers', () => {
+    const nokeyContainer = document.createElement('div')
+    nokeyContainer.className = 'nokey'
+    const inner = document.createElement('div')
+    const button = document.createElement('button')
+    inner.appendChild(button)
+    nokeyContainer.appendChild(inner)
+    container.appendChild(nokeyContainer)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    button.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should allow shortcuts in regular elements', () => {
+    const button = document.createElement('button')
+    container.appendChild(button)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    button.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(false)
+  })
+
+  it('should allow shortcuts on document body', () => {
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    document.body.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(false)
+  })
+
+  it('should handle events with composedPath', () => {
+    const input = document.createElement('input')
+    container.appendChild(input)
+
+    // Create event with composedPath
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true, composed: true })
+    Object.defineProperty(event, 'composedPath', {
+      value: () => [input, container, document.body, document, window],
+    })
+    input.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should fallback to event.target when composedPath unavailable', () => {
+    const input = document.createElement('input')
+    container.appendChild(input)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    // Remove composedPath to test fallback
+    Object.defineProperty(event, 'composedPath', { value: undefined })
+    input.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should handle modifier key combinations', () => {
+    const input = document.createElement('input')
+    container.appendChild(input)
+
+    const event = new KeyboardEvent('keydown', {
+      key: 's',
+      metaKey: true,
+      bubbles: true,
+    })
+    input.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should block Cmd+Z in textarea', () => {
+    const textarea = document.createElement('textarea')
+    container.appendChild(textarea)
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+      bubbles: true,
+    })
+    textarea.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should allow space bar in regular context', () => {
+    const button = document.createElement('button')
+    container.appendChild(button)
+
+    const event = new KeyboardEvent('keydown', { code: 'Space', bubbles: true })
+    button.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(false)
+  })
+
+  it('should block space bar in input', () => {
+    const input = document.createElement('input')
+    container.appendChild(input)
+
+    const event = new KeyboardEvent('keydown', { code: 'Space', bubbles: true })
+    input.dispatchEvent(event)
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(true)
+  })
+
+  it('should handle non-element targets gracefully', () => {
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    Object.defineProperty(event, 'target', { value: null })
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(false)
+  })
+
+  it('should handle text nodes gracefully', () => {
+    const textNode = document.createTextNode('text')
+    container.appendChild(textNode)
+
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    Object.defineProperty(event, 'target', { value: textNode })
+
+    expect(shouldBlockKeyboardShortcut(event)).toBe(false)
+  })
+})

--- a/noodles-editor/src/noodles/utils/input-detection.ts
+++ b/noodles-editor/src/noodles/utils/input-detection.ts
@@ -1,0 +1,18 @@
+// Shared utility for detecting if keyboard shortcuts should be blocked
+// Used by keyboard-manager and direct event listeners to maintain consistent behavior
+
+const inputTags = ['INPUT', 'SELECT', 'TEXTAREA']
+
+// Check if a keyboard event should be blocked due to input field focus or .nokey container
+// This handles:
+// - Standard form inputs (INPUT, SELECT, TEXTAREA)
+// - contenteditable elements
+// - Elements inside .nokey containers
+// - Shadow DOM via composedPath()
+export function shouldBlockKeyboardShortcut(event: KeyboardEvent): boolean {
+  const target = (event.composedPath?.()?.[0] || event.target) as Element | null
+  if (target?.nodeType !== 1) return false
+
+  const isInput = inputTags.includes(target.nodeName) || target.hasAttribute('contenteditable')
+  return isInput || !!target.closest('.nokey')
+}

--- a/noodles-editor/src/noodles/utils/keyboard-manager.test.ts
+++ b/noodles-editor/src/noodles/utils/keyboard-manager.test.ts
@@ -193,4 +193,20 @@ describe('KeyboardManager', () => {
 
     expect(handler).not.toHaveBeenCalled()
   })
+
+  it('should use shared input detection utility', () => {
+    const handler = vi.fn()
+    keyboardManager.register('a', handler)
+
+    // Test that it correctly identifies and blocks input elements
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    const event = new KeyboardEvent('keyup', { key: 'a', bubbles: true })
+    input.dispatchEvent(event)
+
+    expect(handler).not.toHaveBeenCalled()
+
+    document.body.removeChild(input)
+  })
 })

--- a/noodles-editor/src/noodles/utils/keyboard-manager.ts
+++ b/noodles-editor/src/noodles/utils/keyboard-manager.ts
@@ -1,6 +1,8 @@
 // Adapted from React Flow's keyboard handling approach
 // https://github.com/xyflow/xyflow/blob/main/packages/system/src/utils/dom.ts
 
+import { shouldBlockKeyboardShortcut } from './input-detection'
+
 type ShortcutHandler = (e: KeyboardEvent) => undefined | boolean
 
 interface ShortcutRegistration {
@@ -9,22 +11,12 @@ interface ShortcutRegistration {
   id: symbol
 }
 
-const inputTags = ['INPUT', 'SELECT', 'TEXTAREA']
-
 class KeyboardManager {
   private registrations: ShortcutRegistration[] = []
   private initialized = false
 
-  private isInputDOMNode(event: KeyboardEvent): boolean {
-    const target = (event.composedPath?.()?.[0] || event.target) as Element | null
-    if (target?.nodeType !== 1) return false
-
-    const isInput = inputTags.includes(target.nodeName) || target.hasAttribute('contenteditable')
-    return isInput || !!target.closest('.nokey')
-  }
-
   private handleKeyUp = (e: KeyboardEvent) => {
-    if (this.isInputDOMNode(e)) return
+    if (shouldBlockKeyboardShortcut(e)) return
 
     const key = e.key.toLowerCase()
 

--- a/noodles-editor/src/timeline/components/TimelinePanel.tsx
+++ b/noodles-editor/src/timeline/components/TimelinePanel.tsx
@@ -346,9 +346,7 @@ export function TimelinePanel({ height = 300, onCollapse }: TimelinePanelProps) 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key !== 'Delete' && e.key !== 'Backspace') return
-      const target = e.target as HTMLElement
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
-        return
+      if (shouldBlockKeyboardShortcut(e)) return
 
       if (selectedMarkerId) {
         e.preventDefault()

--- a/noodles-editor/src/timeline/components/TimelinePanel.tsx
+++ b/noodles-editor/src/timeline/components/TimelinePanel.tsx
@@ -3,6 +3,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useExportActions } from '../../noodles/contexts/export-actions-context'
+import { shouldBlockKeyboardShortcut } from '../../noodles/utils/input-detection'
 import {
   captureTimelineState,
   fireTimelineMutation,
@@ -418,15 +419,7 @@ export function TimelinePanel({ height = 300, onCollapse }: TimelinePanelProps) 
   // Handle spacebar for play/pause and arrow keys for frame stepping globally
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement
-      // Don't intercept keys in input elements
-      if (
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.contentEditable === 'true'
-      ) {
-        return
-      }
+      if (shouldBlockKeyboardShortcut(e)) return
 
       const store = getTimelineStore()
       if (e.code === 'Space') {


### PR DESCRIPTION
## Summary

Fixes keyboard shortcuts triggering unintentionally while users type in input fields.

## Problem

Users reported that:
- Typing "par" in an ExpressionField triggers the 'a' key shortcut (opens Add Node menu)
- Pressing Cmd+S while typing in a text field triggers Save instead of native browser behavior
- Pressing Cmd+Z while editing text triggers undo instead of native text undo
- Pressing Space while typing in an input doesn't insert a space, it plays/pauses the timeline

The root cause was that multiple keyboard event handlers bypassed the centralized input detection system.

## Solution

Created a unified input detection utility that all keyboard handlers use:

### Files Changed

**New files:**
- `noodles-editor/src/noodles/utils/input-detection.ts` - Shared input detection utility
- `noodles-editor/src/noodles/utils/input-detection.test.ts` - Comprehensive test suite (16 tests)

**Modified files:**
- `keyboard-manager.ts` - Uses shared utility
- `UndoRedoHandler.tsx` - Added input detection for Cmd+Z, Cmd+Shift+Z
- `top-menu-bar.tsx` - Added input detection for Cmd+S, Cmd+N, Cmd+O, Cmd+I, Cmd+F
- `noodles.tsx` - Added input detection for Cmd+Shift+S, Cmd+Shift+A
- `TimelinePanel.tsx` - Replaced manual input check with shared utility (Space, Arrow keys)
- `field-components.tsx` - Added `.nokey` class to all field wrappers
- `ExpressionEditorOverlay.tsx` - Added `.nokey` class for Monaco editor

## Test Coverage

✅ 16 new tests in `input-detection.test.ts`:
- INPUT, TEXTAREA, SELECT, contenteditable elements
- .nokey containers (nested and direct)
- Modifier key combinations (Cmd+S, Cmd+Z, etc.)
- Shadow DOM via composedPath()
- Space bar behavior
- Fallback to event.target

✅ All existing tests pass (14 tests in keyboard-manager.test.ts)

✅ Build succeeds with no TypeScript errors

## Test Plan

1. Open a project in dev mode: `npm start`
2. Click on an ExpressionField and type "par" - verify Add Node menu does NOT open
3. Click on any text input and press Cmd+S - verify project does NOT save
4. Click on a textarea and press Space - verify space is inserted, timeline does NOT play
5. Click outside all inputs and press 'a' - verify Add Node menu DOES open
6. Click outside all inputs and press Space - verify timeline DOES play/pause
7. Open Monaco editor overlay for an expression - verify all shortcuts are blocked inside editor
8. Press Cmd+Z in a textarea - verify native text undo works, not app undo

## Edge Cases Handled

- Shadow DOM (composedPath gets correct target)
- Monaco editor (isolated via .nokey class)
- Nested inputs (composedPath[0] gets deepest element)
- contenteditable divs (explicitly checked)
- Dialogs with inputs (.nokey class blocks all shortcuts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)