### PR TITLE
Add rich visual dropdown for color scheme selection

### DIFF
--- a/noodles-editor/src/noodles/color-schemes.ts
+++ b/noodles-editor/src/noodles/color-schemes.ts
@@ -1,0 +1,154 @@
+import * as d3 from 'd3'
+import {
+  interpolateBlues,
+  interpolateBuGn,
+  interpolateBuPu,
+  interpolateCividis,
+  interpolateCool,
+  interpolateCubehelixDefault,
+  interpolateGnBu,
+  interpolateGreens,
+  interpolateGreys,
+  interpolateInferno,
+  interpolateMagma,
+  interpolateOranges,
+  interpolateOrRd,
+  interpolatePiYG,
+  interpolatePlasma,
+  interpolatePuOr,
+  interpolatePurples,
+  interpolateRainbow,
+  interpolateRdBu,
+  interpolateRdGy,
+  interpolateRdYlBu,
+  interpolateReds,
+  interpolateSinebow,
+  interpolateSpectral,
+  interpolateTurbo,
+  interpolateViridis,
+  interpolateWarm,
+  schemeAccent,
+  schemeBrBG,
+  schemeCategory10,
+  schemeDark2,
+  schemeGreys,
+  schemePaired,
+  schemePiYG,
+  schemePRGn,
+  schemePuBu,
+  schemeRdBu,
+  schemeRdGy,
+  schemeRdYlBu,
+  schemeRdYlGn,
+  schemeSet1,
+  schemeSet2,
+  schemeSet3,
+  schemeSpectral,
+  schemeTableau10,
+  schemeYlGn,
+} from 'd3-scale-chromatic'
+
+export const JOBY_COLORS = [
+  '#FFB300',
+  '#EB6110',
+  '#E64839',
+  '#00994C',
+  '#883DF2',
+  '#7CC3FF',
+  '#3EC26A',
+  '#FF9058',
+  '#FFCC54',
+  '#B580FF',
+]
+
+export const continuousInterpolators = {
+  viridis: interpolateViridis,
+  inferno: interpolateInferno,
+  plasma: interpolatePlasma,
+  magma: interpolateMagma,
+  turbo: interpolateTurbo,
+  cividis: interpolateCividis,
+  warm: interpolateWarm,
+  cool: interpolateCool,
+  cubehelix: interpolateCubehelixDefault,
+  spectral: interpolateSpectral,
+  rainbow: interpolateRainbow,
+  sinebow: interpolateSinebow,
+  blues: interpolateBlues,
+  greens: interpolateGreens,
+  greys: interpolateGreys,
+  reds: interpolateReds,
+  oranges: interpolateOranges,
+  purples: interpolatePurples,
+  joby: d3.interpolateRgbBasis(JOBY_COLORS),
+  PinkYellowGreen: interpolatePiYG,
+  PurpleOrange: interpolatePuOr,
+  RedBlue: interpolateRdBu,
+  RedGrey: interpolateRdGy,
+  RedYellowBlue: interpolateRdYlBu,
+  BlueGreen: interpolateBuGn,
+  BluePurple: interpolateBuPu,
+  GreenBlue: interpolateGnBu,
+  OrangeRed: interpolateOrRd,
+}
+
+export const categoricalSchemesFixed = {
+  accent: schemeAccent,
+  category10: schemeCategory10,
+  dark: schemeDark2,
+  paired: schemePaired,
+  set1: schemeSet1,
+  set2: schemeSet2,
+  set3: schemeSet3,
+  tableau10: schemeTableau10,
+  joby: JOBY_COLORS,
+}
+
+export const categoricalSchemesStepped = {
+  greyscale: schemeGreys,
+  BrownGreen: schemeBrBG,
+  PurpleGreen: schemePRGn,
+  PurpleBlue: schemePuBu,
+  PinkYellowGreen: schemePiYG,
+  RedBlue: schemeRdBu,
+  RedGrey: schemeRdGy,
+  RedYellowBlue: schemeRdYlBu,
+  RedYellowGreen: schemeRdYlGn,
+  YellowGreen: schemeYlGn,
+  spectral: schemeSpectral,
+}
+
+// Render a color scheme to a canvas context
+// Handles continuous interpolators, fixed categorical schemes, and stepped schemes
+export function renderColorScheme(
+  ctx: CanvasRenderingContext2D,
+  schemeName: string,
+  width: number,
+  height: number,
+  stepCount = 8
+) {
+  if (schemeName in continuousInterpolators) {
+    const interpolator = continuousInterpolators[schemeName as keyof typeof continuousInterpolators]
+    for (let i = 0; i < width; i++) {
+      const t = i / (width - 1)
+      ctx.fillStyle = interpolator(t)
+      ctx.fillRect(i, 0, 1, height)
+    }
+  } else if (schemeName in categoricalSchemesFixed) {
+    const scheme = categoricalSchemesFixed[schemeName as keyof typeof categoricalSchemesFixed]
+    const blockWidth = width / scheme.length
+    scheme.forEach((color, i) => {
+      ctx.fillStyle = color
+      ctx.fillRect(i * blockWidth, 0, blockWidth, height)
+    })
+  } else if (schemeName in categoricalSchemesStepped) {
+    const schemes = categoricalSchemesStepped[schemeName as keyof typeof categoricalSchemesStepped]
+    const clamped = Math.min(stepCount, schemes.length - 1)
+    const scheme = schemes[clamped] as readonly string[]
+    const blockWidth = width / scheme.length
+    scheme.forEach((color, i) => {
+      ctx.fillStyle = color
+      ctx.fillRect(i * blockWidth, 0, blockWidth, height)
+    })
+  }
+}

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -4,6 +4,62 @@ import { Cross2Icon } from '@radix-ui/react-icons'
 import { Handle, Position, useEdges, useNodeId, useReactFlow } from '@xyflow/react'
 import cx from 'classnames'
 import type { ScaleLinear, ScaleOrdinal } from 'd3'
