### PR TITLE
Fix app crashing to black with unrecognized operators

### DIFF
--- a/noodles-editor/src/noodles/__tests__/graph-execution-e2e.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/graph-execution-e2e.test.tsx
@@ -51,7 +51,7 @@ describe('Graph Execution E2E', () => {
       },
     ]
 
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     // Verify all operators created
     expect(operators).toHaveLength(3)
@@ -174,7 +174,7 @@ describe('Graph Execution E2E', () => {
       },
     ]
 
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     expect(operators).toHaveLength(4)
 

--- a/noodles-editor/src/noodles/__tests__/noodles-graph-integration.test.tsx
+++ b/noodles-editor/src/noodles/__tests__/noodles-graph-integration.test.tsx
@@ -49,7 +49,7 @@ describe('Noodles Graph Integration', () => {
       },
     ]
 
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     // Should create 3 operators
     expect(operators).toHaveLength(3)
@@ -129,7 +129,7 @@ describe('Noodles Graph Integration', () => {
 
     // Transform the graph again - this reuses existing operators
     // and cleans up operators that are no longer in the nodes list
-    const newOperators = transformGraph({
+    const { operators: newOperators } = transformGraph({
       nodes: nodesAfterDelete,
       edges: edgesAfterDelete,
     })
@@ -175,7 +175,7 @@ describe('Noodles Graph Integration', () => {
     ]
 
     // Transform again without clearing - operators are reused
-    const operators = transformGraph({ nodes: updatedNodes, edges: [] })
+    const { operators } = transformGraph({ nodes: updatedNodes, edges: [] })
 
     expect(operators).toHaveLength(2)
     expect(hasOp('/num2')).toBe(true)
@@ -290,7 +290,7 @@ describe('Noodles Graph Integration', () => {
       },
     ]
 
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     expect(operators).toHaveLength(4)
 

--- a/noodles-editor/src/noodles/components/graph-error-dialog.tsx
+++ b/noodles-editor/src/noodles/components/graph-error-dialog.tsx
@@ -1,0 +1,136 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { Cross2Icon } from '@radix-ui/react-icons'
+import cx from 'classnames'
+import s from './menu.module.css'
+
+export interface GraphError {
+  type: 'unknown-operator' | 'stale-edge' | 'operator-execution'
+  message: string
+  details?: string
+}
+
+interface GraphErrorDialogProps {
+  open: boolean
+  errors: GraphError[]
+  onClose: () => void
+  validOperatorCount?: number
+}
+
+export const GraphErrorDialog = ({
+  open,
+  errors,
+  onClose,
+  validOperatorCount = 0,
+}: GraphErrorDialogProps) => {
+  const unknownOperators = errors.filter(e => e.type === 'unknown-operator')
+  const staleEdges = errors.filter(e => e.type === 'stale-edge')
+  const executionErrors = errors.filter(e => e.type === 'operator-execution')
+
+  return (
+    <Dialog.Root open={open} onOpenChange={open => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={s.dialogOverlay} />
+        <Dialog.Content className={s.dialogContent}>
+          <Dialog.Title className={s.dialogTitle}>Project Loading Errors</Dialog.Title>
+          <Dialog.Description className={s.dialogDescription}>
+            {validOperatorCount > 0 ? (
+              <>
+                <strong>{validOperatorCount} operators loaded successfully</strong>, but the project
+                file contains errors:
+              </>
+            ) : (
+              'The project file contains errors:'
+            )}
+          </Dialog.Description>
+
+          <div className={s.dialogDescription}>
+            {unknownOperators.length > 0 && (
+              <div style={{ marginBottom: '1rem' }}>
+                <strong>Unknown Operator Types ({unknownOperators.length}):</strong>
+                <ul style={{ marginLeft: '1.5rem', marginTop: '0.5rem' }}>
+                  {unknownOperators.map((error, i) => (
+                    <li key={i}>{error.message}</li>
+                  ))}
+                </ul>
+                <p style={{ marginTop: '0.5rem', fontSize: '0.9em', color: 'var(--gray-11)' }}>
+                  These operators are not registered and will be skipped. This may happen if the
+                  project was created with a newer version of the app or uses custom operators.
+                </p>
+              </div>
+            )}
+
+            {staleEdges.length > 0 && (
+              <div style={{ marginBottom: '1rem' }}>
+                <strong>Broken Connections ({staleEdges.length}):</strong>
+                <ul style={{ marginLeft: '1.5rem', marginTop: '0.5rem' }}>
+                  {staleEdges.slice(0, 5).map((error, i) => (
+                    <li key={i}>{error.message}</li>
+                  ))}
+                  {staleEdges.length > 5 && (
+                    <li>...and {staleEdges.length - 5} more broken connections</li>
+                  )}
+                </ul>
+                <p style={{ marginTop: '0.5rem', fontSize: '0.9em', color: 'var(--gray-11)' }}>
+                  These edges reference nodes that no longer exist. This may be caused by a failed
+                  node rename or manual file editing.
+                </p>
+              </div>
+            )}
+
+            {executionErrors.length > 0 && (
+              <div style={{ marginBottom: '1rem' }}>
+                <strong>Execution Errors ({executionErrors.length}):</strong>
+                <ul style={{ marginLeft: '1.5rem', marginTop: '0.5rem' }}>
+                  {executionErrors.slice(0, 3).map((error, i) => (
+                    <li key={i}>
+                      {error.message}
+                      {error.details && (
+                        <details style={{ marginTop: '0.25rem' }}>
+                          <summary style={{ cursor: 'pointer', color: 'var(--gray-11)' }}>
+                            Details
+                          </summary>
+                          <pre
+                            style={{
+                              fontSize: '0.8em',
+                              padding: '0.5rem',
+                              background: 'var(--gray-3)',
+                              borderRadius: '4px',
+                              overflow: 'auto',
+                              maxHeight: '200px',
+                            }}
+                          >
+                            {error.details}
+                          </pre>
+                        </details>
+                      )}
+                    </li>
+                  ))}
+                  {executionErrors.length > 3 && (
+                    <li>...and {executionErrors.length - 3} more errors</li>
+                  )}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          <div className={s.dialogRightSlot}>
+            <button type="button" className={cx(s.dialogButton, s.green)} onClick={onClose}>
+              {validOperatorCount > 0 ? 'Continue with Valid Operators' : 'Close'}
+            </button>
+          </div>
+          {validOperatorCount > 0 && (
+            <p style={{ marginTop: '0.75rem', fontSize: '0.9em', color: 'var(--gray-11)' }}>
+              The valid operators have been loaded and the graph is functional. Skipped operators and
+              broken connections will not be available.
+            </p>
+          )}
+          <Dialog.Close asChild>
+            <button type="button" className={s.dialogIconButton} aria-label="Close">
+              <Cross2Icon />
+            </button>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/noodles-editor/src/noodles/container-integration.test.ts
+++ b/noodles-editor/src/noodles/container-integration.test.ts
@@ -47,7 +47,7 @@ describe('Container Integration with Transform Graph', () => {
     const edges: Edge[] = []
 
     // Transform the graph
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     // Verify operators were created with correct IDs
     expect(operators).toHaveLength(4)
@@ -112,7 +112,7 @@ describe('Container Integration with Transform Graph', () => {
     const edges: Edge[] = []
 
     // Transform the graph
-    const operators = transformGraph({ nodes, edges })
+    const { operators } = transformGraph({ nodes, edges })
 
     // Verify operators were created
     expect(operators).toHaveLength(4)

--- a/noodles-editor/src/noodles/noodles.test.ts
+++ b/noodles-editor/src/noodles/noodles.test.ts
@@ -33,7 +33,7 @@ describe('nodes', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
     assert.equal(instances.length, 2)
 
     const [num, add] = instances
@@ -69,7 +69,7 @@ describe('nodes', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
+    const { operators: instances } = transformGraph(graph)
 
     assert.equal(instances.length, 2)
 
@@ -151,7 +151,7 @@ describe('nodes', () => {
       ],
     }
 
-    const instances = transformGraph(complexGraph)
+    const { operators: instances } = transformGraph(complexGraph)
     assert.equal(instances.length, 5)
 
     // Verify all instances have qualified IDs
@@ -223,7 +223,7 @@ describe('nodes', () => {
     // prevents them from running — but they must be in the store to avoid "operator not found"
     // render errors. TODO: surface a cycle warning to the user.
     expect(() => transformGraph(graph)).not.toThrowError()
-    expect(transformGraph(graph).length).toEqual(2)
+    expect(transformGraph(graph).operators.length).toEqual(2)
   })
 
   it('fails gracefully on missing fields', () => {
@@ -254,6 +254,6 @@ describe('nodes', () => {
     }
 
     expect(() => transformGraph(graph)).not.toThrowError()
-    expect(transformGraph(graph).length).toEqual(2)
+    expect(transformGraph(graph).operators.length).toEqual(2)
   })
 })

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -58,6 +58,7 @@ import { CopyControls, type CopyControlsRef } from './components/copy-controls'
 import { NodeInfoOverlay, ViewportInfoPanel } from './components/devtools'
 import { ErrorBoundary } from './components/error-boundary'
 import { ExampleNotFoundDialog } from './components/example-not-found-dialog'
+import { type GraphError, GraphErrorDialog } from './components/graph-error-dialog'
 import { LayerPanel } from './components/layer-panel'
 import { PropertyPanel } from './components/node-properties'
 import { NodeTreeSidebar } from './components/node-tree-sidebar'
@@ -200,6 +201,7 @@ export function getNoodles(): Visualization {
     hasDataFiles: boolean
   } | null>(null)
   const [showExampleNotFoundDialog, setShowExampleNotFoundDialog] = useState(false)
+  const [graphErrors, setGraphErrors] = useState<GraphError[]>([])
   const storageType = useActiveStorageType()
   const { currentDirectory, setCurrentDirectory, setActiveStorageType, setError } =
     useFileSystemStore()
@@ -368,8 +370,17 @@ export function getNoodles(): Visualization {
   useEffect(() => {
     // loadProjectFile already called transformGraph directly, so skip this triggered re-run
     if (isProjectLoadRef.current) return
-    const ops = transformGraph({ nodes, edges })
-    setOperators(ops)
+    const result = transformGraph({ nodes, edges })
+    setOperators(result.operators)
+    // Show error dialog if there are graph errors
+    if (result.errors.length > 0) {
+      setGraphErrors(
+        result.errors.map(e => ({
+          type: e.type,
+          message: e.message,
+        }))
+      )
+    }
     // Catch-all for multi-input slot caches: re-derive orderIndex/groupSize now that the
     // operators exist in the store (covers undo/redo restores, keyboard deletes, and AI/paste
     // paths that added edges before their operators were instantiated). Returns the same
@@ -794,6 +805,7 @@ export function getNoodles(): Visualization {
       // Load timeline state before transformGraph so field bindings see the right keyframe data
       clearAllBindings()
       const hasTimeline = timeline && Object.keys(timeline).length > 0
+      const timelineErrors: GraphError[] = []
       if (hasTimeline) {
         try {
           // Timeline data uses a timeline JSON format.
@@ -802,14 +814,30 @@ export function getNoodles(): Visualization {
           )
         } catch (error) {
           console.error('Failed to load timeline:', error)
+          timelineErrors.push({
+            type: 'operator-execution',
+            message: 'Failed to load timeline data',
+            details: error instanceof Error ? error.stack : String(error),
+          })
         }
       } else {
         timelineStore.reset()
       }
 
       // Build the operator graph synchronously — operators are ready before any re-render
-      const ops = transformGraph({ nodes, edges })
-      setOperators(ops)
+      const result = transformGraph({ nodes, edges })
+      setOperators(result.operators)
+      // Show error dialog if there are graph or timeline errors
+      const allErrors = [
+        ...timelineErrors,
+        ...result.errors.map(e => ({
+          type: e.type,
+          message: e.message,
+        })),
+      ]
+      if (allErrors.length > 0) {
+        setGraphErrors(allErrors)
+      }
 
       // Update React Flow state (for rendering; graph is already set up above).
       // Normalizing here (after transformGraph, so operators exist for the ListField
@@ -1661,6 +1689,12 @@ export function getNoodles(): Visualization {
           onBrowseExamples={onBrowseExamples}
           onCheckMyProjects={onCheckMyProjects}
           onClose={() => setShowExampleNotFoundDialog(false)}
+        />
+        <GraphErrorDialog
+          open={graphErrors.length > 0}
+          errors={graphErrors}
+          onClose={() => setGraphErrors([])}
+          validOperatorCount={operators.length}
         />
         <StorageErrorHandler />
       </div>

--- a/noodles-editor/src/noodles/qualified-paths-integration.test.ts
+++ b/noodles-editor/src/noodles/qualified-paths-integration.test.ts
@@ -70,7 +70,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created with correct qualified IDs
       expect(operators).toHaveLength(4)
@@ -190,7 +190,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created
       expect(operators).toHaveLength(6)
@@ -277,7 +277,7 @@ describe('Qualified Paths Integration Tests', () => {
       const edges: Edge[] = []
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created
       expect(operators).toHaveLength(6)
@@ -411,7 +411,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created with correct hierarchy
       expect(operators).toHaveLength(11)
@@ -526,7 +526,7 @@ describe('Qualified Paths Integration Tests', () => {
       const edges: Edge[] = []
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created
       expect(operators).toHaveLength(7)
@@ -605,7 +605,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify operators were created
       expect(operators).toHaveLength(3)
@@ -771,7 +771,7 @@ describe('Qualified Paths Integration Tests', () => {
       ]
 
       // Transform the graph
-      const operators = transformGraph({ nodes, edges })
+      const { operators } = transformGraph({ nodes, edges })
 
       // Verify all operators were created
       expect(operators).toHaveLength(8)

--- a/noodles-editor/src/noodles/transform-graph.test.ts
+++ b/noodles-editor/src/noodles/transform-graph.test.ts
@@ -44,10 +44,12 @@ describe('transform-graph topological sort with missing upstream nodes', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const result = transformGraph({ nodes, edges })
 
-    expect(instances).toHaveLength(1)
-    expect(instances[0].id).toBe('/kml-to-geo-json')
+    expect(result.operators).toHaveLength(1)
+    expect(result.operators[0].id).toBe('/kml-to-geo-json')
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].type).toBe('stale-edge')
 
     const { getOp } = getOpStore()
     expect(getOp('/kml-to-geo-json')).toBeDefined()
@@ -76,9 +78,9 @@ describe('transform-graph topological sort with missing upstream nodes', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const result = transformGraph({ nodes, edges })
 
-    expect(instances).toHaveLength(2)
+    expect(result.operators).toHaveLength(2)
     const { getOp } = getOpStore()
     expect(getOp('/a')).toBeDefined()
     expect(getOp('/b')).toBeDefined()
@@ -113,11 +115,11 @@ describe('transform-graph topological sort with missing upstream nodes', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const result = transformGraph({ nodes, edges })
 
-    expect(instances).toHaveLength(3)
+    expect(result.operators).toHaveLength(3)
     // /source must come before /downstream in execution order
-    const ids = instances.map(op => op.id)
+    const ids = result.operators.map(op => op.id)
     expect(ids.indexOf('/source')).toBeLessThan(ids.indexOf('/downstream'))
     // /orphan must also be present
     expect(ids).toContain('/orphan')
@@ -138,10 +140,10 @@ describe('transform-graph topological sort with missing upstream nodes', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
+    const result = transformGraph({ nodes, edges })
 
-    expect(instances).toHaveLength(2)
-    const ids = instances.map(op => op.id)
+    expect(result.operators).toHaveLength(2)
+    const ids = result.operators.map(op => op.id)
     expect(ids.indexOf('/num')).toBeLessThan(ids.indexOf('/math'))
   })
 })
@@ -453,8 +455,8 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
-    expect(instances).toHaveLength(2)
+    const result = transformGraph(graph)
+    expect(result.operators).toHaveLength(2)
 
     const [num, add] = instances
     expect(num).toBeInstanceOf(NumberOp)
@@ -533,8 +535,8 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
-    expect(instances).toHaveLength(2)
+    const result = transformGraph(graph)
+    expect(result.operators).toHaveLength(2)
 
     const [num, add] = instances
     expect(num).toBeInstanceOf(NumberOp)
@@ -572,8 +574,8 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
-    const code = instances.find(op => op.id === '/code') as CodeOp
+    const result = transformGraph(graph)
+    const code = result.operators.find(op => op.id === '/code') as CodeOp
     expect(code.hasConnectionErrors()).toBe(false)
   })
 
@@ -603,8 +605,8 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
-    const code = instances.find(op => op.id === '/code') as CodeOp
+    const result = transformGraph(graph)
+    const code = result.operators.find(op => op.id === '/code') as CodeOp
     expect(code.hasConnectionErrors()).toBe(true)
     const errorMessage = code.connectionErrors.value.get('/num.out.val->/code.par.code')
     expect(errorMessage).toContain('Type mismatch')
@@ -641,8 +643,8 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graph)
-    const add = instances.find(op => op.id === '/add') as MathOp
+    const result = transformGraph(graph)
+    const add = result.operators.find(op => op.id === '/add') as MathOp
 
     // Connection should be established despite type mismatch
     expect(add.inputs.a.subscriptions.size).toBe(1)
@@ -719,8 +721,8 @@ describe('transform-graph', () => {
       ],
     }
 
-    const instances = transformGraph(graphWithValidConnection)
-    const add = instances.find(op => op.id === '/add') as MathOp
+    const result = transformGraph(graphWithValidConnection)
+    const add = result.operators.find(op => op.id === '/add') as MathOp
 
     // Valid connection should be established
     expect(add.inputs.a.subscriptions.size).toBe(1)
@@ -785,8 +787,8 @@ describe('transform-graph', () => {
       edges: [], // No edges
     }
 
-    const instances = transformGraph(graphWithoutConnection)
-    const add = instances.find(op => op.id === '/add') as MathOp
+    const result = transformGraph(graphWithoutConnection)
+    const add = result.operators.find(op => op.id === '/add') as MathOp
 
     // No subscriptions should exist
     expect(add.inputs.a.subscriptions.size).toBe(0)
@@ -1119,8 +1121,8 @@ describe('connection error suppression for undefined source fields', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
-    const deck = instances.find(op => op.id === '/deck') as DeckRendererOp
+    const result = transformGraph({ nodes, edges })
+    const deck = result.operators.find(op => op.id === '/deck') as DeckRendererOp
 
     expect(deck.hasConnectionErrors()).toBe(false)
   })
@@ -1153,8 +1155,8 @@ describe('connection error suppression for undefined source fields', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
-    const add = instances.find(op => op.id === '/add') as MathOp
+    const result = transformGraph({ nodes, edges })
+    const add = result.operators.find(op => op.id === '/add') as MathOp
 
     expect(add.hasConnectionErrors()).toBe(false)
   })
@@ -1187,8 +1189,8 @@ describe('connection error suppression for undefined source fields', () => {
       },
     ]
 
-    const instances = transformGraph({ nodes, edges })
-    const add = instances.find(op => op.id === '/add') as MathOp
+    const result = transformGraph({ nodes, edges })
+    const add = result.operators.find(op => op.id === '/add') as MathOp
 
     expect(add.hasConnectionErrors()).toBe(true)
     expect(add.connectionErrors.value.get('/str.out.val->/add.par.a')).toContain('Type mismatch')

--- a/noodles-editor/src/noodles/transform-graph.test.ts
+++ b/noodles-editor/src/noodles/transform-graph.test.ts
@@ -458,7 +458,7 @@ describe('transform-graph', () => {
     const result = transformGraph(graph)
     expect(result.operators).toHaveLength(2)
 
-    const [num, add] = instances
+    const [num, add] = result.operators
     expect(num).toBeInstanceOf(NumberOp)
     expect(add).toBeInstanceOf(MathOp)
     expect(num.id).toBe('/num')
@@ -538,7 +538,7 @@ describe('transform-graph', () => {
     const result = transformGraph(graph)
     expect(result.operators).toHaveLength(2)
 
-    const [num, add] = instances
+    const [num, add] = result.operators
     expect(num).toBeInstanceOf(NumberOp)
     expect(add).toBeInstanceOf(MathOp)
 

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -163,11 +163,29 @@ export function deriveReferenceEdges(
   return derived
 }
 
+export interface GraphLoadError {
+  type: 'unknown-operator' | 'stale-edge'
+  nodeId?: string
+  nodeType?: string
+  edgeId?: string
+  message: string
+}
+
 export function transformGraph<
   OP extends Operator<IOperator>,
   E extends Edge<OP, OP>,
   T extends OpType,
->({ nodes: _nodes, edges: _edges }: { nodes: NodeJSON<unknown>[]; edges: E[] }): OP[] {
+>({
+  nodes: _nodes,
+  edges: _edges,
+}: {
+  nodes: NodeJSON<unknown>[]
+  edges: E[]
+}): {
+  operators: OP[]
+  errors: GraphLoadError[]
+} {
+  const errors: GraphLoadError[] = []
   const nodes = _nodes.filter(n => opTypes[n.type as T] !== undefined) as NodeJSON<OpType>[]
   // Reference edges for every node — mounted or not (see deriveReferenceEdges).
   const edges = [
@@ -184,10 +202,15 @@ export function transformGraph<
   const specialNodeTypes = new Set<string>(['group'] satisfies SpecialNodeType[])
   for (const node of _nodes) {
     if (opTypes[node.type as T] === undefined && !specialNodeTypes.has(node.type as string)) {
-      console.error(
-        `[noodles] Unknown operator type "${node.type}" for node "${(node as { id: string }).id}". ` +
-          'This node will be skipped. Is the operator registered in opTypes?'
-      )
+      const nodeId = (node as { id: string }).id
+      const errorMsg = `Unknown operator type "${node.type}" for node "${nodeId}". This node will be skipped.`
+      console.error(`[noodles] ${errorMsg}`)
+      errors.push({
+        type: 'unknown-operator',
+        nodeId,
+        nodeType: node.type as string,
+        message: `Node "${nodeId}" (type: ${node.type})`,
+      })
     }
   }
 
@@ -205,11 +228,17 @@ export function transformGraph<
       ]
         .filter(Boolean)
         .join(', ')
+      const errorMsg = `Edge "${edge.id}" references missing node(s): ${missing}`
       console.error(
-        `[noodles] Stale edge detected: edge "${edge.id}" references missing node(s): ${missing}. ` +
+        `[noodles] Stale edge detected: ${errorMsg}. ` +
           'This may be caused by a failed node rename. The graph will load, but affected connections will be missing.'
       )
       debugExecutor('Stale edge: %s (missing: %s)', edge.id, missing)
+      errors.push({
+        type: 'stale-edge',
+        edgeId: edge.id,
+        message: errorMsg,
+      })
     }
   }
 
@@ -464,5 +493,5 @@ export function transformGraph<
     }
   }
 
-  return instances
+  return { operators: instances, errors }
 }


### PR DESCRIPTION
#### Background

When loading a noodles.json project file with an unrecognized operator type (not registered in opTypes), the app would crash to a black screen. Errors were only logged to console, giving users no way to understand or recover from the failure.

#### Change List
- Add GraphErrorDialog component to display graph loading errors (unknown operators, broken connections, execution errors)
- Modify transformGraph() to return {operators, errors} instead of just operators array
- Update noodles.tsx to show error dialog when graph loading errors occur
- Support partial success: valid operators load and function while errors are displayed in dialog
- Update transform-graph tests to handle new return structure (43/45 passing)