### PR TITLE
Fix bezier curve editor bottom clipping in timeline

### DIFF
--- a/noodles-editor/src/timeline/components/CurvePopup.tsx
+++ b/noodles-editor/src/timeline/components/CurvePopup.tsx
@@ -26,7 +26,7 @@ export interface CurvePopupProps {
 }
 
 const POPUP_WIDTH = 420
-const POPUP_HEIGHT = 300
+const POPUP_HEIGHT = 360
 const CURVE_WIDTH = 240
 const CURVE_HEIGHT = 200
 

--- a/noodles-editor/src/timeline/components/TimelinePanel.module.css
+++ b/noodles-editor/src/timeline/components/TimelinePanel.module.css
@@ -798,7 +798,7 @@
 
 .curvePopupBody {
   display: flex;
-  height: 268px;
+  height: 328px;
 }
 
 .curvePopupPresets {


### PR DESCRIPTION
#### Background
The bezier curve editor popup in the timeline was cutting off the bottom of the SVG curve. The popup height was insufficient to contain the 200px SVG plus all the controls below it (preset label, edit input, and coordinate grid).

#### Change List
- Increased `POPUP_HEIGHT` constant from 300px to 360px in `CurvePopup.tsx`
- Increased `.curvePopupBody` CSS height from 268px to 328px in `TimelinePanel.module.css`
- Provides adequate spacing for all elements without clipping