### PR TITLE
Polish field component layout and controls

### DIFF
--- a/noodles-editor/src/noodles/components/field-components.test.tsx
+++ b/noodles-editor/src/noodles/components/field-components.test.tsx
@@ -3,6 +3,7 @@ import { ReactFlowProvider } from '@xyflow/react'
 import { Temporal } from 'temporal-polyfill'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  BezierCurveField,
   BooleanField,
   ColorField,
   CompoundPropsField,
@@ -20,6 +21,7 @@ import { StringOp } from '../operators'
 import { clearOps, setOp } from '../store'
 import { registerPropertyMutationCallback } from '../utils/property-history'
 import {
+  BezierCurveFieldComponent,
   BooleanFieldComponent,
   ColorFieldComponent,
   CompoundFieldComponent,
@@ -581,6 +583,14 @@ describe('VectorFieldComponent', () => {
       expect(screen.getByPlaceholderText('y')).toBeInTheDocument()
     })
 
+    it('keeps channel names visible when inputs have values', () => {
+      const field = new Vec2Field({ x: 10, y: 20 })
+      render(<VectorFieldComponent id="test-field" field={field} disabled={false} />)
+
+      expect(screen.getByText('x')).toBeInTheDocument()
+      expect(screen.getByText('y')).toBeInTheDocument()
+    })
+
     it('renders with correct initial values', () => {
       const field = new Vec2Field({ x: 5, y: 15 })
       render(<VectorFieldComponent id="test-field" field={field} disabled={false} />)
@@ -882,6 +892,33 @@ describe('CompoundFieldComponent', () => {
     inputs.forEach(input => {
       expect(input).toBeDisabled()
     })
+  })
+})
+
+describe('BezierCurveFieldComponent', () => {
+  afterEach(() => {
+    cleanup()
+    clearOps()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps editing instructions behind an accessible help button', () => {
+    const field = new BezierCurveField()
+    render(<BezierCurveFieldComponent id="curve" field={field} disabled={false} />)
+
+    const helpButton = screen.getByRole('button', { name: 'Show Bézier curve help' })
+    expect(helpButton).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText(/Click to add a point/)).not.toBeInTheDocument()
+
+    fireEvent.click(helpButton)
+
+    expect(screen.getByRole('button', { name: 'Hide Bézier curve help' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+    expect(screen.getByRole('note')).toHaveTextContent(
+      'Click to add a point. Click a point to select it. Double-click to remove it. Drag to move it.'
+    )
   })
 })
 

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -1,6 +1,6 @@
 import type { OnMount } from '@monaco-editor/react'
 import * as Dialog from '@radix-ui/react-dialog'
-import { Cross2Icon } from '@radix-ui/react-icons'
+import { Cross2Icon, QuestionMarkCircledIcon } from '@radix-ui/react-icons'
 import { Handle, Position, useEdges, useNodeId, useReactFlow } from '@xyflow/react'
 import cx from 'classnames'
 import type { ScaleLinear, ScaleOrdinal } from 'd3'
@@ -757,17 +757,20 @@ function VectorNumberInput({
   )
 
   return (
-    <DraggableNumberInput
-      value={value}
-      disabled={disabled}
-      onChange={handleChange}
-      onCommit={onCommit}
-      onInteractionStart={onInteractionStart}
-      step={0.1}
-      className={cx(s.fieldInput, s.fieldInputVector, s.fieldInputNumber)}
-      title={`${keyName}: ${value}`}
-      placeholder={keyName}
-    />
+    <div className={s.fieldVectorChannel}>
+      <span className={s.fieldLabelVector}>{keyName}</span>
+      <DraggableNumberInput
+        value={value}
+        disabled={disabled}
+        onChange={handleChange}
+        onCommit={onCommit}
+        onInteractionStart={onInteractionStart}
+        step={0.1}
+        className={cx(s.fieldInput, s.fieldInputVector, s.fieldInputNumber)}
+        title={`${keyName}: ${value}`}
+        placeholder={keyName}
+      />
+    </div>
   )
 }
 
@@ -1282,8 +1285,8 @@ export function FileUrlFieldComponent({
 
   return (
     <>
-      <div className={s.nodeFieldWrapper}>
-        <label className={s.nodeFieldLabel} htmlFor={id}>
+      <div className={cx(s.fieldWrapper, 'nokey')}>
+        <label className={s.fieldLabel} htmlFor={id}>
           {id}
         </label>
         <div
@@ -1504,8 +1507,8 @@ export function MapStyleFieldComponent({
 
   return (
     <>
-      <div className={s.nodeFieldWrapper}>
-        <label className={s.nodeFieldLabel} htmlFor={id}>
+      <div className={cx(s.fieldWrapper, 'nokey')}>
+        <label className={s.fieldLabel} htmlFor={id}>
           {id}
         </label>
         <div className={cx('p-inputgroup', s.fieldFileInputGroup)}>
@@ -2130,7 +2133,7 @@ export function DateFieldComponent({
         <input
           id={id}
           type="datetime-local"
-          className={s.fieldInput}
+          className={cx(s.fieldInput, s.fieldInputDate)}
           value={formatted}
           onChange={onChange}
           disabled={disabled}
@@ -2237,7 +2240,17 @@ export function ColorRampComponent({
 
   return (
     <div className={cx(s.fieldWrapper, 'nokey')}>
-      <canvas className={s.fieldInputColorRamp} ref={canvasRef} width={steps} height={1} />
+      <label className={s.fieldLabel} htmlFor={id}>
+        {id}
+      </label>
+      <canvas
+        id={id}
+        aria-label={`${id} color ramp`}
+        className={s.fieldInputColorRamp}
+        ref={canvasRef}
+        width={steps}
+        height={1}
+      />
     </div>
   )
 }
@@ -2304,6 +2317,7 @@ export function BezierCurveFieldComponent({
   const svgRef = useRef<SVGSVGElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const { captureStart, commitChange } = usePropertyHistory()
+  const [isHelpOpen, setIsHelpOpen] = useState(false)
   const [dragState, setDragState] = useState<{
     isDragging: boolean
     dragIndex: number
@@ -2594,7 +2608,7 @@ export function BezierCurveFieldComponent({
       <label className={s.fieldLabel} htmlFor={id}>
         {id}
       </label>
-      <div className="bezier-curve-editor">
+      <div className={s.bezierCurveEditor}>
         <svg
           ref={svgRef}
           width={svgSize.width}
@@ -2825,11 +2839,24 @@ export function BezierCurveFieldComponent({
           </div>
         )}
 
-        <div
-          className="bezier-curve-controls"
-          style={{ marginTop: '8px', fontSize: '12px', color: '#888' }}
-        >
-          Click to add point • Click point to select • Double-click to remove • Drag to move
+        <div className={s.bezierHelp}>
+          <button
+            type="button"
+            className={cx(s.bezierHelpButton, 'nodrag')}
+            aria-label={`${isHelpOpen ? 'Hide' : 'Show'} Bézier curve help`}
+            aria-controls={`${id}-bezier-help`}
+            aria-expanded={isHelpOpen}
+            title="Bézier curve help"
+            onClick={() => setIsHelpOpen(open => !open)}
+          >
+            <QuestionMarkCircledIcon aria-hidden="true" />
+          </button>
+          {isHelpOpen && (
+            <div id={`${id}-bezier-help`} className={s.bezierHelpPopover} role="note">
+              Click to add a point. Click a point to select it. Double-click to remove it. Drag to
+              move it.
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -3309,10 +3336,7 @@ export function BboxFieldComponent({
         {id}
       </label>
       <div id={id} className={s.fieldCompoundWrapper}>
-        <div
-          className={s.fieldLabel}
-          style={{ fontSize: '11px', opacity: 0.7, marginBottom: '4px' }}
-        >
+        <div className={s.fieldGroupLabel}>
           Southwest
         </div>
         <div className={cx(s.fieldInputWrapper, s.fieldInputWrapperVector)}>
@@ -3350,10 +3374,7 @@ export function BboxFieldComponent({
           />
         </div>
 
-        <div
-          className={s.fieldLabel}
-          style={{ fontSize: '11px', opacity: 0.7, marginBottom: '4px', marginTop: '8px' }}
-        >
+        <div className={cx(s.fieldGroupLabel, s.fieldGroupLabelSpaced)}>
           Northeast
         </div>
         <div className={cx(s.fieldInputWrapper, s.fieldInputWrapperVector)}>

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -101,7 +101,7 @@
   --node-header-border-color: #e0e0e0;
   --node-input-hover-color: var(--color-input-hover);
   --node-input-focus-color: var(--color-input-focus);
-  --node-input-disaabled-color: var(--color-input-disabled);
+  --node-input-disabled-color: var(--color-input-disabled);
 
   --node-add-menu-background-color: #404040;
   --node-add-menu-header-background-color: black;
@@ -438,6 +438,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  gap: 2px;
   min-height: inherit;
 }
 
@@ -446,12 +447,23 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  min-height: 25px;
-  gap: 10px;
+  width: 100%;
+  min-height: 28px;
+  gap: 12px;
+  box-sizing: border-box;
+  font: inherit;
+  line-height: 1.25;
 }
 
 .fieldLabel {
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  line-height: inherit;
+  color: inherit;
+  text-align: left;
 }
 
 .compoundPropsExpander {
@@ -472,7 +484,8 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  flex: 2;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
 .keyframedFieldInput {
@@ -480,11 +493,20 @@
 }
 
 .fieldInput {
+  box-sizing: border-box;
   border: none;
   text-align: right;
-  flex: 1;
+  flex: 0 1 auto;
+  width: 12rem;
+  min-width: 7.5rem;
+  max-width: 18rem;
+  min-height: 24px;
+  padding: 2px 6px;
   background: transparent;
   color: var(--node-text-color);
+  font: inherit;
+  line-height: 20px;
+  field-sizing: content;
 }
 
 .fieldInput:hover {
@@ -497,16 +519,14 @@
 }
 
 .fieldInput:disabled {
-  background: var(--node-input-disaabled-color);
+  background: var(--node-input-disabled-color);
 }
 
 .fieldTextarea {
   resize: vertical;
-  min-height: 1.8em;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: 1.4;
-  padding: 4px 6px;
+  min-height: 24px;
+  max-height: 10rem;
+  overflow: auto;
 }
 
 .fieldInputGroup {
@@ -522,13 +542,73 @@
 }
 
 .fieldInputUploadButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 24px;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
   cursor: pointer;
-  padding: .25rem .875rem;
+  padding: 0;
 }
 
 .fieldCompoundWrapper {
-  flex: 1;
-  margin-left: 10px;
+  flex: 0 1 auto;
+  min-width: 13rem;
+}
+
+.bezierCurveEditor {
+  position: relative;
+}
+
+.bezierHelp {
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+  height: 20px;
+  margin-top: 4px;
+}
+
+.bezierHelpButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-hover);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.bezierHelpButton:hover,
+.bezierHelpButton[aria-expanded="true"] {
+  color: var(--color-text-primary);
+  background: var(--color-bg-hover);
+}
+
+.bezierHelpButton:focus-visible {
+  outline: 2px solid #91a8ba;
+  outline-offset: 1px;
+}
+
+.bezierHelpPopover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  z-index: 1;
+  width: 190px;
+  padding: 7px 9px;
+  color: var(--color-text-primary);
+  background: var(--tooltip-background-color);
+  border: 1px solid var(--color-border-hover);
+  border-radius: 4px;
+  font-size: 11px;
+  line-height: 1.35;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.24);
 }
 
 /* CompoundPropsField wrapper needs top alignment so handle aligns with label button */
@@ -563,7 +643,8 @@
 }
 
 .fieldInputNumber {
-  margin-right: -12px;
+  width: 7.5rem;
+  min-width: 7.5rem;
   cursor: ew-resize;
   user-select: none;
 }
@@ -591,13 +672,24 @@
 }
 
 .fieldLabelVector {
-  width: 10px;
+  display: inline-flex;
+  align-items: center;
+  align-self: stretch;
+  flex: 0 0 auto;
+  min-width: 8px;
   color: var(--node-field-hint-color);
+  font-size: 10px;
+  line-height: 1;
+  text-align: center;
+  text-transform: lowercase;
+  transform: translateY(1px);
 }
 
 .fieldInputWrapperVector {
   display: flex;
-  gap: 3px;
+  align-items: center;
+  min-height: 24px;
+  gap: 6px;
 }
 
 .fieldInputWrapperVector .fieldInputNumber {
@@ -605,8 +697,16 @@
 }
 
 .fieldInputVector {
-  width: 68px;
+  width: 5rem;
+  min-width: 5rem;
   text-align: right;
+}
+
+.fieldVectorChannel {
+  display: flex;
+  align-items: center;
+  height: 24px;
+  gap: 3px;
 }
 
 .fieldInputVector::placeholder {
@@ -615,6 +715,9 @@
 }
 
 .fieldLookupButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin-left: 4px;
   padding: 0;
   width: 24px;
@@ -623,12 +726,62 @@
   flex-shrink: 0;
 }
 
+.fieldLookupButton :global(.p-button-icon) {
+  transform: none;
+}
+
+.fieldInputUploadButton,
+.fieldLookupButton {
+  --field-action-color: #486780;
+  --field-action-hover-color: #587993;
+  --field-action-border-color: #6f899e;
+
+  color: #fff;
+  background: var(--field-action-color);
+  border: 1px solid var(--field-action-border-color);
+  border-radius: 4px;
+  box-shadow: none;
+}
+
+.fieldInputUploadButton:hover:not(:disabled),
+.fieldLookupButton:hover:not(:disabled) {
+  background: var(--field-action-hover-color);
+  border-color: #8299ab;
+}
+
+.fieldInputUploadButton:focus-visible,
+.fieldLookupButton:focus-visible {
+  outline: 2px solid #91a8ba;
+  outline-offset: 1px;
+}
+
+.fieldInputUploadButton:disabled,
+.fieldLookupButton:disabled {
+  opacity: 0.45;
+}
+
+.fieldInputUploadButton :global(.p-button-icon),
+.fieldLookupButton :global(.p-button-icon) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1;
+}
+
 .fieldInputUpload {
   cursor: pointer;
 }
 
 .fieldInputCheckbox {
-  flex: unset;
+  flex: 0 0 auto;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  padding: 0;
   cursor: pointer;
 }
 
@@ -770,23 +923,29 @@
   /* biome-ignore lint/suspicious/noDuplicateProperties: Firefox fallback, standard follows */
   image-rendering: pixelated;
 
-  width: 200px;
-  height: 40px;
+  width: 12rem;
+  height: 28px;
+  border-radius: 2px;
 }
 
 .fieldInputSelect {
-  border: none;
-  background: transparent;
-  color: var(--node-text-color);
-  text-align: right;
+  width: auto;
+  min-width: 7.5rem;
+  padding-right: 4px;
 }
 
-.nodeFieldWrapper {
-  display: flex;
+.fieldInputDate {
+  width: auto;
+  min-width: 11.5rem;
 }
 
 .fieldFileInputGroup {
-  width: unset;
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  width: fit-content;
+  min-width: 0;
+  gap: 2px;
 }
 
 .fieldFileInputGroupSuggestions {
@@ -794,7 +953,10 @@
 }
 
 .fieldInputFileUrl {
-  padding: 0 1em;
+  width: 11rem;
+  min-width: 9rem;
+  max-width: 16rem;
+  padding: 2px 8px;
 }
 
 .fileUrlSuggestions {
@@ -844,8 +1006,18 @@
 }
 
 .fieldInputTypeahead {
-  width: 100%;
-  padding: 0 0.5em;
+  width: 12rem;
+}
+
+.fieldGroupLabel {
+  margin: 0 0 3px;
+  color: var(--node-field-hint-color);
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.fieldGroupLabelSpaced {
+  margin-top: 8px;
 }
 
 .stringLiteralSuggestions {


### PR DESCRIPTION
## Summary

Polishes Noodles.gl field controls so the catalog—and the editor itself—use consistent typography,
spacing, alignment, sizing, corner radii, and action-button styling.

## Changes

- Standardizes field rows around a 28px minimum height, inherited typography, symmetric spacing,
  and content-sized controls.
- Reduces excess width in number, text, enum, date, file/URL, compound, and color-ramp fields while
  retaining type-appropriate minimum widths.
- Keeps vector and geographic channel names visible, and centers labels, values, and point actions
  on a shared 24px centerline.
- Unifies file, map-style, point, and bounds actions as 24px button groups using a muted slate-blue
  palette.
- Gives color ramps an accessible visible label and a compact 28px presentation.
- Moves Bézier editing instructions behind an accessible help button and non-resizing overlay.
- Fixes the misspelled disabled-input color token.

## Visual review

### Before

<img width="3200" height="1800" alt="image" src="https://github.com/user-attachments/assets/d90e1cce-d0d2-4af7-a205-022abdb038fa" />

### Rendered field catalog

[![Rendered Noodles.gl field catalog](https://gist.githubusercontent.com/chrisgervang/3d77781245885c57183a7b5f14745eda/raw/89a85e464496496e583d587d5bbafbcdeec3630c/field-ui-catalog.png)](https://gist.githubusercontent.com/chrisgervang/3d77781245885c57183a7b5f14745eda/raw/89a85e464496496e583d587d5bbafbcdeec3630c/field-ui-catalog.png)

### UI redlines

[![Noodles.gl field UI redlines](https://gist.githubusercontent.com/chrisgervang/3d77781245885c57183a7b5f14745eda/raw/8a0245fc60f6fdfb170e51596b3d93361545e96b/field-ui-redlines.png)](https://gist.githubusercontent.com/chrisgervang/3d77781245885c57183a7b5f14745eda/raw/8a0245fc60f6fdfb170e51596b3d93361545e96b/field-ui-redlines.png)

[Read the exhaustive before/after redline spec](https://gist.github.com/chrisgervang/3d77781245885c57183a7b5f14745eda#file-field-ui-redlines-md).

## Manual testing

The review project is intentionally attached instead of checked into the repository:

**[Download `field-ui-catalog.noodles.json`](https://gist.githubusercontent.com/chrisgervang/3d77781245885c57183a7b5f14745eda/raw/0621cb18fc4a258db634d55102b02769e6d0569f/field-ui-catalog.noodles.json?download=1)**

1. Load the attached project in Noodles.gl.
2. Confirm each field row is compact and its label/control spacing is balanced.
3. Confirm `x/y/z` and `lng/lat` labels remain visible beside populated vector values.
4. Confirm file, map-style, point, and bounds buttons are centered, 24px square, and slate blue.
5. Open the color picker and confirm the field label/swatch remain visible.
6. Click the Bézier `?` button and confirm help opens above the button without resizing the node.

Expected: all 18 live nodes remain separated in a four-column grid; the rendered-bounds check reports
zero intersections.

## Testing

### Automated

- `npx vitest run src/noodles/components/field-components.test.tsx` — **87/87 passing**
- `npm run build` — **passing**
- `git diff --check` — **passing**

### Existing repository checks

- Standalone `npx tsc --noEmit` and full-file Biome checks are not currently clean on `main`; they
  report existing diagnostics across migrations, rendering, and the large shared field/CSS files.
  The production Vite build and focused component suite pass for this change.

## Documentation

- No product documentation changes needed.
- Visual redlines and the complete review project are linked above for implementation review.

## Related issues

None.
