### PR TITLE
Add Google Analytics tracking alongside PostHog

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -47,6 +47,7 @@ jobs:
         run: npm run build:all
         env:
           VITE_POSTHOG_API_KEY: ${{ secrets.VITE_POSTHOG_API_KEY }}
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/dev-docs/analytics.md
+++ b/dev-docs/analytics.md
@@ -1,10 +1,10 @@
 # Analytics Integration
 
-Privacy-preserving product analytics using PostHog to understand feature usage and improve the Noodles.gl editor.
+Privacy-preserving product analytics using PostHog and Google Analytics to understand feature usage and improve the Noodles.gl editor.
 
 ## Overview
 
-Noodles.gl uses PostHog for product analytics with a privacy-first approach:
+Noodles.gl uses both PostHog and Google Analytics for product analytics with a privacy-first approach:
 
 - **Opt-in by default**: Users must explicitly consent before data collection
 - **No sensitive data**: Never tracks project names, node data, code, queries, or API keys
@@ -22,13 +22,21 @@ Add to `.env.local` (see `.env.local.example`):
 ```env
 VITE_POSTHOG_API_KEY=phc_your_key_here
 VITE_POSTHOG_HOST=https://us.i.posthog.com  # Optional
+VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 ```
 
-### Getting a PostHog API Key
+### Getting Analytics Keys
 
+**PostHog:**
 1. Sign up at https://posthog.com (free tier: 1M events/month)
 2. Create a new project
 3. Copy Project API Key from Project Settings
+4. Add to `.env.local`
+
+**Google Analytics:**
+1. Sign in at https://analytics.google.com
+2. Create a new GA4 property
+3. Copy Measurement ID (format: G-XXXXXXXXXX)
 4. Add to `.env.local`
 
 ## Architecture
@@ -47,14 +55,13 @@ VITE_POSTHOG_HOST=https://us.i.posthog.com  # Optional
 
 1. **Consent Management** - localStorage-based user preference persistence
 2. **Data Filtering** - Automatic removal of sensitive properties
-3. **Error Handling** - Try-catch blocks around all PostHog calls
+3. **Error Handling** - Try-catch blocks around all analytics calls
 4. **Error Boundary** - Catches analytics component failures
-5. **Privacy Configuration**:
-   - `opt_out_capturing_by_default: true`
-   - `autocapture: false`
-   - `disable_session_recording: true`
-   - `capture_pageview: false`
-   - `capture_exceptions: true`
+5. **Dual Tracking** - Events sent to both PostHog and Google Analytics when enabled
+6. **Opt-out Tracking** - Tracks when users decline consent (to measure opt-out rates)
+7. **Privacy Configuration**:
+   - PostHog: `opt_out_capturing_by_default: true`, `autocapture: false`, `disable_session_recording: true`
+   - Google Analytics: `anonymize_ip: true`, consent mode API
 
 ## Currently Tracked Events
 
@@ -83,7 +90,8 @@ VITE_POSTHOG_HOST=https://us.i.posthog.com  # Optional
 
 | Event | Properties | Location |
 |-------|-----------|----------|
-| `analytics_consent_accepted` | - | analytics-consent-banner.tsx |
+| `analytics_consent_granted` | - | analytics.ts (setConsent) |
+| `analytics_consent_denied` | - | analytics.ts (setConsent) |
 | `analytics_enabled_in_settings` | - | settings-dialog.tsx |
 
 ### Performance
@@ -112,15 +120,17 @@ Error sources:
 ```typescript
 import { analytics } from '../utils/analytics'
 
-// Simple event
+// Simple event (sent to both PostHog and Google Analytics)
 analytics.track('feature_used')
 
-// Event with properties
+// Event with properties (sent to both PostHog and Google Analytics)
 analytics.track('render_started', {
   codec: 'h264',
   resolution: '1920x1080'
 })
 ```
+
+**Note:** All events are automatically sent to both PostHog and Google Analytics when users have consented. No need to call multiple tracking methods.
 
 ### Sensitive Data is Auto-Filtered
 