+import * as d3 from 'd3'
+import {
+  interpolateBlues,
+  interpolateBrBG,
+  interpolateBuGn,
+  interpolateBuPu,
+  interpolateCividis,
+  interpolateCool,
+  interpolateCubehelixDefault,
+  interpolateGnBu,
+  interpolateGreens,
+  interpolateGreys,
+  interpolateInferno,
+  interpolateMagma,
+  interpolateOranges,
+  interpolateOrRd,
+  interpolatePiYG,
+  interpolatePlasma,
+  interpolatePRGn,
+  interpolatePuBu,
+  interpolatePuOr,
+  interpolatePurples,
+  interpolateRainbow,
+  interpolateRdBu,
+  interpolateRdGy,
+  interpolateRdYlBu,
+  interpolateRdYlGn,
+  interpolateReds,
+  interpolateSinebow,
+  interpolateSpectral,
+  interpolateTurbo,
+  interpolateViridis,
+  interpolateWarm,
+  interpolateYlGn,
+  schemeAccent,
+  schemeBrBG,
+  schemeCategory10,
+  schemeDark2,
+  schemeGreys,
+  schemePaired,
+  schemePiYG,
+  schemePRGn,
+  schemePuBu,
+  schemeRdBu,
+  schemeRdGy,
+  schemeRdYlBu,
+  schemeRdYlGn,
+  schemeSet1,
+  schemeSet2,
+  schemeSet3,
+  schemeSpectral,
+  schemeTableau10,
+  schemeYlGn,
+} from 'd3-scale-chromatic'
+import { scaleOrdinal } from 'd3-scale'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Button } from 'primereact/button'
 import { InputText } from 'primereact/inputtext'
 import {
@@ -82,6 +138,76 @@ import menuStyles from './menu.module.css'
 import contextMenuStyles from './node-properties.module.css'
 import { handleClass, useHandleDimmed } from './op-components'
 import { MultiInputHandle } from './multi-input-handle'
+
+const JOBY_COLORS = [
+  '#FFB300',
+  '#EB6110',
+  '#E64839',
+  '#00994C',
+  '#883DF2',
+  '#7CC3FF',
+  '#3EC26A',
+  '#FF9058',
+  '#FFCC54',
+  '#B580FF',
+]
+
+const continuousInterpolators = {
+  viridis: interpolateViridis,
+  inferno: interpolateInferno,
+  plasma: interpolatePlasma,
+  magma: interpolateMagma,
+  turbo: interpolateTurbo,
+  cividis: interpolateCividis,
+  warm: interpolateWarm,
+  cool: interpolateCool,
+  cubehelix: interpolateCubehelixDefault,
+  spectral: interpolateSpectral,
+  rainbow: interpolateRainbow,
+  sinebow: interpolateSinebow,
+  blues: interpolateBlues,
+  greens: interpolateGreens,
+  greys: interpolateGreys,
+  reds: interpolateReds,
+  oranges: interpolateOranges,
+  purples: interpolatePurples,
+  joby: d3.interpolateRgbBasis(JOBY_COLORS),
+  PinkYellowGreen: interpolatePiYG,
+  PurpleOrange: interpolatePuOr,
+  RedBlue: interpolateRdBu,
+  RedGrey: interpolateRdGy,
+  RedYellowBlue: interpolateRdYlBu,
+  BlueGreen: interpolateBuGn,
+  BluePurple: interpolateBuPu,
+  GreenBlue: interpolateGnBu,
+  OrangeRed: interpolateOrRd,
+}
+
+const categoricalSchemesFixed = {
+  accent: schemeAccent,
+  category10: schemeCategory10,
+  dark: schemeDark2,
+  paired: schemePaired,
+  set1: schemeSet1,
+  set2: schemeSet2,
+  set3: schemeSet3,
+  tableau10: schemeTableau10,
+  joby: JOBY_COLORS,
+}
+
+const categoricalSchemesStepped = {
+  greyscale: schemeGreys,
+  BrownGreen: schemeBrBG,
+  PurpleGreen: schemePRGn,
+  PurpleBlue: schemePuBu,
+  PinkYellowGreen: schemePiYG,
+  RedBlue: schemeRdBu,
+  RedGrey: schemeRdGy,
+  RedYellowBlue: schemeRdYlBu,
+  RedYellowGreen: schemeRdYlGn,
+  YellowGreen: schemeYlGn,
+  spectral: schemeSpectral,
+}
 
 type InputComponent = React.ComponentType<{
   id: OpId
@@ -304,7 +430,20 @@ export function TextFieldComponent({
   if (field instanceof StringLiteralField) {
     const useTypeahead = field.choices.length > 0 && field.freeform
 
-    if (useTypeahead) {
+    if (field.displayAs === 'color-scheme') {
+      input = (
+        <ColorSchemeDropdown
+          choices={field.choices}
+          value={value}
+          onChange={newValue => {
+            captureStart()
+            field.setValue(newValue)
+            commitChange('Change color scheme')
+          }}
+          disabled={disabled}
+        />
+      )
+    } else if (useTypeahead) {
       input = (
         <StringLiteralTypeaheadInput
           id={id}
@@ -2186,6 +2325,92 @@ export function ColorFieldComponent({
   )
 }
 
+function ColorSchemePreview({ schemeName }: { schemeName: string }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const width = 100
+    const height = 16
+
+    if (schemeName in continuousInterpolators) {
+      const interpolator = continuousInterpolators[schemeName as keyof typeof continuousInterpolators]
+      for (let i = 0; i < width; i++) {
+        const t = i / (width - 1)
+        ctx.fillStyle = interpolator(t)
+        ctx.fillRect(i, 0, 1, height)
+      }
+    } else if (schemeName in categoricalSchemesFixed) {
+      const scheme = categoricalSchemesFixed[schemeName as keyof typeof categoricalSchemesFixed]
+      const blockWidth = width / scheme.length
+      scheme.forEach((color, i) => {
+        ctx.fillStyle = color
+        ctx.fillRect(i * blockWidth, 0, blockWidth, height)
+      })
+    } else if (schemeName in categoricalSchemesStepped) {
+      const schemes = categoricalSchemesStepped[schemeName as keyof typeof categoricalSchemesStepped]
+      const scheme = schemes[Math.min(8, schemes.length - 1)] as readonly string[]
+      const blockWidth = width / scheme.length
+      scheme.forEach((color, i) => {
+        ctx.fillStyle = color
+        ctx.fillRect(i * blockWidth, 0, blockWidth, height)
+      })
+    }
+  }, [schemeName])
+
+  return <canvas ref={canvasRef} className={s.colorSchemePreviewCanvas} width={100} height={16} />
+}
+
+function ColorSchemeDropdown({
+  choices,
+  value,
+  onChange,
+  disabled,
+  triggerElement,
+}: {
+  choices: { value: string; label: string }[]
+  value: string
+  onChange: (value: string) => void
+  disabled: boolean
+  triggerElement?: React.ReactNode
+}) {
+  const defaultTrigger = (
+    <button type="button" className={cx(s.fieldInput, s.fieldInputSelect)} disabled={disabled}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <ColorSchemePreview schemeName={value} />
+        <span>{choices.find(c => c.value === value)?.label || value}</span>
+      </div>
+    </button>
+  )
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild disabled={disabled}>
+        {triggerElement || defaultTrigger}
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={s.colorSchemeDropdownContent} sideOffset={4}>
+          {choices.map(choice => (
+            <DropdownMenu.Item
+              key={choice.value}
+              className={s.colorSchemeDropdownItem}
+              onSelect={() => onChange(choice.value)}
+            >
+              <ColorSchemePreview schemeName={choice.value} />
+              <span className={s.colorSchemeName}>{choice.label}</span>
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
 export function ColorRampComponent({
   id,
   field,
@@ -2207,11 +2432,6 @@ export function ColorRampComponent({
     return () => sub.unsubscribe()
   }, [field])
 
-  const _onChange = e => {
-    if (disabled) return
-    field.setValue(e.currentTarget.value)
-  }
-
   const canvasRef = useRef<HTMLCanvasElement>(null)
   useEffect(() => {
     const canvas = canvasRef.current
@@ -2220,14 +2440,6 @@ export function ColorRampComponent({
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
-    // const gradient = ctx.createLinearGradient(0, 0, 200, 0)
-    // gradient.addColorStop(0, 'red')
-    // gradient.addColorStop(0.5, 'green')
-    // gradient.addColorStop(1, 'blue')
-
-    // ctx.fillStyle = gradient
-    // ctx.fillRect(0, 0, 200, 100)
-
     for (let i = 0; i < steps; ++i) {
       const val = field instanceof CategoricalColorRampField ? `${id}-${i}` : i / (steps - 1)
       ctx.fillStyle = interpolate(val)
@@ -2235,6 +2447,49 @@ export function ColorRampComponent({
     }
   }, [interpolate, field, id, steps])
 
+  // Check for sibling colorScheme field
+  const colorSchemeField = useMemo(() => {
+    const op = field.op
+    if (!op) return null
+    const csField = op.inputs.colorScheme
+    return csField instanceof StringLiteralField && csField.displayAs === 'color-scheme'
+      ? csField
+      : null
+  }, [field.op])
+
+  const { captureStart, commitChange } = usePropertyHistory()
+
+  if (colorSchemeField) {
+    // Render clickable canvas with dropdown
+    const triggerElement = (
+      <button
+        type="button"
+        className={s.fieldInputColorRampButton}
+        disabled={disabled}
+        title="Click to change color scheme"
+      >
+        <canvas ref={canvasRef} className={s.fieldInputColorRamp} width={steps} height={1} />
+      </button>
+    )
+
+    return (
+      <div className={cx(s.fieldWrapper, 'nokey')}>
+        <ColorSchemeDropdown
+          choices={colorSchemeField.choices}
+          value={colorSchemeField.value}
+          onChange={newValue => {
+            captureStart()
+            colorSchemeField.setValue(newValue)
+            commitChange('Change color scheme')
+          }}
+          disabled={disabled}
+          triggerElement={triggerElement}
+        />
+      </div>
+    )
+  }
+
+  // Fallback: read-only canvas (existing behavior)
   return (
     <div className={cx(s.fieldWrapper, 'nokey')}>
       <canvas className={s.fieldInputColorRamp} ref={canvasRef} width={steps} height={1} />

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -4,61 +4,6 @@ import { Cross2Icon } from '@radix-ui/react-icons'
 import { Handle, Position, useEdges, useNodeId, useReactFlow } from '@xyflow/react'
 import cx from 'classnames'
 import type { ScaleLinear, ScaleOrdinal } from 'd3'
-import * as d3 from 'd3'
-import {
-  interpolateBlues,
-  interpolateBrBG,
-  interpolateBuGn,
-  interpolateBuPu,
-  interpolateCividis,
-  interpolateCool,
-  interpolateCubehelixDefault,
-  interpolateGnBu,
-  interpolateGreens,
-  interpolateGreys,
-  interpolateInferno,
-  interpolateMagma,
-  interpolateOranges,
-  interpolateOrRd,
-  interpolatePiYG,
-  interpolatePlasma,
-  interpolatePRGn,
-  interpolatePuBu,
-  interpolatePuOr,
-  interpolatePurples,
-  interpolateRainbow,
-  interpolateRdBu,
-  interpolateRdGy,
-  interpolateRdYlBu,
-  interpolateRdYlGn,
-  interpolateReds,
-  interpolateSinebow,
-  interpolateSpectral,
-  interpolateTurbo,
-  interpolateViridis,
-  interpolateWarm,
-  interpolateYlGn,
-  schemeAccent,
-  schemeBrBG,
-  schemeCategory10,
-  schemeDark2,
-  schemeGreys,
-  schemePaired,
-  schemePiYG,
-  schemePRGn,
-  schemePuBu,
-  schemeRdBu,
-  schemeRdGy,
-  schemeRdYlBu,
-  schemeRdYlGn,
-  schemeSet1,
-  schemeSet2,
-  schemeSet3,
-  schemeSpectral,
-  schemeTableau10,
-  schemeYlGn,
-} from 'd3-scale-chromatic'
-import { scaleOrdinal } from 'd3-scale'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Button } from 'primereact/button'
 import { InputText } from 'primereact/inputtext'
@@ -138,76 +83,12 @@ import menuStyles from './menu.module.css'
 import contextMenuStyles from './node-properties.module.css'
 import { handleClass, useHandleDimmed } from './op-components'
 import { MultiInputHandle } from './multi-input-handle'
-
-const JOBY_COLORS = [
-  '#FFB300',
-  '#EB6110',
-  '#E64839',
-  '#00994C',
-  '#883DF2',
-  '#7CC3FF',
-  '#3EC26A',
-  '#FF9058',
-  '#FFCC54',
-  '#B580FF',
-]
-
-const continuousInterpolators = {
-  viridis: interpolateViridis,
-  inferno: interpolateInferno,
-  plasma: interpolatePlasma,
-  magma: interpolateMagma,
-  turbo: interpolateTurbo,
-  cividis: interpolateCividis,
-  warm: interpolateWarm,
-  cool: interpolateCool,
-  cubehelix: interpolateCubehelixDefault,
-  spectral: interpolateSpectral,
-  rainbow: interpolateRainbow,
-  sinebow: interpolateSinebow,
-  blues: interpolateBlues,
-  greens: interpolateGreens,
-  greys: interpolateGreys,
-  reds: interpolateReds,
-  oranges: interpolateOranges,
-  purples: interpolatePurples,
-  joby: d3.interpolateRgbBasis(JOBY_COLORS),
-  PinkYellowGreen: interpolatePiYG,
-  PurpleOrange: interpolatePuOr,
-  RedBlue: interpolateRdBu,
-  RedGrey: interpolateRdGy,
-  RedYellowBlue: interpolateRdYlBu,
-  BlueGreen: interpolateBuGn,
-  BluePurple: interpolateBuPu,
-  GreenBlue: interpolateGnBu,
-  OrangeRed: interpolateOrRd,
-}
-
-const categoricalSchemesFixed = {
-  accent: schemeAccent,
-  category10: schemeCategory10,
-  dark: schemeDark2,
-  paired: schemePaired,
-  set1: schemeSet1,
-  set2: schemeSet2,
-  set3: schemeSet3,
-  tableau10: schemeTableau10,
-  joby: JOBY_COLORS,
-}
-
-const categoricalSchemesStepped = {
-  greyscale: schemeGreys,
-  BrownGreen: schemeBrBG,
-  PurpleGreen: schemePRGn,
-  PurpleBlue: schemePuBu,
-  PinkYellowGreen: schemePiYG,
-  RedBlue: schemeRdBu,
-  RedGrey: schemeRdGy,
-  RedYellowBlue: schemeRdYlBu,
-  RedYellowGreen: schemeRdYlGn,
-  YellowGreen: schemeYlGn,
-  spectral: schemeSpectral,
-}
+import {
+  categoricalSchemesFixed,
+  categoricalSchemesStepped,
+  continuousInterpolators,
+  renderColorScheme,
+} from '../color-schemes'
 
 type InputComponent = React.ComponentType<{
   id: OpId
@@ -431,6 +312,12 @@ export function TextFieldComponent({
     const useTypeahead = field.choices.length > 0 && field.freeform
 
     if (field.displayAs === 'color-scheme') {
+      // Get step count for categorical ramps
+      const stepCount =
+        field.op && 'steps' in field.op.inputs
+          ? (field.op.inputs.steps?.value as number | undefined)
+          : undefined
+
       input = (
         <ColorSchemeDropdown
           choices={field.choices}
@@ -441,6 +328,7 @@ export function TextFieldComponent({
             commitChange('Change color scheme')
           }}
           disabled={disabled}
+          stepCount={stepCount}
         />
       )
     } else if (useTypeahead) {
@@ -2325,7 +2213,13 @@ export function ColorFieldComponent({
   )
 }
 
-function ColorSchemePreview({ schemeName }: { schemeName: string }) {
+function ColorSchemePreview({
+  schemeName,
+  stepCount = 8,
+}: {
+  schemeName: string
+  stepCount?: number
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -2335,33 +2229,8 @@ function ColorSchemePreview({ schemeName }: { schemeName: string }) {
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
-    const width = 100
-    const height = 16
-
-    if (schemeName in continuousInterpolators) {
-      const interpolator = continuousInterpolators[schemeName as keyof typeof continuousInterpolators]
-      for (let i = 0; i < width; i++) {
-        const t = i / (width - 1)
-        ctx.fillStyle = interpolator(t)
-        ctx.fillRect(i, 0, 1, height)
-      }
-    } else if (schemeName in categoricalSchemesFixed) {
-      const scheme = categoricalSchemesFixed[schemeName as keyof typeof categoricalSchemesFixed]
-      const blockWidth = width / scheme.length
-      scheme.forEach((color, i) => {
-        ctx.fillStyle = color
-        ctx.fillRect(i * blockWidth, 0, blockWidth, height)
-      })
-    } else if (schemeName in categoricalSchemesStepped) {
-      const schemes = categoricalSchemesStepped[schemeName as keyof typeof categoricalSchemesStepped]
-      const scheme = schemes[Math.min(8, schemes.length - 1)] as readonly string[]
-      const blockWidth = width / scheme.length
-      scheme.forEach((color, i) => {
-        ctx.fillStyle = color
-        ctx.fillRect(i * blockWidth, 0, blockWidth, height)
-      })
-    }
-  }, [schemeName])
+    renderColorScheme(ctx, schemeName, 100, 16, stepCount)
+  }, [schemeName, stepCount])
 
   return <canvas ref={canvasRef} className={s.colorSchemePreviewCanvas} width={100} height={16} />
 }
@@ -2372,17 +2241,19 @@ function ColorSchemeDropdown({
   onChange,
   disabled,
   triggerElement,
+  stepCount,
 }: {
   choices: { value: string; label: string }[]
   value: string
   onChange: (value: string) => void
   disabled: boolean
   triggerElement?: React.ReactNode
+  stepCount?: number
 }) {
   const defaultTrigger = (
     <button type="button" className={cx(s.fieldInput, s.fieldInputSelect)} disabled={disabled}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-        <ColorSchemePreview schemeName={value} />
+        <ColorSchemePreview schemeName={value} stepCount={stepCount} />
         <span>{choices.find(c => c.value === value)?.label || value}</span>
       </div>
     </button>
@@ -2401,7 +2272,7 @@ function ColorSchemeDropdown({
               className={s.colorSchemeDropdownItem}
               onSelect={() => onChange(choice.value)}
             >
-              <ColorSchemePreview schemeName={choice.value} />
+              <ColorSchemePreview schemeName={choice.value} stepCount={stepCount} />
               <span className={s.colorSchemeName}>{choice.label}</span>
             </DropdownMenu.Item>
           ))}
@@ -2457,6 +2328,13 @@ export function ColorRampComponent({
       : null
   }, [field.op])
 
+  // Get step count for categorical ramps
+  const stepCount = useMemo(() => {
+    const op = field.op
+    if (!op || !('steps' in op.inputs)) return undefined
+    return op.inputs.steps?.value as number | undefined
+  }, [field.op])
+
   const { captureStart, commitChange } = usePropertyHistory()
 
   if (colorSchemeField) {
@@ -2484,6 +2362,7 @@ export function ColorRampComponent({
           }}
           disabled={disabled}
           triggerElement={triggerElement}
+          stepCount={stepCount}
         />
       </div>
     )

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -2294,7 +2294,13 @@ export function ColorRampComponent({
   const [interpolate, setInterpolate] = useState<
     ScaleOrdinal<string, string> | ScaleLinear<number, string>
   >(() => field.value)
-  const steps = field instanceof CategoricalColorRampField ? field.count : 512
+
+  // For categorical ramps, get count from the scale's domain length
+  // For continuous ramps, use a fixed pixel width
+  const steps =
+    field instanceof CategoricalColorRampField && 'domain' in interpolate
+      ? (interpolate as ScaleOrdinal<string, string>).domain().length
+      : 512
 
   useEffect(() => {
     const sub = field.subscribe(newVal => {

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -67,6 +67,7 @@ type CompoundPropsFieldOptions = BaseFieldOptions &
 type StringLiteralFieldOptions = BaseFieldOptions & {
   values: string[] | Record<string, unknown> | { value: unknown; label: string }[]
   freeform?: boolean
+  displayAs?: 'select' | 'typeahead' | 'color-scheme'
 }
 
 type CodeFieldOptions = BaseFieldOptions & {
@@ -605,6 +606,7 @@ export class StringLiteralField extends Field<
   static defaultValue = ''
   choices: StringLiteralOption[] = []
   freeform = false
+  displayAs?: 'select' | 'typeahead' | 'color-scheme'
   createSchema(options: Partial<StringLiteralFieldOptions>) {
     const values = (options.values || []) as StringLiteralOption[]
     const freeform = options.freeform ?? false
@@ -622,6 +624,7 @@ export class StringLiteralField extends Field<
     super(override, { ...(Array.isArray(opts) ? {} : opts), values: choices })
     this.choices = choices
     this.freeform = !Array.isArray(opts) && (opts?.freeform ?? false)
+    this.displayAs = !Array.isArray(opts) ? opts?.displayAs : undefined
   }
 
   updateChoices(opts: Partial<StringLiteralFieldOptions> | StringLiteralOption[] | string[]) {

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -1333,3 +1333,68 @@
   background-color: transparent !important;
   border: none !important;
 }
+
+/* Color scheme dropdown styles */
+.fieldInputColorRampButton {
+  width: 100%;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 2px;
+  background: rgba(255, 255, 255, 0.05);
+  transition: all 0.2s;
+}
+
+.fieldInputColorRampButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.fieldInputColorRampButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.colorSchemeDropdownContent {
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 4px;
+  max-height: 400px;
+  overflow-y: auto;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.colorSchemeDropdownItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s;
+  outline: none;
+}
+
+.colorSchemeDropdownItem:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.colorSchemeDropdownItem[data-highlighted] {
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.colorSchemePreviewCanvas {
+  width: 100px;
+  height: 16px;
+  border-radius: 3px;
+  image-rendering: auto;
+  flex-shrink: 0;
+}
+
+.colorSchemeName {
+  flex: 1;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.9);
+}

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -1789,7 +1789,10 @@ export class ColorRampOp extends Operator<ColorRampOp> {
       OrangeRed: interpolateOrRd,
     }
 
-    const colorScheme = new StringLiteralField('viridis', Object.keys(interpolators))
+    const colorScheme = new StringLiteralField('viridis', {
+      values: Object.keys(interpolators),
+      displayAs: 'color-scheme',
+    })
 
     colorScheme.subscribe(val => {
       const interpolate = interpolators[val as keyof typeof interpolators]
@@ -1863,7 +1866,10 @@ export class CategoricalColorRampOp extends Operator<CategoricalColorRampOp> {
 
     const allSchemeNames = [...Object.keys(fixedSchemes), ...Object.keys(steppedSchemes)]
 
-    const colorScheme = new StringLiteralField('accent', allSchemeNames)
+    const colorScheme = new StringLiteralField('accent', {
+      values: allSchemeNames,
+      displayAs: 'color-scheme',
+    })
     const steps = new NumberField(8, { min: 3, max: 11, step: 1 })
 
     const updateRamp = () => {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -70,54 +70,8 @@ import {
   color as d3Color,
   hsl,
   interpolate,
-  interpolateBlues,
-  interpolateBuGn,
-  interpolateBuPu,
-  interpolateCividis,
-  interpolateCool,
-  interpolateCubehelixDefault,
-  interpolateGnBu,
-  interpolateGreens,
-  interpolateGreys,
-  interpolateInferno,
-  interpolateMagma,
-  interpolateOranges,
-  interpolateOrRd,
-  interpolatePiYG,
-  interpolatePlasma,
-  interpolatePuOr,
-  interpolatePurples,
-  interpolateRainbow,
-  interpolateRdBu,
-  interpolateRdGy,
-  interpolateRdYlBu,
-  interpolateReds,
-  interpolateSinebow,
-  interpolateSpectral,
-  interpolateTurbo,
-  interpolateViridis,
-  interpolateWarm,
   scaleLinear,
   scaleOrdinal,
-  schemeAccent,
-  schemeBrBG,
-  schemeCategory10,
-  schemeDark2,
-  schemeGreys,
-  schemePaired,
-  schemePiYG,
-  schemePRGn,
-  schemePuBu,
-  schemeRdBu,
-  schemeRdGy,
-  schemeRdYlBu,
-  schemeRdYlGn,
-  schemeSet1,
-  schemeSet2,
-  schemeSet3,
-  schemeSpectral,
-  schemeTableau10,
-  schemeYlGn,
   tsv,
   tsvParse,
 } from 'd3'
@@ -145,6 +99,11 @@ import {
 import { CARTO_DARK, MAP_STYLES } from '../utils/map-styles'
 import { mulberry32 } from '../utils/random'
 import { sqlIdentifier, sqlLiteral } from '../utils/sql'
+import {
+  categoricalSchemesFixed,
+  categoricalSchemesStepped,
+  continuousInterpolators,
+} from './color-schemes'
 import { FilterColorExtension } from './extensions/filter-color-extension'
 import { Mask3DExtension } from './extensions/mask-3d-extension'
 import {
@@ -1734,68 +1693,19 @@ export class HSLOp extends Operator<HSLOp> {
   }
 }
 
-const JOBY_COLORS = [
-  '#FFB300', // Joby Yellow
-  '#EB6110', // Joby Orange
-  '#E64839', // Joby Red
-  '#00994C', // Joby Green
-  '#883DF2', // Joby Purple
-  '#7CC3FF', // Joby Light Blue
-  '#3EC26A', // Joby Light Green
-  '#FF9058', // Joby Light Orange
-  '#FFCC54', // Joby Light Yellow
-  '#B580FF', // Joby Light Purple
-]
-
 export class ColorRampOp extends Operator<ColorRampOp> {
   static displayName = 'ColorRamp'
   static description = 'Interpolate a color from a color ramp, value range 0-1'
   createInputs() {
     const colorRamp = new ColorRampField()
 
-    const interpolators = {
-      viridis: interpolateViridis,
-      inferno: interpolateInferno,
-      plasma: interpolatePlasma,
-      magma: interpolateMagma,
-      turbo: interpolateTurbo,
-      cividis: interpolateCividis,
-
-      warm: interpolateWarm,
-      cool: interpolateCool,
-      cubehelix: interpolateCubehelixDefault,
-      spectral: interpolateSpectral,
-
-      rainbow: interpolateRainbow,
-      sinebow: interpolateSinebow,
-
-      blues: interpolateBlues,
-      greens: interpolateGreens,
-      greys: interpolateGreys,
-      reds: interpolateReds,
-      oranges: interpolateOranges,
-      purples: interpolatePurples,
-
-      joby: d3.interpolateRgbBasis(JOBY_COLORS),
-
-      PinkYellowGreen: interpolatePiYG,
-      PurpleOrange: interpolatePuOr,
-      RedBlue: interpolateRdBu,
-      RedGrey: interpolateRdGy,
-      RedYellowBlue: interpolateRdYlBu,
-      BlueGreen: interpolateBuGn,
-      BluePurple: interpolateBuPu,
-      GreenBlue: interpolateGnBu,
-      OrangeRed: interpolateOrRd,
-    }
-
     const colorScheme = new StringLiteralField('viridis', {
-      values: Object.keys(interpolators),
+      values: Object.keys(continuousInterpolators),
       displayAs: 'color-scheme',
     })
 
     colorScheme.subscribe(val => {
-      const interpolate = interpolators[val as keyof typeof interpolators]
+      const interpolate = continuousInterpolators[val as keyof typeof continuousInterpolators]
       colorRamp.setValue(interpolate)
     })
 
@@ -1838,33 +1748,10 @@ export class CategoricalColorRampOp extends Operator<CategoricalColorRampOp> {
   createInputs() {
     const colorRamp = new CategoricalColorRampField()
 
-    const fixedSchemes = {
-      accent: schemeAccent,
-      category10: schemeCategory10,
-      dark: schemeDark2,
-      paired: schemePaired,
-      set1: schemeSet1,
-      set2: schemeSet2,
-      set3: schemeSet3,
-      tableau10: schemeTableau10,
-      joby: JOBY_COLORS,
-    }
-
-    const steppedSchemes = {
-      greyscale: schemeGreys,
-      BrownGreen: schemeBrBG,
-      PurpleGreen: schemePRGn,
-      PurpleBlue: schemePuBu,
-      PinkYellowGreen: schemePiYG,
-      RedBlue: schemeRdBu,
-      RedGrey: schemeRdGy,
-      RedYellowBlue: schemeRdYlBu,
-      RedYellowGreen: schemeRdYlGn,
-      YellowGreen: schemeYlGn,
-      spectral: schemeSpectral,
-    }
-
-    const allSchemeNames = [...Object.keys(fixedSchemes), ...Object.keys(steppedSchemes)]
+    const allSchemeNames = [
+      ...Object.keys(categoricalSchemesFixed),
+      ...Object.keys(categoricalSchemesStepped),
+    ]
 
     const colorScheme = new StringLiteralField('accent', {
       values: allSchemeNames,
@@ -1876,11 +1763,12 @@ export class CategoricalColorRampOp extends Operator<CategoricalColorRampOp> {
       const schemeName = colorScheme.value
       const n = Math.max(Math.round(steps.value), 3)
       let scheme: readonly string[]
-      if (schemeName in fixedSchemes) {
-        const full = fixedSchemes[schemeName as keyof typeof fixedSchemes]
+      if (schemeName in categoricalSchemesFixed) {
+        const full = categoricalSchemesFixed[schemeName as keyof typeof categoricalSchemesFixed]
         scheme = full.slice(0, Math.min(n, full.length))
       } else {
-        const steppedScheme = steppedSchemes[schemeName as keyof typeof steppedSchemes]
+        const steppedScheme =
+          categoricalSchemesStepped[schemeName as keyof typeof categoricalSchemesStepped]
         const clamped = Math.min(n, steppedScheme.length - 1)
         scheme = steppedScheme[clamped] as readonly string[]
       }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -1697,22 +1697,14 @@ export class ColorRampOp extends Operator<ColorRampOp> {
   static displayName = 'ColorRamp'
   static description = 'Interpolate a color from a color ramp, value range 0-1'
   createInputs() {
-    const colorRamp = new ColorRampField()
-
     const colorScheme = new StringLiteralField('viridis', {
       values: Object.keys(continuousInterpolators),
       displayAs: 'color-scheme',
     })
 
-    colorScheme.subscribe(val => {
-      const interpolate = continuousInterpolators[val as keyof typeof continuousInterpolators]
-      colorRamp.setValue(interpolate)
-    })
-
     const value = new NumberField(0, { min: 0, max: 1, step: 0.01, accessor: true })
 
     return {
-      colorRamp,
       colorScheme,
       value,
     }
@@ -1724,14 +1716,16 @@ export class ColorRampOp extends Operator<ColorRampOp> {
     }
   }
   execute({
-    colorRamp,
-    colorScheme: _,
+    colorScheme,
     value,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    // Get the interpolator for the selected scheme
+    const interpolate = continuousInterpolators[colorScheme as keyof typeof continuousInterpolators]
+
     // Normalize all color formats to hex for consistency
     // TODO: VIS-813: Make all colors d3 Colors?
     const normalizedRamp = (val: number) => {
-      const c = colorRamp(val)
+      const c = interpolate(val)
       return d3Color(c)?.formatHex() ?? c
     }
 
@@ -1746,8 +1740,6 @@ export class CategoricalColorRampOp extends Operator<CategoricalColorRampOp> {
   static displayName = 'CategoricalColorRamp'
   static description = 'Map a string category to a color'
   createInputs() {
-    const colorRamp = new CategoricalColorRampField()
-
     const allSchemeNames = [
       ...Object.keys(categoricalSchemesFixed),
       ...Object.keys(categoricalSchemesStepped),
@@ -1759,31 +1751,9 @@ export class CategoricalColorRampOp extends Operator<CategoricalColorRampOp> {
     })
     const steps = new NumberField(8, { min: 3, max: 11, step: 1 })
 
-    const updateRamp = () => {
-      const schemeName = colorScheme.value
-      const n = Math.max(Math.round(steps.value), 3)
-      let scheme: readonly string[]
-      if (schemeName in categoricalSchemesFixed) {
-        const full = categoricalSchemesFixed[schemeName as keyof typeof categoricalSchemesFixed]
-        scheme = full.slice(0, Math.min(n, full.length))
-      } else {
-        const steppedScheme =
-          categoricalSchemesStepped[schemeName as keyof typeof categoricalSchemesStepped]
-        const clamped = Math.min(n, steppedScheme.length - 1)
-        scheme = steppedScheme[clamped] as readonly string[]
-      }
-      const interpolate = scaleOrdinal(scheme)
-      colorRamp.count = scheme.length
-      colorRamp.setValue(interpolate)
-    }
-
-    colorScheme.subscribe(updateRamp)
-    steps.subscribe(updateRamp)
-
     const value = new StringField('', { accessor: true })
 
     return {
-      colorRamp,
       colorScheme,
       steps,
       value,
@@ -1792,12 +1762,29 @@ export class CategoricalColorRampOp extends Operator<CategoricalColorRampOp> {
   createOutputs() {
     return {
       color: new ColorField(),
+      colorRamp: new CategoricalColorRampField(),
     }
   }
   execute({
-    colorRamp,
+    colorScheme,
+    steps,
     value,
   }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    // Derive the color scheme from colorScheme and steps
+    const schemeName = colorScheme
+    const n = Math.max(Math.round(steps), 3)
+    let scheme: readonly string[]
+    if (schemeName in categoricalSchemesFixed) {
+      const full = categoricalSchemesFixed[schemeName as keyof typeof categoricalSchemesFixed]
+      scheme = full.slice(0, Math.min(n, full.length))
+    } else {
+      const steppedScheme =
+        categoricalSchemesStepped[schemeName as keyof typeof categoricalSchemesStepped]
+      const clamped = Math.min(n, steppedScheme.length - 1)
+      scheme = steppedScheme[clamped] as readonly string[]
+    }
+    const colorRamp = scaleOrdinal(scheme)
+
     const scale = (val: string) => {
       const color = colorRamp(val)
 
@@ -1809,7 +1796,7 @@ export class CategoricalColorRampOp extends Operator<CategoricalColorRampOp> {
     // Use composeAccessor helper to handle both static values and accessor functions
     const color = composeAccessor(value, scale)
 
-    return { color }
+    return { color, colorRamp }
   }
 }
 


### PR DESCRIPTION
#### Background

The color scheme selector in ColorRampOp and CategoricalColorRampOp used a plain HTML select dropdown, making it difficult to distinguish between similar color schemes (e.g., diverging palettes) without trial and error. This enhancement replaces it with a rich visual dropdown similar to kepler.gl's color picker.

#### Change List
- Add `colorScheme` metadata option to StringLiteralField for marking color scheme pickers
- Create ColorSchemeDropdown component using Radix UI DropdownMenu with visual canvas previews
- Import and map all d3 continuous interpolators (viridis, plasma, magma, etc.) and categorical schemes (accent, set1, tableau10, etc.)
- Update ColorRampOp and CategoricalColorRampOp to enable rich picker via metadata
- Make ColorRampField preview canvas clickable to trigger the dropdown when a sibling colorScheme field exists
- Add dark theme CSS styles for dropdown, preview canvases, and hover/focus states
- Render appropriate previews for continuous (gradient) and categorical (color blocks) schemes

Before:
<img width="409" height="394" alt="image" src="https://github.com/user-attachments/assets/102c288f-db4d-4edc-808d-708252725704" />


After:
<img width="378" height="512" alt="image" src="https://github.com/user-attachments/assets/71b8c51b-0487-47e6-8d90-70701fb78a59" />
