### PR TITLE
Enable PostHog session recordings

### DIFF
--- a/noodles-editor/src/utils/analytics.ts
+++ b/noodles-editor/src/utils/analytics.ts
@@ -55,7 +55,6 @@ export class AnalyticsManager {
         api_host: POSTHOG_HOST,
         opt_out_capturing_by_default: consent?.enabled === false, // only opt out if explicitly declined
         autocapture: false, // Privacy: manual events only
-        disable_session_recording: true, // Privacy: no session recording
         capture_pageview: true, // Captures initial page load; route changes tracked manually
         capture_pageleave: true,
         capture_exceptions: true, // Capture unhandled exceptions

--- a/website/posthog-plugin/index.js
+++ b/website/posthog-plugin/index.js
@@ -1,35 +1,34 @@
-const path = require('path')
+const path = require("path");
 
 module.exports = function posthogPlugin(_context, options) {
-  const { apiKey, host = 'https://us.i.posthog.com' } = options
+	const { apiKey, host = "https://us.i.posthog.com" } = options;
 
-  return {
-    name: 'docusaurus-plugin-posthog',
+	return {
+		name: "docusaurus-plugin-posthog",
 
-    injectHtmlTags() {
-      if (!apiKey) return {}
-      return {
-        headTags: [
-          {
-            tagName: 'script',
-            innerHTML: `
+		injectHtmlTags() {
+			if (!apiKey) return {};
+			return {
+				headTags: [
+					{
+						tagName: "script",
+						innerHTML: `
               !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
               posthog.init(${JSON.stringify(apiKey)}, {
                 api_host: ${JSON.stringify(host)},
                 capture_pageview: true,
                 capture_pageleave: true,
                 autocapture: true,
-                disable_session_recording: true,
                 person_profiles: 'never',
               });
             `,
-          },
-        ],
-      }
-    },
+					},
+				],
+			};
+		},
 
-    getClientModules() {
-      return [path.resolve(__dirname, './client.js')]
-    },
-  }
-}
+		getClientModules() {
+			return [path.resolve(__dirname, "./client.js")];
+		},
+	};
+};


### PR DESCRIPTION
## Summary
- Remove `disable_session_recording: true` from PostHog config in editor app
- Remove `disable_session_recording: true` from PostHog config in website

## Test plan
- [ ] Verify session recordings appear in PostHog after deploying
- [ ] Confirm no console errors from PostHog SDK
- [ ] Check that opt-out still respects user privacy preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)