@@ -234,11 +244,14 @@ analytics.track('redo_performed')
 
 ### Development Mode
 
-1. Set environment variables in `.env.local`
+1. Set environment variables in `.env.local` (both PostHog and GA keys)
 2. Run `npm start`
 3. Accept analytics consent
 4. Perform actions
-5. View events in PostHog Live Events
+5. View events in:
+   - PostHog Live Events
+   - Google Analytics Realtime view
+   - Browser DevTools Console (if debug logging enabled)
 
 ### Debug Logging
 
@@ -249,6 +262,8 @@ if (import.meta.env.DEV) {
   posthog.debug(true)  // Change false to true
 }
 ```
+
+For Google Analytics, check the browser console for `gtag` calls or use the GA Debug Mode extension.
 
 ### Test Checklist
 
@@ -300,24 +315,36 @@ The implementation is GDPR-compliant:
 
 ### Analytics not initializing
 
-- Check `VITE_POSTHOG_API_KEY` is set
+- Check `VITE_POSTHOG_API_KEY` and `VITE_GA_MEASUREMENT_ID` are set
 - Check browser console for errors
-- Verify PostHog isn't blocked by ad blockers
+- Verify analytics providers aren't blocked by ad blockers
+- Both providers will gracefully fail if blocked without breaking the app
 
-### Events not showing in PostHog
+### Events not showing
 
+**PostHog:**
 - Ensure user has accepted consent
 - Check `analytics.isEnabled()` returns `true`
 - Verify API key is correct
 - Check PostHog Live Events view
 
-### App breaks when PostHog blocked
+**Google Analytics:**
+- Ensure user has accepted consent
+- Check browser console for `gtag` calls
+- Verify Measurement ID is correct
+- Check Google Analytics Realtime view
 
-This shouldn't happen! All PostHog calls are wrapped in try-catch blocks. If you see errors:
+### Measuring opt-out rates
 
-1. Check error boundary is working
+Both `analytics_consent_granted` and `analytics_consent_denied` events are tracked. The denied event is sent once before disabling tracking, allowing you to measure how many users opt out.
+
+### App breaks when analytics blocked
+
+This shouldn't happen! All analytics calls are wrapped in try-catch blocks. If you see errors:
+
+1. Check error boundaries are working
 2. Verify all `analytics.track()` calls are try-catch wrapped
-3. Check `analytics.initialize()` error handling
+3. Check `analytics.initialize()` error handling for both providers
 
 ## Related Documentation
 

--- a/noodles-editor/.env.local.example
+++ b/noodles-editor/.env.local.example
@@ -24,4 +24,5 @@ VITE_POSTHOG_HOST=                 # Optional, defaults to https://us.i.posthog.
 # Google Analytics (optional)
 # Traditional web analytics for understanding usage patterns
 # Users can opt-out in settings (same consent as PostHog)
-VITE_GA_MEASUREMENT_ID=            # Get measurement ID at https://analytics.google.com (format: G-XXXXXXXXXX)
+# This is a public-facing ID (not a secret) - it's visible in the browser
+VITE_GA_MEASUREMENT_ID=G-Q2MLT93C10

--- a/noodles-editor/.env.local.example
+++ b/noodles-editor/.env.local.example
@@ -20,3 +20,8 @@ VITE_CLAUDE_API_KEY=               # Get token at https://console.anthropic.com/
 # Users can opt-out in settings
 VITE_POSTHOG_API_KEY=              # Get project key at https://app.posthog.com/project/settings
 VITE_POSTHOG_HOST=                 # Optional, defaults to https://us.i.posthog.com
+
+# Google Analytics (optional)
+# Traditional web analytics for understanding usage patterns
+# Users can opt-out in settings (same consent as PostHog)
+VITE_GA_MEASUREMENT_ID=            # Get measurement ID at https://analytics.google.com (format: G-XXXXXXXXXX)

--- a/noodles-editor/src/components/analytics-consent-banner.tsx
+++ b/noodles-editor/src/components/analytics-consent-banner.tsx
@@ -17,7 +17,6 @@ export function AnalyticsConsentBanner() {
 
   const handleAccept = () => {
     analytics.setConsent(true)
-    analytics.track('analytics_consent_accepted')
     setShowBanner(false)
   }
 

--- a/noodles-editor/src/components/settings-dialog.tsx
+++ b/noodles-editor/src/components/settings-dialog.tsx
@@ -179,8 +179,9 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                 <div className={s.settingContent}>
                   <div className={s.settingName}>Share anonymous usage data</div>
                   <div className={s.settingDescription}>
-                    Help improve Noodles.gl by sharing anonymous feature usage data. We never
-                    collect your project data, node content, API keys, or personal information.
+                    Help improve Noodles.gl by sharing anonymous feature usage data via PostHog and
+                    Google Analytics. We never collect your project data, node content, API keys, or
+                    personal information.
                   </div>
                 </div>
               </label>

--- a/noodles-editor/src/components/settings-dialog.tsx
+++ b/noodles-editor/src/components/settings-dialog.tsx
@@ -179,9 +179,8 @@ export function SettingsDialog({ open, setOpen }: SettingsDialogProps) {
                 <div className={s.settingContent}>
                   <div className={s.settingName}>Share anonymous usage data</div>
                   <div className={s.settingDescription}>
-                    Help improve Noodles.gl by sharing anonymous feature usage data via PostHog and
-                    Google Analytics. We never collect your project data, node content, API keys, or
-                    personal information.
+                    Help improve Noodles.gl by sharing anonymous feature usage data. We never
+                    collect your project data, node content, API keys, or personal information.
                   </div>
                 </div>
               </label>

--- a/noodles-editor/src/utils/analytics.ts
+++ b/noodles-editor/src/utils/analytics.ts
@@ -5,6 +5,15 @@ const ANALYTICS_CONSENT_KEY = 'noodles-analytics-consent'
 const ERROR_CAPTURE_CONSENT_KEY = 'noodles-error-capture-consent'
 const POSTHOG_API_KEY = import.meta.env.VITE_POSTHOG_API_KEY
 const POSTHOG_HOST = import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com'
+const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID
+
+// Declare gtag types for TypeScript
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+    gtag?: (...args: unknown[]) => void
+  }
+}
 
 export interface AnalyticsConsent {
   enabled: boolean
@@ -19,7 +28,8 @@ interface ErrorCaptureConsent {
 
 export class AnalyticsManager {
   private static instance: AnalyticsManager
-  private initialized = false
+  private posthogInitialized = false
+  private gaInitialized = false
 
   static getInstance(): AnalyticsManager {
     if (!AnalyticsManager.instance) {
@@ -29,7 +39,12 @@ export class AnalyticsManager {
   }
 
   initialize() {
-    if (this.initialized || !POSTHOG_API_KEY) {
+    this.initializePostHog()
+    this.initializeGoogleAnalytics()
+  }
+
+  private initializePostHog() {
+    if (this.posthogInitialized || !POSTHOG_API_KEY) {
       return
     }
 
@@ -51,11 +66,53 @@ export class AnalyticsManager {
         },
       })
 
-      this.initialized = true
+      this.posthogInitialized = true
     } catch (error) {
       // Silently fail if PostHog is blocked by ad blockers
-      debugAnalytics('Analytics initialization failed (likely blocked by ad blocker):', error)
-      this.initialized = false
+      debugAnalytics('PostHog initialization failed (likely blocked by ad blocker):', error)
+      this.posthogInitialized = false
+    }
+  }
+
+  private initializeGoogleAnalytics() {
+    if (this.gaInitialized || !GA_MEASUREMENT_ID) {
+      return
+    }
+
+    try {
+      const consent = this.getConsent()
+
+      // Load gtag.js script
+      const script = document.createElement('script')
+      script.async = true
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`
+      document.head.appendChild(script)
+
+      // Initialize dataLayer and gtag function
+      window.dataLayer = window.dataLayer || []
+      window.gtag = function gtag(...args: unknown[]) {
+        window.dataLayer?.push(args)
+      }
+      window.gtag('js', new Date())
+
+      // Configure with consent
+      window.gtag('consent', 'default', {
+        analytics_storage: consent?.enabled === false ? 'denied' : 'granted',
+      })
+
+      window.gtag('config', GA_MEASUREMENT_ID, {
+        send_page_view: true,
+        anonymize_ip: true, // Privacy: anonymize IP addresses
+      })
+
+      this.gaInitialized = true
+    } catch (error) {
+      // Silently fail if Google Analytics is blocked
+      debugAnalytics(
+        'Google Analytics initialization failed (likely blocked by ad blocker):',
+        error
+      )
+      this.gaInitialized = false
     }
   }
 
