### PR TITLE
Fix container rename deleting hidden children

### DIFF
--- a/noodles-editor/src/noodles/components/__tests__/container-op-component.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/container-op-component.test.tsx
@@ -1,8 +1,9 @@
 // Test for ContainerOpComponent children count reactivity
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import type { Node as ReactFlowNode } from '@xyflow/react'
 import { ReactFlowProvider } from '@xyflow/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProjectModificationActionsProvider } from '../../contexts/project-modification-actions-context'
 import type { ContainerOp } from '../../operators'
 import { clearOps, deleteOp, getOp } from '../../store'
 import { transformGraph } from '../../transform-graph'
@@ -24,26 +25,57 @@ describe('ContainerOpComponent children count reactivity', () => {
   }
 
   // Helper to render ContainerOpComponent within the required contexts
-  const renderContainerOpComponent = (containerId: string) => {
+  const renderContainerOpComponent = (
+    containerId: string,
+    updateOperatorId = vi.fn()
+  ) => {
     const containerOp = getOp(containerId) as ContainerOp
     expect(containerOp).toBeDefined()
 
     const ContainerComponent = nodeComponents.ContainerOp
 
     return render(
-      <ReactFlowProvider>
-        <ContainerComponent
-          id={containerId}
-          type="ContainerOp"
-          selected={false}
-          data={{ inputs: {} }}
-          isConnectable={true}
-          zIndex={0}
-          dragging={false}
-        />
-      </ReactFlowProvider>
+      <ProjectModificationActionsProvider updateOperatorId={updateOperatorId}>
+        <ReactFlowProvider>
+          <ContainerComponent
+            id={containerId}
+            type="ContainerOp"
+            selected={false}
+            data={{ inputs: {} }}
+            isConnectable={true}
+            zIndex={0}
+            dragging={false}
+          />
+        </ReactFlowProvider>
+      </ProjectModificationActionsProvider>
     )
   }
+
+  it('routes header renames through the canonical project mutation action', () => {
+    setupGraph([
+      {
+        id: '/my-container',
+        type: 'ContainerOp',
+        position: { x: 0, y: 0 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/my-container/child',
+        type: 'NumberOp',
+        position: { x: 100, y: 100 },
+        data: { inputs: { val: 42 } },
+      },
+    ])
+    const updateOperatorId = vi.fn()
+    const view = renderContainerOpComponent('/my-container', updateOperatorId)
+
+    fireEvent.doubleClick(view.getByRole('button', { name: 'my-container' }))
+    const input = view.getByDisplayValue('my-container')
+    fireEvent.change(input, { target: { value: 'scale-container' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(updateOperatorId).toHaveBeenCalledWith('/my-container', 'scale-container', true)
+  })
 
   it('displays initial children count of 0 for empty container', () => {
     const nodes = [

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -58,12 +58,12 @@ import {
   getOp,
   hasOp,
   setHoveredOutputHandle,
-  updateOperatorId,
   useEdgeConnectionStore,
   useNestingStore,
   useOperatorStore,
   useUIStore,
 } from '../store'
+import { useProjectModificationActions } from '../contexts/project-modification-actions-context'
 import { inferSchema, type TableSchema } from '../table-schema'
 import type { NodeDataJSON } from '../transform-graph'
 import { canConnect } from '../utils/can-connect'
@@ -1310,7 +1310,7 @@ export function NodeHeader({
   const [editing, setEditing] = useState(false)
   const [inputValue, setInputValue] = useState('')
   const [hasConflict, setHasConflict] = useState(false)
-  const { setNodes, setEdges } = useReactFlow()
+  const { updateOperatorId } = useProjectModificationActions()
 
   const checkForConflict = useCallback(
     (newBaseName: string): boolean => {
@@ -1354,14 +1354,14 @@ export function NodeHeader({
         const isContainer = type === 'ContainerOp'
 
         // Call the store function to update the operator
-        updateOperatorId(id, trimmedName, isContainer, setNodes, setEdges)
+        updateOperatorId(id, trimmedName, isContainer)
       }
 
       setEditing(false)
       setHasConflict(false)
       setInputValue('')
     },
-    [id, type, baseName, setNodes, setEdges, checkForConflict]
+    [id, type, baseName, updateOperatorId, checkForConflict]
   )
 
   const onInputChange = useCallback(

--- a/noodles-editor/src/noodles/contexts/project-modification-actions-context.tsx
+++ b/noodles-editor/src/noodles/contexts/project-modification-actions-context.tsx
@@ -1,0 +1,38 @@
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+
+export type UpdateOperatorId = (
+  nodeId: string,
+  newBaseName: string,
+  isContainer: boolean
+) => void
+
+interface ProjectModificationActions {
+  updateOperatorId: UpdateOperatorId
+}
+
+const missingProvider = () => {
+  throw new Error('ProjectModificationActionsProvider is required for graph mutations')
+}
+
+const ProjectModificationActionsContext = createContext<ProjectModificationActions>({
+  updateOperatorId: missingProvider,
+})
+
+export function ProjectModificationActionsProvider({
+  updateOperatorId,
+  children,
+}: {
+  updateOperatorId: UpdateOperatorId
+  children: ReactNode
+}) {
+  const value = useMemo(() => ({ updateOperatorId }), [updateOperatorId])
+  return (
+    <ProjectModificationActionsContext.Provider value={value}>
+      {children}
+    </ProjectModificationActionsContext.Provider>
+  )
+}
+
+export function useProjectModificationActions() {
+  return useContext(ProjectModificationActionsContext)
+}

--- a/noodles-editor/src/noodles/hooks/__tests__/use-project-modifications.test.tsx
+++ b/noodles-editor/src/noodles/hooks/__tests__/use-project-modifications.test.tsx
@@ -4,8 +4,8 @@
 import { act, renderHook } from '@testing-library/react'
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { ConcatOp, DeckRendererOp, NumberOp } from '../../operators'
-import { clearOps, setOp, setPendingInsertionIndex } from '../../store'
+import { ConcatOp, ContainerOp, DeckRendererOp, NumberOp } from '../../operators'
+import { clearOps, getOp, hasOp, setOp, setPendingInsertionIndex } from '../../store'
 import { MULTI_INPUT_EDGE_TYPE } from '../../utils/multi-input-utils'
 import { type ProjectModification, useProjectModifications } from '../use-project-modifications'
 
@@ -189,6 +189,72 @@ describe('useProjectModifications', () => {
       expect(op.isFieldVisible('effects')).toBe(true)
       expect(op.visibleFields.value).toBeInstanceOf(Set)
       expect(op.visibleFields.value?.has('effects')).toBe(true)
+    })
+  })
+
+  describe('updateOperatorId', () => {
+    it('renames a container across the complete node and edge graph', async () => {
+      const container = new ContainerOp('/container')
+      const child = new NumberOp('/container/group/child', { val: 42 }, false, '/container/group')
+      setOp(container.id, container)
+      setOp(child.id, child)
+      nodes = [
+        {
+          id: '/container',
+          type: 'ContainerOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: {} },
+        },
+        {
+          id: '/container/group',
+          type: 'group',
+          position: { x: 50, y: 50 },
+          data: {},
+        },
+        {
+          id: '/container/group/child',
+          type: 'NumberOp',
+          parentId: '/container/group',
+          position: { x: 20, y: 20 },
+          data: { inputs: { val: 42 } },
+        },
+      ]
+      edges = [
+        {
+          id: '/container/group/child.out.val->/container.par.in',
+          source: '/container/group/child',
+          sourceHandle: 'out.val',
+          target: '/container',
+          targetHandle: 'par.in',
+        },
+      ]
+      const { result } = renderHook(() =>
+        useProjectModifications({ getNodes, getEdges, setNodes, setEdges })
+      )
+
+      await act(async () => {
+        result.current.updateOperatorId('/container', 'scale-container', true)
+        await Promise.resolve()
+      })
+
+      expect(nodes.map(node => node.id)).toEqual([
+        '/scale-container',
+        '/scale-container/group',
+        '/scale-container/group/child',
+      ])
+      expect(nodes[2].parentId).toBe('/scale-container/group')
+      expect(edges).toEqual([
+        expect.objectContaining({
+          id: '/scale-container/group/child.out.val->/scale-container.par.in',
+          source: '/scale-container/group/child',
+          target: '/scale-container',
+        }),
+      ])
+      expect(hasOp('/container')).toBe(false)
+      expect(hasOp('/container/group/child')).toBe(false)
+      expect(getOp('/scale-container')).toBe(container)
+      expect(getOp('/scale-container/group/child')).toBe(child)
+      expect(child.containerId).toBe('/scale-container/group')
     })
   })
 

--- a/noodles-editor/src/noodles/hooks/use-project-modifications.ts
+++ b/noodles-editor/src/noodles/hooks/use-project-modifications.ts
@@ -25,7 +25,7 @@ import {
   normalizeMultiInputEdges,
   orderedEdgeIdsForHandle,
 } from '../utils/multi-input-utils'
-import { generateQualifiedPath, parseHandleId } from '../utils/path-utils'
+import { generateQualifiedPath, getParentPath, parseHandleId } from '../utils/path-utils'
 
 // Using ReactFlowNode instead of AnyNodeJSON for compatibility
 export type ProjectModification =
@@ -984,6 +984,7 @@ export function useProjectModifications(options: UseProjectModificationsOptions)
           const newChildId = newQualifiedId + oldChildId.slice(nodeId.length)
           setOp(newChildId, childOp)
           childOp.id = newChildId
+          childOp.containerId = getParentPath(newChildId)
 
           // Rename timeline tracks for child operator
           getTimelineStore().renameTracksForOperator(oldChildId, newChildId)
@@ -1012,7 +1013,12 @@ export function useProjectModifications(options: UseProjectModificationsOptions)
           }
           // Update children if this is a container
           if (isContainer && n.id.startsWith(`${nodeId}/`)) {
-            return { ...n, id: newQualifiedId + n.id.slice(nodeId.length) }
+            const parentId = n.parentId?.startsWith(`${nodeId}/`)
+              ? newQualifiedId + n.parentId.slice(nodeId.length)
+              : n.parentId === nodeId
+                ? newQualifiedId
+                : n.parentId
+            return { ...n, id: newQualifiedId + n.id.slice(nodeId.length), parentId }
           }
           return n
         })

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -71,6 +71,7 @@ import { SidebarTabs } from './components/sidebar-tabs'
 import { StorageErrorHandler } from './components/storage-error-handler'
 import { CanvasDropImport } from './components/tools/canvas-drop-import'
 import { UndoRedoHandler, type UndoRedoHandlerRef } from './components/UndoRedoHandler'
+import { ProjectModificationActionsProvider } from './contexts/project-modification-actions-context'
 import { useActiveStorageType, useFileSystemStore } from './filesystem-store'
 import { findEdgeAtPosition, useConnectionDropOnEdge } from './hooks/use-connection-drop-on-edge'
 import { useKeyboardShortcut } from './hooks/use-keyboard-shortcut'
@@ -1577,41 +1578,43 @@ export function getNoodles(): Visualization {
       >
         <PrimeReactProvider>
           <TimelineProvider>
-            <ReactFlow
-              ref={reactFlowRef}
-              nodes={displayedNodes}
-              edges={activeEdges}
-              onNodesChange={onNodesChange}
-              onEdgesChange={onEdgesChange}
-              onConnect={onConnect}
-              onConnectStart={onConnectStart}
-              onConnectEnd={onConnectEnd}
-              onReconnect={onReconnect}
-              onReconnectEnd={onReconnectEnd}
-              onNodeContextMenu={onNodeContextMenu}
-              onNodesDelete={onNodesDelete}
-              onNodeDrag={onNodeDrag}
-              onNodeDragStop={onNodeDragStop}
-              onPaneContextMenu={onPaneContextMenu}
-              onPaneClick={onPaneClick}
-              minZoom={0.2}
-              fitViewOptions={fitViewOptions}
-              defaultEdgeOptions={defaultEdgeOptions}
-              defaultViewport={defaultViewport}
-              nodeTypes={nodeComponents}
-              edgeTypes={edgeComponents}
-            >
-              <ReactFlowInstanceCapture />
-              <EdgeConnectionSynchronizer />
-              <CanvasDropImport />
-              <Background />
-              <Controls position="bottom-right" />
-              <BlockLibrary ref={blockLibraryRef} reactFlowRef={reactFlowRef} />
-              <CopyControls ref={copyControlsRef} graphRef={graphRef} />
-              <UndoRedoHandler ref={undoRedoRef} graphRef={graphRef} />
-              {showDebugInfo && <NodeInfoOverlay />}
-              {showDebugInfo && <ViewportInfoPanel />}
-            </ReactFlow>
+            <ProjectModificationActionsProvider updateOperatorId={updateOperatorId}>
+              <ReactFlow
+                ref={reactFlowRef}
+                nodes={displayedNodes}
+                edges={activeEdges}
+                onNodesChange={onNodesChange}
+                onEdgesChange={onEdgesChange}
+                onConnect={onConnect}
+                onConnectStart={onConnectStart}
+                onConnectEnd={onConnectEnd}
+                onReconnect={onReconnect}
+                onReconnectEnd={onReconnectEnd}
+                onNodeContextMenu={onNodeContextMenu}
+                onNodesDelete={onNodesDelete}
+                onNodeDrag={onNodeDrag}
+                onNodeDragStop={onNodeDragStop}
+                onPaneContextMenu={onPaneContextMenu}
+                onPaneClick={onPaneClick}
+                minZoom={0.2}
+                fitViewOptions={fitViewOptions}
+                defaultEdgeOptions={defaultEdgeOptions}
+                defaultViewport={defaultViewport}
+                nodeTypes={nodeComponents}
+                edgeTypes={edgeComponents}
+              >
+                <ReactFlowInstanceCapture />
+                <EdgeConnectionSynchronizer />
+                <CanvasDropImport />
+                <Background />
+                <Controls position="bottom-right" />
+                <BlockLibrary ref={blockLibraryRef} reactFlowRef={reactFlowRef} />
+                <CopyControls ref={copyControlsRef} graphRef={graphRef} />
+                <UndoRedoHandler ref={undoRedoRef} graphRef={graphRef} />
+                {showDebugInfo && <NodeInfoOverlay />}
+                {showDebugInfo && <ViewportInfoPanel />}
+              </ReactFlow>
+            </ProjectModificationActionsProvider>
           </TimelineProvider>
         </PrimeReactProvider>
         {parameterEditorState.operatorId && (

--- a/noodles-editor/src/noodles/store.tsx
+++ b/noodles-editor/src/noodles/store.tsx
@@ -1,10 +1,9 @@
-import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
+import type { Edge as ReactFlowEdge } from '@xyflow/react'
 import { create } from 'zustand'
 import type { IOperator, Operator } from './operators'
 // only import types from noodles to avoid circular dependencies
 import type { OpId } from './utils/id-utils'
-import { edgeId } from './utils/id-utils'
-import { generateQualifiedPath, isAbsolutePath, resolvePath } from './utils/path-utils'
+import { isAbsolutePath, resolvePath } from './utils/path-utils'
 
 // ============================================================================
 // Operator Store (Zustand) - Separate slice for operators and sheet objects
@@ -288,100 +287,6 @@ export const takePendingInsertionIndex = (
     return pending.index
   }
   return null
-}
-
-// ============================================================================
-// Operator ID Update Helper
-// ============================================================================
-
-//
-// Updates an operator's ID and all references to it (nodes, edges, children).
-// This is used when renaming operators in the node tree sidebar or node headers.
-//
-// @param nodeId - Current ID of the operator
-// @param newBaseName - New base name (without path prefix)
-// @param isContainer - Whether the operator is a container
-// @param setNodes - React Flow setNodes function
-// @param setEdges - React Flow setEdges function
-export const updateOperatorId = (
-  nodeId: string,
-  newBaseName: string,
-  isContainer: boolean,
-  setNodes: (updater: (nodes: ReactFlowNode[]) => ReactFlowNode[]) => void,
-  setEdges: (updater: (edges: ReactFlowEdge[]) => ReactFlowEdge[]) => void
-) => {
-  const store = getOpStore()
-  const op = store.getOp(nodeId)
-  if (!op) return
-
-  const newQualifiedId = generateQualifiedPath(newBaseName, op.containerId ?? '/')
-
-  // Update the operator itself
-  setOp(newQualifiedId, op)
-  op.id = newQualifiedId
-
-  // If this is a container, update all children nodes and their operators
-  if (isContainer) {
-    const childOps = getAllOps().filter((childOp: Operator<IOperator>) =>
-      childOp.id.startsWith(`${nodeId}/`)
-    )
-
-    for (const childOp of childOps) {
-      const oldChildId = childOp.id
-      // Replace only the exact container path at the start
-      const newChildId = newQualifiedId + oldChildId.slice(nodeId.length)
-      setOp(newChildId, childOp)
-      childOp.id = newChildId
-      queueMicrotask(() => deleteOp(oldChildId))
-    }
-  }
-
-  // Give React time to update the component tree before deleting the old id
-  queueMicrotask(() => {
-    deleteOp(nodeId)
-  })
-
-  // Update React Flow nodes and edges
-  setNodes(nodes =>
-    nodes.map(n => {
-      // Update the node itself if it matches
-      if (n.id === nodeId) {
-        return { ...n, id: newQualifiedId }
-      }
-      // Update children if this is a container
-      if (isContainer && n.id.startsWith(`${nodeId}/`)) {
-        return { ...n, id: newQualifiedId + n.id.slice(nodeId.length) }
-      }
-      return n
-    })
-  )
-
-  setEdges(edges =>
-    edges.map(edge => {
-      const sourceNeedsUpdate =
-        edge.source === nodeId || (isContainer && edge.source.startsWith(`${nodeId}/`))
-      const targetNeedsUpdate =
-        edge.target === nodeId || (isContainer && edge.target.startsWith(`${nodeId}/`))
-
-      if (!sourceNeedsUpdate && !targetNeedsUpdate) return edge
-
-      const updatedEdge = {
-        ...edge,
-        source: sourceNeedsUpdate
-          ? edge.source === nodeId
-            ? newQualifiedId
-            : newQualifiedId + edge.source.slice(nodeId.length)
-          : edge.source,
-        target: targetNeedsUpdate
-          ? edge.target === nodeId
-            ? newQualifiedId
-            : newQualifiedId + edge.target.slice(nodeId.length)
-          : edge.target,
-      }
-
-      return { ...updatedEdge, id: edgeId(updatedEdge) }
-    })
-  )
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- route node-header renames through the canonical full-project mutation action
- preserve path-based descendants, internal edges, nested parent IDs, and operator container IDs
- remove the duplicate rename helper that operated on the visible React Flow scope

## Root cause
At the root graph level, React Flow receives only displayed root nodes and edges. The node header called its scoped setters directly, so renaming a container appeared as removal of the old container and triggered cascade deletion of children that were not in the displayed scope.

## Testing
### Automated
- Focused container component and project-modification suites: 40 passed
- Full suite: 2,884 passed initially; the remaining 4 environment-sensitive tests passed when rerun with required API-key variables and without concurrent build load
- Lint and format checks passed
- Production app build passed
- Standalone TypeScript currently reports the existing repository-wide baseline backlog; no new errors were reported for the new context or rename hook implementation

### Manual test runbook
1. Open a project with a top-level container containing GraphInput, processing nodes, and GraphOutput.
2. From the parent graph, rename the container through its node header.
3. Open the renamed container.
4. Confirm every child remains present and internal and external connections point to the renamed paths.
5. Save and reload the project; confirm the graph remains intact.

## Documentation
No user-facing documentation changes needed.