### PR TITLE
Make right panel elements resize with panel width

### DIFF
--- a/noodles-editor/src/noodles/components/node-properties.module.css
+++ b/noodles-editor/src/noodles/components/node-properties.module.css
@@ -2,6 +2,7 @@
 .panel {
   width: 100%;
   padding: 8px;
+  box-sizing: border-box;
   font-size: 11px;
   display: flex;
   flex-direction: column;

--- a/noodles-editor/src/noodles/components/node-properties.module.css
+++ b/noodles-editor/src/noodles/components/node-properties.module.css
@@ -1,6 +1,6 @@
 /* Base panel */
 .panel {
-  width: var(--property-panel-width);
+  width: 100%;
   padding: 8px;
   font-size: 11px;
   display: flex;

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -59,7 +59,6 @@
   --node-view-color: #0e8fc9;
   --node-widget-color: #7a61d5;
 
-  --property-panel-width: 296px;
   --property-panel-background-color: #282b2fcc;
   --tooltip-icon-color: #919191;
   --tooltip-background-color: #383838;

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -104,9 +104,9 @@ import {
   selectDirectory,
   writeFileToDirectory,
 } from './utils/filesystem'
-import { shouldBlockKeyboardShortcut } from './utils/input-detection'
 import { reconcileForLoopGroups } from './utils/for-loop-group-utils'
 import { edgeId, nodeId } from './utils/id-utils'
+import { shouldBlockKeyboardShortcut } from './utils/input-detection'
 import { generateDraftId, memoryProjectStore } from './utils/memory-project-store'
 import { migrateProject } from './utils/migrate-schema'
 import { normalizeMultiInputEdges } from './utils/multi-input-utils'


### PR DESCRIPTION
#### Background
The right panel (properties panel) had a fixed inner width of 296px, even though the panel itself could be resized from 12-30% of viewport width. This caused field elements to remain constrained to 296px regardless of actual panel width, leading to ellipsed text that didn't expand when more space was available.

#### Change List
- Changed `.panel` CSS from `width: var(--property-panel-width)` to `width: 100%` in `node-properties.module.css`
- Removed unused `--property-panel-width: 296px;` CSS variable from `noodles.module.css`
- Field inputs now dynamically expand/contract as the panel is resized