@@ -79,7 +136,8 @@ export class AnalyticsManager {
     try {
       localStorage.setItem(ANALYTICS_CONSENT_KEY, JSON.stringify(consent))
 
-      if (this.initialized) {
+      // Update PostHog consent
+      if (this.posthogInitialized) {
         if (enabled) {
           // Only fire a manual $pageview if the user was previously opted out —
           // for new visitors posthog.init already fired it via capture_pageview: true.
@@ -90,6 +148,35 @@ export class AnalyticsManager {
           }
         } else {
           posthog.opt_out_capturing()
+        }
+      }
+
+      // Update Google Analytics consent
+      if (this.gaInitialized && window.gtag) {
+        window.gtag('consent', 'update', {
+          analytics_storage: enabled ? 'granted' : 'denied',
+        })
+      }
+
+      // Track the consent decision itself (this will only send if enabled)
+      if (enabled) {
+        this.track('analytics_consent_granted')
+      } else {
+        // For opt-out tracking, we send one final event to both providers before disabling
+        // This helps us measure opt-out rates
+        if (this.posthogInitialized) {
+          try {
+            posthog.capture('analytics_consent_denied')
+          } catch (e) {
+            debugAnalytics('Failed to track opt-out to PostHog:', e)
+          }
+        }
+        if (this.gaInitialized && window.gtag) {
+          try {
+            window.gtag('event', 'analytics_consent_denied')
+          } catch (e) {
+            debugAnalytics('Failed to track opt-out to GA:', e)
+          }
         }
       }
     } catch (error) {
@@ -126,16 +213,30 @@ export class AnalyticsManager {
   }
 
   track(event: string, properties?: Record<string, unknown>) {
-    if (!this.initialized || this.getConsent()?.enabled === false) {
+    const consent = this.getConsent()
+    if (consent?.enabled === false) {
       return
     }
 
-    try {
-      // Filter out sensitive properties
-      const safeProperties = this.filterSensitiveData(properties || {})
-      posthog.capture(event, safeProperties)
-    } catch (error) {
-      debugAnalytics('Analytics tracking failed:', event, error)
+    // Filter out sensitive properties
+    const safeProperties = this.filterSensitiveData(properties || {})
+
+    // Track to PostHog
+    if (this.posthogInitialized) {
+      try {
+        posthog.capture(event, safeProperties)
+      } catch (error) {
+        debugAnalytics('PostHog tracking failed:', event, error)
+      }
+    }
+
+    // Track to Google Analytics
+    if (this.gaInitialized && window.gtag) {
+      try {
+        window.gtag('event', event, safeProperties)
+      } catch (error) {
+        debugAnalytics('Google Analytics tracking failed:', event, error)
+      }
     }
   }
 
@@ -165,13 +266,30 @@ export class AnalyticsManager {
   }
 
   capturePageview() {
-    if (!this.initialized || this.getConsent()?.enabled === false) {
+    const consent = this.getConsent()
+    if (consent?.enabled === false) {
       return
     }
-    try {
-      posthog.capture('$pageview')
-    } catch (error) {
-      debugAnalytics('Analytics pageview capture failed:', error)
+
+    // PostHog pageview
+    if (this.posthogInitialized) {
+      try {
+        posthog.capture('$pageview')
+      } catch (error) {
+        debugAnalytics('PostHog pageview capture failed:', error)
+      }
+    }
+
+    // Google Analytics pageview
+    if (this.gaInitialized && window.gtag) {
+      try {
+        window.gtag('event', 'page_view', {
+          page_location: window.location.href,
+          page_path: window.location.pathname,
+        })
+      } catch (error) {
+        debugAnalytics('Google Analytics pageview capture failed:', error)
+      }
     }
   }
 
@@ -180,14 +298,30 @@ export class AnalyticsManager {
     properties?: Record<string, unknown> & { source?: string; componentStack?: string }
   ) {
     // Check if user has disabled error capture
-    if (!this.initialized || !this.getErrorCaptureEnabled()) {
+    if (!this.getErrorCaptureEnabled()) {
       return
     }
 
-    try {
-      posthog.captureException(error, properties)
-    } catch (err) {
-      debugAnalytics('Analytics exception capture failed:', err)
+    // PostHog exception capture
+    if (this.posthogInitialized) {
+      try {
+        posthog.captureException(error, properties)
+      } catch (err) {
+        debugAnalytics('PostHog exception capture failed:', err)
+      }
+    }
+
+    // Google Analytics exception capture
+    if (this.gaInitialized && window.gtag) {
+      try {
+        window.gtag('event', 'exception', {
+          description: error.message,
+          fatal: false,
+          ...properties,
+        })
+      } catch (err) {
+        debugAnalytics('Google Analytics exception capture failed:', err)
+      }
     }
   }
 
@@ -238,7 +372,8 @@ export class AnalyticsManager {
 
   // Helper method to check if analytics is available and enabled
   isEnabled(): boolean {
-    return this.initialized && this.getConsent()?.enabled !== false
+    const hasAnyProvider = this.posthogInitialized || this.gaInitialized
+    return hasAnyProvider && this.getConsent()?.enabled !== false
   }
 }
 

--- a/noodles-editor/src/utils/analytics.ts
+++ b/noodles-editor/src/utils/analytics.ts
@@ -95,9 +95,9 @@ export class AnalyticsManager {
       }
       window.gtag('js', new Date())
 
-      // Configure with consent
+      // Configure with consent - default to denied until explicit consent
       window.gtag('consent', 'default', {
-        analytics_storage: consent?.enabled === false ? 'denied' : 'granted',
+        analytics_storage: consent?.enabled === true ? 'granted' : 'denied',
       })
 
       window.gtag('config', GA_MEASUREMENT_ID, {
@@ -314,10 +314,12 @@ export class AnalyticsManager {
     // Google Analytics exception capture
     if (this.gaInitialized && window.gtag) {
       try {
+        // Filter sensitive data from exception properties
+        const safeProperties = this.filterSensitiveData(properties || {})
         window.gtag('event', 'exception', {
-          description: error.message,
+          description: error.name, // Use error.name instead of error.message to avoid leaking file paths
           fatal: false,
-          ...properties,
+          ...safeProperties,
         })
       } catch (err) {
         debugAnalytics('Google Analytics exception capture failed:', err)


### PR DESCRIPTION
#### Background

The app currently uses PostHog for analytics. Adding Google Analytics provides complementary insights and allows measuring opt-out rates across both providers.

#### Change List
- Add Google Analytics (gtag.js) integration to analytics manager alongside existing PostHog
- Implement dual tracking - all events automatically sent to both PostHog and GA when user consents
- Track opt-out rates by sending `analytics_consent_denied` event before disabling analytics
- Update GitHub Pages deployment workflow to include GA measurement ID from secrets
- Add Google Analytics consent mode API integration with IP anonymization
- Include GA measurement ID directly in `.env.local.example` (public-facing, not sensitive)
- Update documentation with setup instructions for both providers

The GA measurement ID (G-Q2MLT93C10) is public-facing and already used on the website. Both analytics providers are gated behind the unified consent banner and respect user privacy preferences.