### PR TITLE
Replace text +/- with eye icons for field visibility controls

### DIFF
--- a/noodles-editor/src/noodles/components/__tests__/node-properties-visibility.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/node-properties-visibility.test.tsx
@@ -103,23 +103,23 @@ describe('NodeProperties field visibility editing', () => {
   }
 
   describe('Field visibility controls', () => {
-    it('shows hide buttons (−) for visible fields', () => {
+    it('shows hide buttons (eye icons) for visible fields', () => {
       const node = setupOperator('DeckRendererOp', '/deck')
       renderNodeProperties(node)
 
-      // Find hide buttons (the − buttons) - they have type="button" and contain '−'
+      // Find hide buttons (EyeNoneIcon) - they have type="button" and contain an SVG
       const allButtons = screen.getAllByRole('button')
-      const hideButtons = allButtons.filter(btn => btn.textContent === '−')
+      const hideButtons = allButtons.filter(btn => btn.querySelector('svg') && !btn.textContent)
       expect(hideButtons.length).toBeGreaterThan(0)
     })
 
-    it('shows add buttons (+) for hidden fields', () => {
+    it('shows add buttons (eye icons) for hidden fields', () => {
       const node = setupOperator('DeckRendererOp', '/deck')
       renderNodeProperties(node)
 
-      // Find add buttons (the + buttons)
+      // Find add buttons (EyeOpenIcon) - they have type="button" and contain an SVG
       const allButtons = screen.getAllByRole('button')
-      const addButtons = allButtons.filter(btn => btn.textContent === '+')
+      const addButtons = allButtons.filter(btn => btn.querySelector('svg') && !btn.textContent)
       expect(addButtons.length).toBeGreaterThan(0)
     })
 
@@ -134,7 +134,7 @@ describe('NodeProperties field visibility editing', () => {
   })
 
   describe('Showing hidden fields', () => {
-    it('clicking + button shows a hidden field', () => {
+    it('clicking eye icon button shows a hidden field', () => {
       const node = setupOperator('DeckRendererOp', '/deck')
       renderNodeProperties(node)
 
@@ -144,7 +144,7 @@ describe('NodeProperties field visibility editing', () => {
       expect(op.isFieldVisible('effects')).toBe(false)
 
       const addButton = findFieldActionButton('effects')
-      expect(addButton?.textContent).toBe('+')
+      expect(addButton?.querySelector('svg')).toBeInTheDocument()
       fireEvent.click(addButton!)
 
       // Now the field should be visible
@@ -202,7 +202,7 @@ describe('NodeProperties field visibility editing', () => {
   })
 
   describe('Hiding visible fields', () => {
-    it('clicking − button hides a field without custom value', () => {
+    it('clicking eye icon button hides a field without custom value', () => {
       // Start with 'effects' explicitly visible
       const node = setupOperator('DeckRendererOp', '/deck', {}, [
         'layers',
@@ -215,9 +215,9 @@ describe('NodeProperties field visibility editing', () => {
       const op = getOp('/deck') as DeckRendererOp
       expect(op.isFieldVisible('effects')).toBe(true)
 
-      // Find the effects field - it should have a − button
+      // Find the effects field - it should have an eye icon button
       const hideButton = findFieldActionButton('effects')
-      expect(hideButton?.textContent).toBe('−')
+      expect(hideButton?.querySelector('svg')).toBeInTheDocument()
       fireEvent.click(hideButton!)
 
       // Now the field should be hidden
@@ -260,9 +260,9 @@ describe('NodeProperties field visibility editing', () => {
       }
       renderNodeProperties(node)
 
-      // Find the layers field and its − button
+      // Find the layers field and its eye icon button
       const hideButton = findFieldActionButton('layers')
-      expect(hideButton?.textContent).toBe('−')
+      expect(hideButton?.querySelector('svg')).toBeInTheDocument()
 
       // Button should be disabled
       expect(hideButton).toBeDisabled()

--- a/noodles-editor/src/noodles/components/__tests__/node-properties-visibility.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/node-properties-visibility.test.tsx
@@ -107,20 +107,22 @@ describe('NodeProperties field visibility editing', () => {
       const node = setupOperator('DeckRendererOp', '/deck')
       renderNodeProperties(node)
 
-      // Find hide buttons (EyeNoneIcon) - they have type="button" and contain an SVG
-      const allButtons = screen.getAllByRole('button')
-      const hideButtons = allButtons.filter(btn => btn.querySelector('svg') && !btn.textContent)
+      // Find hide buttons by aria-label
+      const hideButtons = screen.getAllByLabelText('Hide field')
       expect(hideButtons.length).toBeGreaterThan(0)
+      // Verify they contain SVG icons
+      expect(hideButtons[0].querySelector('svg')).toBeInTheDocument()
     })
 
     it('shows add buttons (eye icons) for hidden fields', () => {
       const node = setupOperator('DeckRendererOp', '/deck')
       renderNodeProperties(node)
 
-      // Find add buttons (EyeOpenIcon) - they have type="button" and contain an SVG
-      const allButtons = screen.getAllByRole('button')
-      const addButtons = allButtons.filter(btn => btn.querySelector('svg') && !btn.textContent)
+      // Find add buttons by aria-label
+      const addButtons = screen.getAllByLabelText('Show field')
       expect(addButtons.length).toBeGreaterThan(0)
+      // Verify they contain SVG icons
+      expect(addButtons[0].querySelector('svg')).toBeInTheDocument()
     })
 
     it('all fields are always visible in list', () => {

--- a/noodles-editor/src/noodles/components/node-properties.module.css
+++ b/noodles-editor/src/noodles/components/node-properties.module.css
@@ -152,6 +152,11 @@
   user-select: none;
 }
 
+.addRemoveBtn svg {
+  width: 14px;
+  height: 14px;
+}
+
 .addBtn {
   background: rgba(34, 197, 94, 0.15);
   color: #22c55e;
@@ -358,6 +363,21 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.connectedIcon {
+  display: inline-flex;
+  align-items: center;
+  color: rgba(234, 179, 8, 0.8);
+  flex-shrink: 0;
+}
+
+.connectedIcon svg {
+  width: 12px;
+  height: 12px;
 }
 
 /* Port */

--- a/noodles-editor/src/noodles/components/node-properties.module.css
+++ b/noodles-editor/src/noodles/components/node-properties.module.css
@@ -360,12 +360,16 @@
 .propertyLabel {
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+.propertyLabelText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .connectedIcon {

--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -286,6 +286,7 @@ function AddRemoveButton({
       className={cx(s.addRemoveBtn, type === 'add' ? s.addBtn : s.removeBtn)}
       onClick={onClick}
       disabled={disabled}
+      aria-label={type === 'add' ? 'Show field' : 'Hide field'}
     >
       {type === 'add' ? <EyeOpenIcon /> : <EyeNoneIcon />}
     </button>
@@ -893,7 +894,7 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
                       )}
                       <div className={cx(s.port, input.handleClass)} />
                       <span className={s.propertyLabel}>
-                        {input.name}
+                        <span className={s.propertyLabelText}>{input.name}</span>
                         {incomers.length > 0 && (
                           <Tooltip text="Field is connected" position="right">
                             <span className={s.connectedIcon}>

--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog'
-import { Cross2Icon } from '@radix-ui/react-icons'
+import { Cross2Icon, EyeNoneIcon, EyeOpenIcon, Link2Icon } from '@radix-ui/react-icons'
 import type { Edge } from '@xyflow/react'
 import { useReactFlow, useStore } from '@xyflow/react'
 import cx from 'classnames'
@@ -287,7 +287,7 @@ function AddRemoveButton({
       onClick={onClick}
       disabled={disabled}
     >
-      {type === 'add' ? '+' : '−'}
+      {type === 'add' ? <EyeOpenIcon /> : <EyeNoneIcon />}
     </button>
   )
 }
@@ -892,7 +892,16 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
                         </Tooltip>
                       )}
                       <div className={cx(s.port, input.handleClass)} />
-                      <span className={s.propertyLabel}>{input.name}</span>
+                      <span className={s.propertyLabel}>
+                        {input.name}
+                        {incomers.length > 0 && (
+                          <Tooltip text="Field is connected" position="right">
+                            <span className={s.connectedIcon}>
+                              <Link2Icon />
+                            </span>
+                          </Tooltip>
+                        )}
+                      </span>
                       {/* Value type, not connected: editable input + keyframe indicator */}
                       {isValueField(input.field) && incomers.length === 0 && (
                         <>

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -150,8 +150,8 @@ import { Mask3DExtension } from './extensions/mask-3d-extension'
 import {
   ArrayField,
   applySerializedFieldValue,
-  BezierCurveField,
   BboxField,
+  BezierCurveField,
   BooleanField,
   CategoricalColorRampField,
   CodeField,


### PR DESCRIPTION
#### Background
The field visibility toggle buttons in the right panel used text characters (`+` and `−`) which weren't immediately obvious to users. Connected fields that couldn't be hidden used a dark red minus that didn't clearly communicate the connection state.

#### Change List
- Replace `+` text with `EyeOpenIcon` from Radix UI for showing hidden fields (green button)
- Replace `−` text with `EyeNoneIcon` from Radix UI for hiding visible fields (red button, hover-to-reveal)
- Add `Link2Icon` indicator next to field names that have incoming connections (yellow/amber color)
- Update visibility control tests to check for SVG icons instead of text characters
- Add CSS styling for icon sizing and connected field indicator