### PR TITLE
Add property context menu enhancements for copy/paste references

### DIFF
--- a/noodles-editor/src/noodles/components/__tests__/expression-driven-field.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/expression-driven-field.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@xyflow/react', async () => {
       setNodes: vi.fn(),
       getNodes: vi.fn(() => []),
     }),
+    useNodeId: () => '/num',
   }
 })
 
@@ -47,12 +48,12 @@ describe('per-field expression mode UI', () => {
     clearOps()
   })
 
-  it('offers Add expression in the field context menu for drivable fields', () => {
+  it('offers Edit expression in the field context menu for drivable fields', () => {
     const op = new NumberOp('/num')
     setOp('/num', op)
     renderField(op)
     fireEvent.contextMenu(screen.getByText('val'))
-    expect(screen.getByText('Add expression')).toBeTruthy()
+    expect(screen.getByText('Edit expression')).toBeTruthy()
   })
 
   it('enters expression mode pre-filled with the current value', () => {
@@ -62,7 +63,7 @@ describe('per-field expression mode UI', () => {
     renderField(op)
 
     fireEvent.contextMenu(screen.getByText('val'))
-    fireEvent.click(screen.getByText('Add expression'))
+    fireEvent.click(screen.getByText('Edit expression'))
 
     expect(op.inputs.val.expression).toEqual('12')
     // The driven input shows the expression source
@@ -76,7 +77,7 @@ describe('per-field expression mode UI', () => {
     renderField(op)
 
     fireEvent.contextMenu(screen.getByText('val'))
-    fireEvent.click(screen.getByText('Add expression'))
+    fireEvent.click(screen.getByText('Edit expression'))
     const input = screen.getByPlaceholderText('Enter expression…')
     fireEvent.change(input, { target: { value: '2 + 3' } })
     fireEvent.blur(input)
@@ -92,7 +93,7 @@ describe('per-field expression mode UI', () => {
     renderField(op)
 
     fireEvent.contextMenu(screen.getByText('val'))
-    fireEvent.click(screen.getByText('Add expression'))
+    fireEvent.click(screen.getByText('Edit expression'))
     const input = screen.getByPlaceholderText('Enter expression…')
     fireEvent.change(input, { target: { value: '2 +' } })
     fireEvent.blur(input)
@@ -106,7 +107,7 @@ describe('per-field expression mode UI', () => {
     renderField(op)
 
     fireEvent.contextMenu(screen.getByText('val'))
-    fireEvent.click(screen.getByText('Add expression'))
+    fireEvent.click(screen.getByText('Edit expression'))
     const input = screen.getByPlaceholderText('Enter expression…')
     fireEvent.change(input, { target: { value: "op('/missing').out.val" } })
     fireEvent.blur(input)
@@ -121,7 +122,7 @@ describe('per-field expression mode UI', () => {
     renderField(op)
 
     fireEvent.contextMenu(screen.getByText('val'))
-    fireEvent.click(screen.getByText('Add expression'))
+    fireEvent.click(screen.getByText('Edit expression'))
     const input = screen.getByPlaceholderText('Enter expression…')
     fireEvent.change(input, { target: { value: '40 + 2' } })
     fireEvent.blur(input)
@@ -142,7 +143,7 @@ describe('per-field expression mode UI', () => {
     renderField(op)
 
     fireEvent.contextMenu(screen.getByText('val'))
-    fireEvent.click(screen.getByText('Add expression'))
+    fireEvent.click(screen.getByText('Edit expression'))
     const input = screen.getByPlaceholderText('Enter expression…')
     fireEvent.change(input, { target: { value: 'await Promise.resolve(5)' } })
     fireEvent.blur(input)
@@ -164,7 +165,7 @@ describe('per-field expression mode UI', () => {
     renderField(op)
 
     fireEvent.contextMenu(screen.getByText('val'))
-    fireEvent.click(screen.getByText('Add expression'))
+    fireEvent.click(screen.getByText('Edit expression'))
     const input = screen.getByPlaceholderText('Enter expression…')
     fireEvent.change(input, { target: { value: "op('/source').out.val + 1" } })
     fireEvent.blur(input)
@@ -193,6 +194,6 @@ describe('per-field expression mode UI', () => {
       </ReactFlowProvider>
     )
     fireEvent.contextMenu(screen.getByText('expression'))
-    expect(screen.queryByText('Add expression')).toBeNull()
+    expect(screen.queryByText('Edit expression')).toBeNull()
   })
 })

--- a/noodles-editor/src/noodles/components/__tests__/node-properties-context-menu.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/node-properties-context-menu.test.tsx
@@ -117,7 +117,7 @@ describe('Context menu copy actions', () => {
     expect(mockClipboard.writeText).toHaveBeenCalledWith('0.5')
   })
 
-  it('clicking "Copy field name" writes field name to clipboard', () => {
+  it('clicking "Copy reference" writes absolute code ref to clipboard', () => {
     transformGraph({
       nodes: [
         {
@@ -131,47 +131,10 @@ describe('Context menu copy actions', () => {
     })
     renderNodeProperties('/geo')
     openContextMenuOnField('opacity')
-    fireEvent.click(screen.getByText('Copy field name'))
 
-    expect(mockClipboard.writeText).toHaveBeenCalledWith('opacity')
-  })
-
-  it('clicking "Copy code reference" writes code ref to clipboard', () => {
-    transformGraph({
-      nodes: [
-        {
-          id: '/geo',
-          type: 'GeoJsonLayerOp',
-          position: { x: 0, y: 0 },
-          data: { inputs: { opacity: 0.5 } },
-        },
-      ],
-      edges: [],
-    })
-    renderNodeProperties('/geo')
-    openContextMenuOnField('opacity')
-    fireEvent.click(screen.getByText('Copy code reference'))
+    fireEvent.click(screen.getByText('Copy reference'))
 
     expect(mockClipboard.writeText).toHaveBeenCalledWith("op('/geo').par.opacity")
-  })
-
-  it('clicking "Copy mustache reference" writes mustache ref to clipboard', () => {
-    transformGraph({
-      nodes: [
-        {
-          id: '/geo',
-          type: 'GeoJsonLayerOp',
-          position: { x: 0, y: 0 },
-          data: { inputs: { opacity: 0.5 } },
-        },
-      ],
-      edges: [],
-    })
-    renderNodeProperties('/geo')
-    openContextMenuOnField('opacity')
-    fireEvent.click(screen.getByText('Copy mustache reference'))
-
-    expect(mockClipboard.writeText).toHaveBeenCalledWith('{{/geo.par.opacity}}')
   })
 })
 
@@ -363,9 +326,7 @@ describe('Context menu on output fields', () => {
 
     // Copy actions should still be present
     expect(screen.getByText('Copy value')).toBeInTheDocument()
-    expect(screen.getByText('Copy field name')).toBeInTheDocument()
-    expect(screen.getByText('Copy code reference')).toBeInTheDocument()
-    expect(screen.getByText('Copy mustache reference')).toBeInTheDocument()
+    expect(screen.getByText('Copy reference')).toBeInTheDocument()
   })
 })
 
@@ -445,7 +406,7 @@ describe('Context menu expression actions', () => {
     clearOps()
   })
 
-  it('shows "Add expression" for drivable fields and enters expression mode', () => {
+  it('shows "Edit expression" for drivable fields and enters expression mode', () => {
     transformGraph({
       nodes: [{ id: '/num', type: 'NumberOp', position: { x: 0, y: 0 }, data: {} }],
       edges: [],
@@ -455,7 +416,7 @@ describe('Context menu expression actions', () => {
     const label = screen.getAllByText('val', { selector: 'span' })[0]
     fireEvent.contextMenu(label.closest('[role="listitem"]')!)
 
-    const item = screen.getByText('Add expression')
+    const item = screen.getByText('Edit expression')
     expect(item).not.toBeDisabled()
     fireEvent.click(item)
 
@@ -503,6 +464,6 @@ describe('Context menu expression actions', () => {
     const label = screen.getAllByText('val', { selector: 'span' })[0]
     fireEvent.contextMenu(label.closest('[role="listitem"]')!)
 
-    expect(screen.getByText('Add expression')).toBeDisabled()
+    expect(screen.getByText('Edit expression')).toBeDisabled()
   })
 })

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -2852,7 +2852,7 @@ const EXPRESSION_EXCLUDED_TYPES = new Set([
 ])
 
 // Returns true for scalar/value field types that can show an editable input
-function isValueField(field: Field): boolean {
+export function isValueField(field: Field): boolean {
   const { type } = field.constructor as typeof Field
   return [
     'number',

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -61,15 +61,21 @@ import type { Edge } from '../noodles'
 import s from '../noodles.module.css'
 import { getFriendlyErrorMessage, type IOperator, type Operator } from '../operators'
 import { checkAssetExists, getAssetFileHandle, writeAsset } from '../storage'
-import { useEdgeConnectionStore } from '../store'
+import { getOp, useEdgeConnectionStore } from '../store'
 import { type ExpressionContext, getExpressionContext } from '../utils/expression-context'
 import { projectScheme } from '../utils/filesystem'
 import { edgeId, type OpId } from '../utils/id-utils'
+import { computeRelativePath } from '../utils/path-utils'
 import {
   captureOperatorInputs,
   firePropertyMutation,
   usePropertyHistory,
 } from '../utils/property-history'
+import {
+  formatReference,
+  parseReference,
+  type ReferenceFormat,
+} from '../utils/reference-utils'
 import { ColorSwatch } from './color-swatch'
 import { ExpressionEditorOverlay } from './ExpressionEditorOverlay'
 import { GeocodingDialog } from './geocoding-dialog'
@@ -2845,6 +2851,23 @@ const EXPRESSION_EXCLUDED_TYPES = new Set([
   'visualization',
 ])
 
+// Returns true for scalar/value field types that can show an editable input
+function isValueField(field: Field): boolean {
+  const { type } = field.constructor as typeof Field
+  return [
+    'number',
+    'boolean',
+    'color',
+    'string',
+    'string-literal',
+    'date',
+    'vec2',
+    'vec3',
+    'geopoint-2d',
+    'geopoint-3d',
+  ].includes(type)
+}
+
 // Whether a field's type supports expression mode (connection state is checked separately)
 export function canFieldBeDriven(field: Field): boolean {
   const { type } = field.constructor as typeof Field
@@ -2876,18 +2899,116 @@ export function toggleFieldExpression(field: Field): void {
   }
 }
 
-// Right-click context menu for a field row. Currently holds the expression-mode toggle;
-// a natural home for more per-field actions later.
+// Determine the preferred reference format for a field type
+function getPreferredReferenceFormat(field: Field): ReferenceFormat {
+  // SQL code fields use mustache syntax
+  if (field instanceof CodeField && field.language === 'sql') {
+    return 'mustache'
+  }
+  // JavaScript code and expression fields use code syntax
+  if (field instanceof CodeField || field instanceof ExpressionField) {
+    return 'code'
+  }
+  // Default to code format for other fields
+  return 'code'
+}
+
+async function pasteReference(
+  field: Field,
+  operatorId: string,
+  useRelativePath: boolean
+): Promise<boolean> {
+  try {
+    const text = await navigator.clipboard.readText()
+    const parsed = parseReference(text)
+    if (!parsed) {
+      return false
+    }
+
+    // Validate reference points to valid field
+    const { opPath, namespace, fieldName } = parsed
+    const targetOp = getOp(opPath, operatorId)
+    if (!targetOp) {
+      console.warn(`Paste reference: operator not found: ${opPath}`)
+      return false
+    }
+
+    const targetField =
+      namespace === 'par' ? targetOp.inputs[fieldName] : targetOp.outputs[fieldName]
+    if (!targetField) {
+      console.warn(`Paste reference: field not found: ${fieldName}`)
+      return false
+    }
+
+    // Convert to relative path if requested
+    let finalPath = opPath
+    if (useRelativePath) {
+      finalPath = computeRelativePath(targetOp.id, operatorId)
+    }
+
+    // Determine format based on field type
+    const preferredFormat = getPreferredReferenceFormat(field)
+    const ref = { opPath: finalPath, namespace, fieldName }
+    const formattedRef = formatReference(ref, preferredFormat)
+
+    // Set expression on field
+    const before = captureOperatorInputs()
+    field.setExpression(formattedRef.trim())
+    firePropertyMutation('Paste reference', before)
+
+    return true
+  } catch (err) {
+    console.error('Failed to paste reference:', err)
+    return false
+  }
+}
+
+// Right-click context menu for a field row.
 export function FieldContextMenu({
   field,
+  operatorId,
+  fieldName,
+  namespace,
   position,
   onClose,
 }: {
   field: Field
+  operatorId: string
+  fieldName: string
+  namespace: 'par' | 'out'
   position: { x: number; y: number }
   onClose: () => void
 }) {
   const isDriven = field.expression !== null
+
+  // Generate absolute code reference
+  const absoluteCodeRef = `op('${operatorId}').${namespace}.${fieldName}`
+
+  // Lazy field value serialization - only compute when copying
+  const canCopyValue = isValueField(field)
+  const getFieldValue = useCallback((): string | undefined => {
+    if (!isValueField(field)) return undefined
+    try {
+      const v = field.value
+      return typeof v === 'string' ? v : JSON.stringify(v)
+    } catch {
+      return undefined
+    }
+  }, [field])
+
+  // Check clipboard for valid reference
+  const [clipboardHasReference, setClipboardHasReference] = useState(false)
+  useEffect(() => {
+    navigator.clipboard
+      .readText()
+      .then(text => {
+        const parsed = parseReference(text)
+        setClipboardHasReference(parsed !== null)
+      })
+      .catch(() => {
+        setClipboardHasReference(false)
+      })
+  }, [])
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -2910,12 +3031,65 @@ export function FieldContextMenu({
       <button
         type="button"
         className={contextMenuStyles.contextMenuItem}
+        disabled={!canCopyValue}
+        onClick={() => {
+          const fieldValue = getFieldValue()
+          if (fieldValue === undefined) return
+          navigator.clipboard.writeText(fieldValue)
+          onClose()
+        }}
+      >
+        Copy value
+      </button>
+      <div className={contextMenuStyles.contextMenuSeparator} />
+      <button
+        type="button"
+        className={contextMenuStyles.contextMenuItem}
+        onClick={() => {
+          navigator.clipboard.writeText(absoluteCodeRef)
+          onClose()
+        }}
+      >
+        Copy reference
+      </button>
+      {clipboardHasReference && (
+        <>
+          <button
+            type="button"
+            className={contextMenuStyles.contextMenuItem}
+            onClick={async () => {
+              const success = await pasteReference(field, operatorId, false)
+              if (success) {
+                onClose()
+              }
+            }}
+          >
+            Paste as absolute reference
+          </button>
+          <button
+            type="button"
+            className={contextMenuStyles.contextMenuItem}
+            onClick={async () => {
+              const success = await pasteReference(field, operatorId, true)
+              if (success) {
+                onClose()
+              }
+            }}
+          >
+            Paste as relative reference
+          </button>
+        </>
+      )}
+      <div className={contextMenuStyles.contextMenuSeparator} />
+      <button
+        type="button"
+        className={contextMenuStyles.contextMenuItem}
         onClick={() => {
           toggleFieldExpression(field)
           onClose()
         }}
       >
-        {isDriven ? 'Remove expression' : 'Add expression'}
+        {isDriven ? 'Remove expression' : 'Edit expression'}
       </button>
     </div>,
     document.body
@@ -3017,9 +3191,12 @@ export function FieldComponent({
         ) : (
           <InputComp id={fieldId} field={field} disabled={disabled} />
         ))}
-      {contextMenuPos && (
+      {contextMenuPos && nid && (
         <FieldContextMenu
           field={field}
+          operatorId={nid}
+          fieldName={fieldId}
+          namespace={handle?.namespace ?? 'par'}
           position={contextMenuPos}
           onClose={() => setContextMenuPos(null)}
         />

--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -15,7 +15,9 @@ import {
 } from '../../timeline/timeline-store'
 import type { KeyframeValue } from '../../timeline/types'
 import {
+  CodeField,
   CompoundPropsField,
+  ExpressionField,
   type Field,
   type IField,
   IN_NS,
@@ -26,7 +28,7 @@ import {
 import { useObservable } from '../hooks/use-observable'
 import type { IOperator, OpType, Operator } from '../operators'
 import { OutOp } from '../operators'
-import { getOpStore, useNestingStore, useUIStore } from '../store'
+import { getOp, getOpStore, useNestingStore, useUIStore } from '../store'
 import type { ConnectionPlan } from '../utils/auto-connect'
 import { edgeId } from '../utils/id-utils'
 import {
@@ -35,7 +37,13 @@ import {
   orderedEdgeIdsForHandle,
 } from '../utils/multi-input-utils'
 import { type NodeType, createNodesForType } from '../utils/node-creation-utils'
-import { getBaseName, parseHandleId } from '../utils/path-utils'
+import { computeRelativePath, getBaseName, parseHandleId } from '../utils/path-utils'
+import { captureOperatorInputs, firePropertyMutation } from '../utils/property-history'
+import {
+  formatReference,
+  parseReference,
+  type ReferenceFormat,
+} from '../utils/reference-utils'
 import { ErrorBoundary } from './error-boundary'
 import {
   BooleanFieldComponent,
@@ -180,6 +188,69 @@ function resetToDefaults(op: Operator<IOperator>, edges: Edge[]) {
 
 function copy(text: string) {
   navigator.clipboard.writeText(text)
+}
+
+// Determine the preferred reference format for a field type
+function getPreferredReferenceFormat(field: Field): ReferenceFormat {
+  // SQL code fields use mustache syntax
+  if (field instanceof CodeField && field.language === 'sql') {
+    return 'mustache'
+  }
+  // JavaScript code and expression fields use code syntax
+  if (field instanceof CodeField || field instanceof ExpressionField) {
+    return 'code'
+  }
+  // Default to code format for other fields
+  return 'code'
+}
+
+async function pasteReference(
+  field: Field,
+  operatorId: string,
+  useRelativePath: boolean
+): Promise<boolean> {
+  try {
+    const text = await navigator.clipboard.readText()
+    const parsed = parseReference(text)
+    if (!parsed) {
+      return false
+    }
+
+    // Validate reference points to valid field
+    const { opPath, namespace, fieldName } = parsed
+    const targetOp = getOp(opPath, operatorId)
+    if (!targetOp) {
+      console.warn(`Paste reference: operator not found: ${opPath}`)
+      return false
+    }
+
+    const targetField = namespace === 'par' ? targetOp.inputs[fieldName] : targetOp.outputs[fieldName]
+    if (!targetField) {
+      console.warn(`Paste reference: field not found: ${fieldName}`)
+      return false
+    }
+
+    // Convert to relative path if requested
+    let finalPath = opPath
+    if (useRelativePath) {
+      finalPath = computeRelativePath(targetOp.id, operatorId)
+    }
+
+    // Determine format based on field type
+    const preferredFormat = getPreferredReferenceFormat(field)
+    const ref = { opPath: finalPath, namespace, fieldName }
+    const formattedRef = formatReference(ref, preferredFormat)
+
+    // Set expression on field
+    const before = captureOperatorInputs()
+    field.setExpression(formattedRef.trim())
+    firePropertyMutation('Paste reference', before)
+
+    return true
+  } catch (err) {
+    console.error('Failed to paste reference:', err)
+    return false
+  }
 }
 
 function Tooltip({
@@ -421,7 +492,6 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
     x: number
     y: number
     codeRef: string
-    mustacheRef: string
     fieldName: string
     fieldValue?: string
     fieldPath?: string
@@ -431,6 +501,7 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
     isVisible?: boolean // whether the field is currently shown
     hasConnection?: boolean // whether the field has an incoming edge
     expressionField?: Field // field instance when expression mode can be toggled
+    clipboardReference?: string // parsed reference from clipboard if valid
   } | null>(null)
   const descriptionRef = useRef<HTMLDivElement>(null)
   const draggingRef = useRef<HTMLElement | null>(null)
@@ -571,10 +642,25 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
         /* ignore */
       }
     }
+    // Check clipboard for valid reference async
+    navigator.clipboard
+      .readText()
+      .then(text => {
+        const parsed = parseReference(text)
+        if (parsed) {
+          // Update context menu with clipboard reference
+          setContextMenu(prev =>
+            prev ? { ...prev, clipboardReference: text } : prev
+          )
+        }
+      })
+      .catch(() => {
+        // Clipboard read failed, ignore
+      })
+
     setContextMenu({
       ...position,
       codeRef: input.codeRef,
-      mustacheRef: input.mustacheRef,
       fieldName: input.name,
       fieldValue,
       fieldPath: isAnimatable ? getFieldPath(op.id, input.name) : undefined,
@@ -1073,32 +1159,42 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
               type="button"
               className={s.contextMenuItem}
               onClick={() => {
-                copy(contextMenu.fieldName)
-                setContextMenu(null)
-              }}
-            >
-              Copy field name
-            </button>
-            <button
-              type="button"
-              className={s.contextMenuItem}
-              onClick={() => {
                 copy(contextMenu.codeRef)
                 setContextMenu(null)
               }}
             >
-              Copy code reference
+              Copy reference
             </button>
-            <button
-              type="button"
-              className={s.contextMenuItem}
-              onClick={() => {
-                copy(contextMenu.mustacheRef)
-                setContextMenu(null)
-              }}
-            >
-              Copy mustache reference
-            </button>
+            {contextMenu.clipboardReference && contextMenu.expressionField && (
+              <>
+                <button
+                  type="button"
+                  className={s.contextMenuItem}
+                  onClick={async () => {
+                    if (!contextMenu.expressionField) return
+                    const success = await pasteReference(contextMenu.expressionField, nodeId, false)
+                    if (success) {
+                      setContextMenu(null)
+                    }
+                  }}
+                >
+                  Paste as absolute reference
+                </button>
+                <button
+                  type="button"
+                  className={s.contextMenuItem}
+                  onClick={async () => {
+                    if (!contextMenu.expressionField) return
+                    const success = await pasteReference(contextMenu.expressionField, nodeId, true)
+                    if (success) {
+                      setContextMenu(null)
+                    }
+                  }}
+                >
+                  Paste as relative reference
+                </button>
+              </>
+            )}
             {contextMenu.isVisible !== undefined && (
               <>
                 <div className={s.contextMenuSeparator} />
@@ -1172,7 +1268,7 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
                 >
                   {contextMenu.expressionField?.expression != null
                     ? 'Remove expression'
-                    : 'Add expression'}
+                    : 'Edit expression'}
                 </button>
                 <button
                   type="button"

--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -51,6 +51,7 @@ import {
   canFieldBeDriven,
   DateFieldComponent,
   ExpressionDrivenInput,
+  isValueField,
   NumberFieldComponent,
   TextFieldComponent,
   toggleFieldExpression,
@@ -394,23 +395,6 @@ function EditableFieldInput({
         </div>
       )
   }
-}
-
-// Returns true for scalar/value field types that can show an editable input
-function isValueField(field: Field): boolean {
-  const { type } = field.constructor as typeof Field
-  return [
-    'number',
-    'boolean',
-    'color',
-    'string',
-    'string-literal',
-    'date',
-    'vec2',
-    'vec3',
-    'geopoint-2d',
-    'geopoint-3d',
-  ].includes(type)
 }
 
 // Renders compound field sub-fields inline with labels, inputs, and keyframe indicators

--- a/noodles-editor/src/noodles/utils/path-utils.test.ts
+++ b/noodles-editor/src/noodles/utils/path-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  computeRelativePath,
   generateQualifiedPath,
   getBaseName,
   getParentPath,
@@ -230,6 +231,101 @@ describe('parseHandleId', () => {
     expect(parseHandleId('invalid')).toBeUndefined()
     expect(parseHandleId('operator.invalid.field')).toBeUndefined() // Invalid namespace
     expect(parseHandleId('random.text')).toBeUndefined() // Not valid format
+  })
+})
+
+describe('computeRelativePath', () => {
+  describe('same container', () => {
+    it('returns ./ prefixed path for siblings', () => {
+      expect(computeRelativePath('/container/target', '/container/source')).toBe('./target')
+      expect(computeRelativePath('/container/operator-a', '/container/operator-b')).toBe(
+        './operator-a'
+      )
+    })
+
+    it('handles nested targets in same container', () => {
+      expect(computeRelativePath('/container/sub/target', '/container/source')).toBe('./sub/target')
+    })
+  })
+
+  describe('parent/ancestor references', () => {
+    it('returns ../ for parent container', () => {
+      expect(computeRelativePath('/target', '/container/source')).toBe('../target')
+    })
+
+    it('returns multiple ../ for grandparent', () => {
+      expect(computeRelativePath('/target', '/container/sub/source')).toBe('../../target')
+    })
+
+    it('navigates to different branch through common ancestor', () => {
+      expect(computeRelativePath('/container/sub/target', '/other/source')).toBe(
+        '../container/sub/target'
+      )
+      expect(computeRelativePath('/analysis/output', '/preprocessing/input')).toBe(
+        '../analysis/output'
+      )
+    })
+  })
+
+  describe('root level operators', () => {
+    it('handles both at root level', () => {
+      expect(computeRelativePath('/target', '/source')).toBe('./target')
+    })
+
+    it('handles target at root, context nested', () => {
+      expect(computeRelativePath('/target', '/container/operator')).toBe('../target')
+    })
+
+    it('handles context at root, target nested', () => {
+      expect(computeRelativePath('/container/target', '/source')).toBe('./container/target')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns . for same path', () => {
+      expect(computeRelativePath('/operator', '/operator')).toBe('.')
+      expect(computeRelativePath('/container/operator', '/container/operator')).toBe('.')
+    })
+
+    it('handles empty paths', () => {
+      expect(computeRelativePath('', '/context')).toBe('')
+      expect(computeRelativePath('/target', '')).toBe('/target')
+    })
+
+    it('handles complex nested scenarios', () => {
+      const context = '/analysis/preprocessing/filter'
+      expect(computeRelativePath('/analysis/preprocessing/transform', context)).toBe('./transform')
+      expect(computeRelativePath('/analysis/postprocessing/aggregate', context)).toBe(
+        '../postprocessing/aggregate'
+      )
+      expect(computeRelativePath('/visualization/chart', context)).toBe('../../visualization/chart')
+    })
+  })
+
+  describe('inverse of resolvePath', () => {
+    it('computes relative path that resolves back to target', () => {
+      const target = '/container/target'
+      const context = '/other/source'
+      const relative = computeRelativePath(target, context)
+      const resolved = resolvePath(relative, context)
+      expect(resolved).toBe(target)
+    })
+
+    it('works for same container', () => {
+      const target = '/container/target'
+      const context = '/container/source'
+      const relative = computeRelativePath(target, context)
+      const resolved = resolvePath(relative, context)
+      expect(resolved).toBe(target)
+    })
+
+    it('works for nested paths', () => {
+      const target = '/analysis/preprocessing/filter'
+      const context = '/visualization/output/chart'
+      const relative = computeRelativePath(target, context)
+      const resolved = resolvePath(relative, context)
+      expect(resolved).toBe(target)
+    })
   })
 })
 

--- a/noodles-editor/src/noodles/utils/path-utils.ts
+++ b/noodles-editor/src/noodles/utils/path-utils.ts
@@ -2,7 +2,7 @@
 // Supports Unix-style absolute and relative path resolution
 import path from 'node:path'
 
-const { basename, dirname, isAbsolute, join, normalize, resolve } = path.posix
+const { basename, dirname, isAbsolute, join, normalize, relative, resolve } = path.posix
 
 export function isAbsolutePath(pathStr: string): boolean {
   if (!pathStr) return false
@@ -229,34 +229,9 @@ export function computeRelativePath(targetPath: string, contextPath: string): st
     return targetPath
   }
 
-  // Split paths into segments
-  const targetSegments = targetPath.split('/').filter(s => s !== '')
-  const containerSegments =
-    contextContainer === '/' ? [] : contextContainer.split('/').filter(s => s !== '')
+  // Use Node's path.relative for the heavy lifting
+  const relativePath = relative(contextContainer, targetPath) || '.'
 
-  // Find common ancestor by comparing segments
-  let commonLength = 0
-  const minLength = Math.min(targetSegments.length, containerSegments.length)
-  for (let i = 0; i < minLength; i++) {
-    if (targetSegments[i] === containerSegments[i]) {
-      commonLength++
-    } else {
-      break
-    }
-  }
-
-  // Calculate how many levels up from context container to common ancestor
-  const levelsUp = containerSegments.length - commonLength
-
-  // Build relative path
-  if (levelsUp === 0) {
-    // Same container - use ./ prefix
-    const remainingSegments = targetSegments.slice(commonLength)
-    return `./${remainingSegments.join('/')}`
-  }
-
-  // Go up levels and append remaining target segments
-  const upSegments = Array(levelsUp).fill('..')
-  const remainingSegments = targetSegments.slice(commonLength)
-  return [...upSegments, ...remainingSegments].join('/')
+  // Add './' prefix for same-container paths (paths that don't start with '..')
+  return relativePath.startsWith('..') ? relativePath : `./${relativePath}`
 }

--- a/noodles-editor/src/noodles/utils/path-utils.ts
+++ b/noodles-editor/src/noodles/utils/path-utils.ts
@@ -204,3 +204,59 @@ export function isWithinContainer(operatorId: string, containerOperatorId: strin
   // The operator is within the container if its path starts with the container's path followed by '/'
   return operatorId.startsWith(`${containerOperatorId}/`)
 }
+
+// Compute a relative path from contextPath to targetPath
+// The relative path is computed from the context operator's CONTAINER (parent directory)
+// This matches how operator references work: op('./sibling') means "in my parent container"
+// Examples:
+//   computeRelativePath('/container/target', '/container/source') → './target'
+//   computeRelativePath('/container/sub/target', '/other/source') → '../../container/sub/target'
+//   computeRelativePath('/target', '/container/source') → '../../target'
+export function computeRelativePath(targetPath: string, contextPath: string): string {
+  if (!targetPath || !contextPath) {
+    return targetPath
+  }
+
+  // Same path returns '.'
+  if (targetPath === contextPath) {
+    return '.'
+  }
+
+  // Get the container of the context operator (its parent path)
+  // Relative paths are resolved from the operator's container, not the operator itself
+  const contextContainer = getParentPath(contextPath)
+  if (!contextContainer) {
+    return targetPath
+  }
+
+  // Split paths into segments
+  const targetSegments = targetPath.split('/').filter(s => s !== '')
+  const containerSegments =
+    contextContainer === '/' ? [] : contextContainer.split('/').filter(s => s !== '')
+
+  // Find common ancestor by comparing segments
+  let commonLength = 0
+  const minLength = Math.min(targetSegments.length, containerSegments.length)
+  for (let i = 0; i < minLength; i++) {
+    if (targetSegments[i] === containerSegments[i]) {
+      commonLength++
+    } else {
+      break
+    }
+  }
+
+  // Calculate how many levels up from context container to common ancestor
+  const levelsUp = containerSegments.length - commonLength
+
+  // Build relative path
+  if (levelsUp === 0) {
+    // Same container - use ./ prefix
+    const remainingSegments = targetSegments.slice(commonLength)
+    return `./${remainingSegments.join('/')}`
+  }
+
+  // Go up levels and append remaining target segments
+  const upSegments = Array(levelsUp).fill('..')
+  const remainingSegments = targetSegments.slice(commonLength)
+  return [...upSegments, ...remainingSegments].join('/')
+}

--- a/noodles-editor/src/noodles/utils/reference-utils.test.ts
+++ b/noodles-editor/src/noodles/utils/reference-utils.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+import {
+  convertReferenceFormat,
+  formatReference,
+  parseReference,
+  type ParsedReference,
+} from './reference-utils'
+
+describe('parseReference', () => {
+  describe('code format', () => {
+    it('parses absolute code reference', () => {
+      const result = parseReference("op('/operator').par.field")
+      expect(result).toEqual({
+        opPath: '/operator',
+        namespace: 'par',
+        fieldName: 'field',
+      })
+    })
+
+    it('parses relative code reference', () => {
+      const result = parseReference("op('./sibling').par.field")
+      expect(result).toEqual({
+        opPath: './sibling',
+        namespace: 'par',
+        fieldName: 'field',
+      })
+    })
+
+    it('parses code reference with double quotes', () => {
+      const result = parseReference('op("/container/operator").out.result')
+      expect(result).toEqual({
+        opPath: '/container/operator',
+        namespace: 'out',
+        fieldName: 'result',
+      })
+    })
+
+    it('parses code reference with nested path', () => {
+      const result = parseReference("op('/container/sub/operator').par.data")
+      expect(result).toEqual({
+        opPath: '/container/sub/operator',
+        namespace: 'par',
+        fieldName: 'data',
+      })
+    })
+  })
+
+  describe('mustache format', () => {
+    it('parses absolute mustache reference', () => {
+      const result = parseReference('{{/operator.par.field}}')
+      expect(result).toEqual({
+        opPath: '/operator',
+        namespace: 'par',
+        fieldName: 'field',
+      })
+    })
+
+    it('parses relative mustache reference', () => {
+      const result = parseReference('{{./sibling.par.field}}')
+      expect(result).toEqual({
+        opPath: './sibling',
+        namespace: 'par',
+        fieldName: 'field',
+      })
+    })
+
+    it('parses mustache reference with nested path', () => {
+      const result = parseReference('{{/container/sub/operator.out.result}}')
+      expect(result).toEqual({
+        opPath: '/container/sub/operator',
+        namespace: 'out',
+        fieldName: 'result',
+      })
+    })
+  })
+
+  describe('invalid input', () => {
+    it('returns null for invalid format', () => {
+      expect(parseReference('invalid')).toBeNull()
+      expect(parseReference('op(path).par.field')).toBeNull() // missing quotes
+      expect(parseReference('{{path.par.field')).toBeNull() // missing closing brace
+      expect(parseReference('op("/path")')).toBeNull() // missing field access
+    })
+
+    it('returns null for empty string', () => {
+      expect(parseReference('')).toBeNull()
+    })
+  })
+})
+
+describe('formatReference', () => {
+  const ref: ParsedReference = {
+    opPath: '/container/operator',
+    namespace: 'par',
+    fieldName: 'data',
+  }
+
+  it('formats as code', () => {
+    const result = formatReference(ref, 'code')
+    expect(result).toBe("op('/container/operator').par.data")
+  })
+
+  it('formats as mustache', () => {
+    const result = formatReference(ref, 'mustache')
+    expect(result).toBe('{{/container/operator.par.data}}')
+  })
+
+  it('formats relative path as code', () => {
+    const relativeRef: ParsedReference = {
+      opPath: '../sibling',
+      namespace: 'out',
+      fieldName: 'result',
+    }
+    const result = formatReference(relativeRef, 'code')
+    expect(result).toBe("op('../sibling').out.result")
+  })
+
+  it('formats relative path as mustache', () => {
+    const relativeRef: ParsedReference = {
+      opPath: './sibling',
+      namespace: 'par',
+      fieldName: 'value',
+    }
+    const result = formatReference(relativeRef, 'mustache')
+    expect(result).toBe('{{./sibling.par.value}}')
+  })
+})
+
+describe('convertReferenceFormat', () => {
+  it('converts code to mustache', () => {
+    const result = convertReferenceFormat("op('/operator').par.field", 'mustache')
+    expect(result).toBe('{{/operator.par.field}}')
+  })
+
+  it('converts mustache to code', () => {
+    const result = convertReferenceFormat('{{/operator.par.field}}', 'code')
+    expect(result).toBe("op('/operator').par.field")
+  })
+
+  it('converts code to code (no-op)', () => {
+    const input = "op('/operator').par.field"
+    const result = convertReferenceFormat(input, 'code')
+    expect(result).toBe("op('/operator').par.field")
+  })
+
+  it('converts mustache to mustache (no-op)', () => {
+    const input = '{{/operator.par.field}}'
+    const result = convertReferenceFormat(input, 'mustache')
+    expect(result).toBe('{{/operator.par.field}}')
+  })
+
+  it('preserves relative paths in conversion', () => {
+    const codeResult = convertReferenceFormat("op('./sibling').par.field", 'mustache')
+    expect(codeResult).toBe('{{./sibling.par.field}}')
+
+    const mustacheResult = convertReferenceFormat('{{../parent.out.result}}', 'code')
+    expect(mustacheResult).toBe("op('../parent').out.result")
+  })
+
+  it('returns null for invalid input', () => {
+    expect(convertReferenceFormat('invalid', 'code')).toBeNull()
+    expect(convertReferenceFormat('', 'mustache')).toBeNull()
+  })
+})
+
+describe('round-trip conversions', () => {
+  it('maintains reference through code → mustache → code', () => {
+    const original = "op('/container/operator').par.field"
+    const mustache = convertReferenceFormat(original, 'mustache')
+    const backToCode = convertReferenceFormat(mustache!, 'code')
+    expect(backToCode).toBe(original)
+  })
+
+  it('maintains reference through mustache → code → mustache', () => {
+    const original = '{{/container/operator.out.result}}'
+    const code = convertReferenceFormat(original, 'code')
+    const backToMustache = convertReferenceFormat(code!, 'mustache')
+    expect(backToMustache).toBe(original)
+  })
+
+  it('maintains relative paths through conversions', () => {
+    const original = "op('../sibling').par.value"
+    const mustache = convertReferenceFormat(original, 'mustache')
+    expect(mustache).toBe('{{../sibling.par.value}}')
+    const backToCode = convertReferenceFormat(mustache!, 'code')
+    expect(backToCode).toBe(original)
+  })
+})

--- a/noodles-editor/src/noodles/utils/reference-utils.ts
+++ b/noodles-editor/src/noodles/utils/reference-utils.ts
@@ -1,4 +1,7 @@
 // Utilities for parsing and formatting operator field references
+// Reuses existing regex patterns from fields.ts to avoid duplication
+
+import { fnRe, mustacheRe } from '../fields'
 
 export type ParsedReference = {
   opPath: string
@@ -12,19 +15,29 @@ export type ReferenceFormat = 'code' | 'mustache'
 // Supports both code format: op('path').par.field
 // and mustache format: {{path.par.field}}
 export function parseReference(text: string): ParsedReference | null {
-  // Parse op('path').par.field format
-  const fnMatch = text.match(/op\(['"]([^'"]+)['"]\)\.(par|out)\.(\w+)/)
-  if (fnMatch) {
-    return { opPath: fnMatch[1], namespace: fnMatch[2] as 'par' | 'out', fieldName: fnMatch[3] }
+  // Reset regex state
+  fnRe.lastIndex = 0
+  mustacheRe.lastIndex = 0
+
+  // Try function-style first: op('path').par.field
+  const fnMatch = fnRe.exec(text)
+  if (fnMatch?.groups) {
+    const fieldPath = fnMatch.groups.fieldPath?.split('.')[0]
+    return {
+      opPath: fnMatch.groups.opId,
+      namespace: fnMatch.groups.inOut as 'par' | 'out',
+      fieldName: fieldPath || '',
+    }
   }
 
-  // Parse {{path.par.field}} format
-  const mustacheMatch = text.match(/\{\{([^}]+)\.(par|out)\.(\w+)\}\}/)
-  if (mustacheMatch) {
+  // Try mustache-style: {{path.par.field}}
+  const mustacheMatch = mustacheRe.exec(text)
+  if (mustacheMatch?.groups) {
+    const fieldPath = mustacheMatch.groups.fieldPath?.split('.')[0]
     return {
-      opPath: mustacheMatch[1],
-      namespace: mustacheMatch[2] as 'par' | 'out',
-      fieldName: mustacheMatch[3],
+      opPath: mustacheMatch.groups.opId,
+      namespace: mustacheMatch.groups.inOut as 'par' | 'out',
+      fieldName: fieldPath || '',
     }
   }
 
@@ -32,10 +45,7 @@ export function parseReference(text: string): ParsedReference | null {
 }
 
 // Format a parsed reference in the specified format
-export function formatReference(
-  ref: ParsedReference,
-  format: ReferenceFormat
-): string {
+export function formatReference(ref: ParsedReference, format: ReferenceFormat): string {
   const { opPath, namespace, fieldName } = ref
   if (format === 'mustache') {
     return `{{${opPath}.${namespace}.${fieldName}}}`
@@ -44,10 +54,7 @@ export function formatReference(
 }
 
 // Convert a reference string from one format to another
-export function convertReferenceFormat(
-  text: string,
-  targetFormat: ReferenceFormat
-): string | null {
+export function convertReferenceFormat(text: string, targetFormat: ReferenceFormat): string | null {
   const parsed = parseReference(text)
   if (!parsed) return null
   return formatReference(parsed, targetFormat)

--- a/noodles-editor/src/noodles/utils/reference-utils.ts
+++ b/noodles-editor/src/noodles/utils/reference-utils.ts
@@ -15,13 +15,8 @@ export type ReferenceFormat = 'code' | 'mustache'
 // Supports both code format: op('path').par.field
 // and mustache format: {{path.par.field}}
 export function parseReference(text: string): ParsedReference | null {
-  // fnRe and mustacheRe are global regexes (defined with /g flag in fields.ts)
-  // Reset lastIndex to ensure idempotent behavior across multiple calls
-  fnRe.lastIndex = 0
-  mustacheRe.lastIndex = 0
-
   // Try function-style first: op('path').par.field
-  const fnMatch = fnRe.exec(text)
+  const fnMatch = text.matchAll(fnRe).next().value
   if (fnMatch?.groups) {
     const fieldPath = fnMatch.groups.fieldPath?.split('.')[0]
     return {
@@ -32,7 +27,7 @@ export function parseReference(text: string): ParsedReference | null {
   }
 
   // Try mustache-style: {{path.par.field}}
-  const mustacheMatch = mustacheRe.exec(text)
+  const mustacheMatch = text.matchAll(mustacheRe).next().value
   if (mustacheMatch?.groups) {
     const fieldPath = mustacheMatch.groups.fieldPath?.split('.')[0]
     return {

--- a/noodles-editor/src/noodles/utils/reference-utils.ts
+++ b/noodles-editor/src/noodles/utils/reference-utils.ts
@@ -15,7 +15,8 @@ export type ReferenceFormat = 'code' | 'mustache'
 // Supports both code format: op('path').par.field
 // and mustache format: {{path.par.field}}
 export function parseReference(text: string): ParsedReference | null {
-  // Reset regex state
+  // fnRe and mustacheRe are global regexes (defined with /g flag in fields.ts)
+  // Reset lastIndex to ensure idempotent behavior across multiple calls
   fnRe.lastIndex = 0
   mustacheRe.lastIndex = 0
 

--- a/noodles-editor/src/noodles/utils/reference-utils.ts
+++ b/noodles-editor/src/noodles/utils/reference-utils.ts
@@ -1,0 +1,54 @@
+// Utilities for parsing and formatting operator field references
+
+export type ParsedReference = {
+  opPath: string
+  namespace: 'par' | 'out'
+  fieldName: string
+}
+
+export type ReferenceFormat = 'code' | 'mustache'
+
+// Parse a reference from clipboard text
+// Supports both code format: op('path').par.field
+// and mustache format: {{path.par.field}}
+export function parseReference(text: string): ParsedReference | null {
+  // Parse op('path').par.field format
+  const fnMatch = text.match(/op\(['"]([^'"]+)['"]\)\.(par|out)\.(\w+)/)
+  if (fnMatch) {
+    return { opPath: fnMatch[1], namespace: fnMatch[2] as 'par' | 'out', fieldName: fnMatch[3] }
+  }
+
+  // Parse {{path.par.field}} format
+  const mustacheMatch = text.match(/\{\{([^}]+)\.(par|out)\.(\w+)\}\}/)
+  if (mustacheMatch) {
+    return {
+      opPath: mustacheMatch[1],
+      namespace: mustacheMatch[2] as 'par' | 'out',
+      fieldName: mustacheMatch[3],
+    }
+  }
+
+  return null
+}
+
+// Format a parsed reference in the specified format
+export function formatReference(
+  ref: ParsedReference,
+  format: ReferenceFormat
+): string {
+  const { opPath, namespace, fieldName } = ref
+  if (format === 'mustache') {
+    return `{{${opPath}.${namespace}.${fieldName}}}`
+  }
+  return `op('${opPath}').${namespace}.${fieldName}`
+}
+
+// Convert a reference string from one format to another
+export function convertReferenceFormat(
+  text: string,
+  targetFormat: ReferenceFormat
+): string | null {
+  const parsed = parseReference(text)
+  if (!parsed) return null
+  return formatReference(parsed, targetFormat)
+}


### PR DESCRIPTION
#### Background

Adds comprehensive copy/paste functionality for property references similar to Houdini, TouchDesigner, and Blender drivers. Users can now quickly wire up operator connections by copying property paths as references and pasting them into expression fields.

#### Change List
- Add **Copy value** menu option to serialize current field value to clipboard
- Add **Copy as reference** submenu with 4 options:
  - Absolute (code): `op('/path').par.field`
  - Absolute (mustache): `{{/path.par.field}}`
  - Relative (code): `op('../sibling').par.field`
  - Relative (mustache): `{{../sibling.par.field}}`
- Add **Paste reference** with smart format detection:
  - SQL CodeFields → automatically converts to mustache format
  - JavaScript CodeFields/ExpressionFields → automatically converts to code format
- Rename "Add expression" to **Edit expression** for clearer intent
- Create shared `reference-utils.ts` for parsing and format conversion
- Add `computeRelativePath()` utility to generate relative operator paths
- Create reusable `ContextMenuSubmenu` component for hierarchical menus
- Implement lazy field value evaluation to avoid stale closures
- Update both Properties Panel and canvas field context menus
- Add comprehensive test coverage (76 tests: 54 path-utils + 22 reference-utils)