### PR TITLE
Fix tool shelf horizontal shifting when assistant button toggles

### DIFF
--- a/noodles-editor/src/noodles/components/tools/tool-shelf.module.css
+++ b/noodles-editor/src/noodles/components/tools/tool-shelf.module.css
@@ -6,7 +6,8 @@
      sections around, so it takes the space between them and no more. */
   flex: 1 1 auto;
   min-width: 0;
-  justify-content: center;
+  justify-content: flex-start;
+  padding-left: 16px;
 }
 
 .button,

--- a/noodles-editor/src/noodles/components/tools/tool-shelf.tsx
+++ b/noodles-editor/src/noodles/components/tools/tool-shelf.tsx
@@ -37,6 +37,8 @@ const SOURCE_RECIPES = GEO_RECIPES.filter(recipe => recipe.group === 'source')
 // Space kept clear for the always-visible items (Import, Point, Draw, Measure, Add Op)
 const RESERVED_WIDTH = 330
 const GAP = 4
+// Left padding on the shelf container (must match tool-shelf.module.css)
+const SHELF_PADDING_LEFT = 16
 
 export function ToolShelf({
   onOpenAddNode,
@@ -68,7 +70,7 @@ export function ToolShelf({
     const measurer = measureRef.current
     if (!row || !measurer) return
     const widths = Array.from(measurer.children).map(child => child.getBoundingClientRect().width)
-    const available = row.getBoundingClientRect().width - RESERVED_WIDTH
+    const available = row.getBoundingClientRect().width - RESERVED_WIDTH - SHELF_PADDING_LEFT
     const moreWidth = moreMeasureRef.current?.getBoundingClientRect().width ?? 0
     setLayout(computeShelfLayout(widths, available, GAP, moreWidth))
   }, [])

--- a/noodles-editor/src/noodles/components/top-menu-bar.module.css
+++ b/noodles-editor/src/noodles/components/top-menu-bar.module.css
@@ -110,6 +110,7 @@
   color: var(--color-text-primary);
   transition: all 0.15s;
   white-space: nowrap;
+  min-width: 95px;
 }
 
 .assistantButton:hover {


### PR DESCRIPTION
#### Background

The assistant button toggles between \"Assistant\" and \"Hide\" text, causing a ~25px width change. This made the tool shelf buttons shift horizontally because the shelf was centered and its available space changed when the right section resized.

#### Change List
- Left-align tool shelf with `justify-content: flex-start` and 16px left padding for stable tool positions
- Add `min-width: 95px` to assistant button to prevent visual resize
- Maintains all existing overflow and responsive behavior