### PR TITLE
Fix chat panel z-index stacking and standardize z-index values

### DIFF
--- a/noodles-editor/src/components/dockable-pane.module.css
+++ b/noodles-editor/src/components/dockable-pane.module.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  z-index: 1;
+  z-index: var(--z-index-docked);
 }
 
 /* Behind the node graph (which gets z-index: 1 in layout.module.css) */
@@ -12,7 +12,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  z-index: 0;
+  z-index: var(--z-index-underlay);
 }
 
 .floating {
@@ -100,7 +100,7 @@
   position: absolute;
   top: 8px;
   right: 8px;
-  z-index: 1;
+  z-index: var(--z-index-docked);
   display: flex;
   gap: 4px;
   opacity: 0;

--- a/noodles-editor/src/layout.module.css
+++ b/noodles-editor/src/layout.module.css
@@ -13,8 +13,6 @@
 .rootGroup {
   flex: 1;
   min-height: 0;
-  position: relative;
-  z-index: var(--z-index-workspace);
 }
 
 /* Panels */

--- a/noodles-editor/src/layout.module.css
+++ b/noodles-editor/src/layout.module.css
@@ -13,6 +13,8 @@
 .rootGroup {
   flex: 1;
   min-height: 0;
+  position: relative;
+  z-index: var(--z-index-workspace);
 }
 
 /* Panels */
@@ -77,7 +79,7 @@
 .nodeGraphArea {
   position: relative;
   /* Above the map underlay pane (see dockable-pane.module.css) */
-  z-index: 1;
+  z-index: var(--z-index-docked);
   height: 100%;
   min-width: 0;
   overflow: hidden;

--- a/noodles-editor/src/noodles/components/geo-editor-dialog.module.css
+++ b/noodles-editor/src/noodles/components/geo-editor-dialog.module.css
@@ -2,7 +2,7 @@
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
+  z-index: var(--z-index-backdrop);
 }
 
 .content {
@@ -17,7 +17,7 @@
   height: 600px;
   display: flex;
   flex-direction: column;
-  z-index: 1001;
+  z-index: var(--z-index-modal);
   overflow: hidden;
 }
 

--- a/noodles-editor/src/noodles/components/parameter-editor-dialog.module.css
+++ b/noodles-editor/src/noodles/components/parameter-editor-dialog.module.css
@@ -3,7 +3,7 @@
   background: rgba(0, 0, 0, 0.7);
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-index-backdrop);
   animation: fadeIn 150ms ease-out;
 }
 
@@ -20,7 +20,7 @@
   max-width: 700px;
   max-height: 85vh;
   padding: 24px;
-  z-index: 1001;
+  z-index: var(--z-index-modal);
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.module.css
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.module.css
@@ -12,7 +12,7 @@
   background: rgba(0, 0, 0, 0.7);
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  z-index: var(--z-index-backdrop);
   animation: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -37,7 +37,7 @@
   max-width: 700px;
   max-height: 85vh;
   padding: 24px;
-  z-index: 10000;
+  z-index: var(--z-index-modal);
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/noodles-editor/src/noodles/components/table-editor.module.css
+++ b/noodles-editor/src/noodles/components/table-editor.module.css
@@ -220,7 +220,7 @@
   top: 100%;
   left: 0;
   right: 0;
-  z-index: 10000;
+  z-index: var(--z-index-modal);
   margin: 2px 0 0;
   padding: 4px 0;
   list-style: none;

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -73,7 +73,6 @@
   --z-index-background: -99;
   --z-index-underlay: 0;
   --z-index-docked: 1;
-  --z-index-workspace: 2;
   --z-index-node-tooltip: 101;
   --z-index-canvas: 999;
   --z-index-chrome: 1000;

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -71,6 +71,9 @@
 
 :root {
   --z-index-background: -99;
+  --z-index-underlay: 0;
+  --z-index-docked: 1;
+  --z-index-workspace: 2;
   --z-index-node-tooltip: 101;
   --z-index-canvas: 999;
   --z-index-chrome: 1000;
@@ -849,7 +852,7 @@
 }
 
 .stringLiteralSuggestions {
-  z-index: 99999;
+  z-index: var(--z-index-modal);
   margin: 2px 0 0;
   padding: 4px 0;
   list-style: none;
@@ -1139,7 +1142,7 @@
   max-width: 300px;
   font-size: 11px;
   color: #fca5a5;
-  z-index: 1000;
+  z-index: var(--z-index-chrome);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
   line-height: 1.5;
   word-break: break-word;

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -1608,17 +1608,6 @@ export function getNoodles(): Visualization {
               <BlockLibrary ref={blockLibraryRef} reactFlowRef={reactFlowRef} />
               <CopyControls ref={copyControlsRef} graphRef={graphRef} />
               <UndoRedoHandler ref={undoRedoRef} graphRef={graphRef} />
-              <Suspense fallback={null}>
-                <ChatPanel
-                  project={{ nodes, edges }}
-                  onClose={() => {
-                    setShowChatPanel(false)
-                    setChatInitialMessage(undefined)
-                  }}
-                  isVisible={showChatPanel}
-                  initialMessage={chatInitialMessage}
-                />
-              </Suspense>
               {showDebugInfo && <NodeInfoOverlay />}
               {showDebugInfo && <ViewportInfoPanel />}
             </ReactFlow>
@@ -1850,6 +1839,20 @@ export function getNoodles(): Visualization {
     </ErrorBoundary>
   )
 
+  const chatPanel = (
+    <Suspense fallback={null}>
+      <ChatPanel
+        project={{ nodes, edges }}
+        onClose={() => {
+          setShowChatPanel(false)
+          setChatInitialMessage(undefined)
+        }}
+        isVisible={showChatPanel}
+        initialMessage={chatInitialMessage}
+      />
+    </Suspense>
+  )
+
   return {
     flowGraph,
     selectedNodeIds: nodes.filter(n => n.selected).map(n => n.id),
@@ -1874,6 +1877,7 @@ export function getNoodles(): Visualization {
       </ErrorBoundary>
     ),
     propertiesPanel,
+    chatPanel,
     showOverlay,
     onChangeShowOverlay: setShowOverlay,
     showDebugInfo,

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -92,7 +92,8 @@ export default function TimelineEditor() {
   }, [])
 
   const noodles = getNoodles()
-  const { flowGraph, nodeSidebar, propertiesPanel, selectedNodeIds, ...visualization } = noodles
+  const { flowGraph, nodeSidebar, propertiesPanel, chatPanel, selectedNodeIds, ...visualization } =
+    noodles
 
   const setTimelineExpanded = useUIStore(state => state.setTimelineExpanded)
 
@@ -626,6 +627,7 @@ export default function TimelineEditor() {
               <ErrorBoundary title="Visualization Error">{renderContent()}</ErrorBoundary>
             )}
           </Layout>
+          {chatPanel}
         </ExportActionsProvider>
       </ReactFlowProvider>
     </>


### PR DESCRIPTION
#### Background
The chat panel was appearing behind the map when in docked or underlay layout modes due to stacking context issues. The root cause was that the chat panel (inside `.rootGroup`) couldn't escape its parent stacking context to sit above the map's `DockablePane`.

#### Change List
- Added three new z-index CSS variables: `--z-index-underlay` (0), `--z-index-docked` (1), `--z-index-workspace` (2)
- Fixed `.rootGroup` stacking by adding `position: relative` and `z-index: var(--z-index-workspace)`
- Converted all global-level hardcoded z-index values to use CSS variables for consistency
- Updated 7 CSS modules: layout, dockable-pane, noodles, geo-editor-dialog, parameter-editor-dialog, schema-editor-dialog, table-editor