### PR TITLE
Fix fresh-load container input pull ordering

### DIFF
--- a/noodles-editor/src/noodles/container-integration.test.ts
+++ b/noodles-editor/src/noodles/container-integration.test.ts
@@ -3,7 +3,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { getExecutor } from './graph-executor'
 import type { Edge } from './noodles'
 import type { OpType } from './operators'
-import { ContainerOp, GraphInputOp, GraphOutputOp, type ViewerOp } from './operators'
+import {
+  type CodeOp,
+  ContainerOp,
+  GraphInputOp,
+  GraphOutputOp,
+  type PointOp,
+  type ViewerOp,
+} from './operators'
 import { clearOps, getOp } from './store'
 import { transformGraph } from './transform-graph'
 
@@ -252,6 +259,114 @@ describe('Container Integration with Transform Graph', () => {
     expect(output.outputs.propagatedValue.value).toBe(14)
     expect(container.outputs.out.value).toBe(14)
     expect(viewer.inputs.data.value).toBe(14)
+  })
+
+  it('pulls an upstream container input before executing the child graph on first load', async () => {
+    const nodes: NodeJSON<OpType>[] = [
+      {
+        id: '/point',
+        type: 'PointOp',
+        position: { x: 0, y: 0 },
+        data: { inputs: { coordinates: { lng: -117.94, lat: 34.25 } } },
+      },
+      {
+        id: '/analysis',
+        type: 'ContainerOp',
+        position: { x: 100, y: 0 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/analysis/input',
+        type: 'GraphInputOp',
+        position: { x: 200, y: 0 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/analysis/read-coordinates',
+        type: 'CodeOp',
+        position: { x: 300, y: 0 },
+        data: { inputs: { code: ['return d.geometry.coordinates'] } },
+      },
+      {
+        id: '/analysis/output',
+        type: 'GraphOutputOp',
+        position: { x: 400, y: 0 },
+        data: { inputs: {} },
+      },
+      {
+        id: '/viewer',
+        type: 'ViewerOp',
+        position: { x: 500, y: 0 },
+        data: { inputs: {} },
+      },
+    ]
+    const edges: Edge[] = [
+      {
+        id: '/point.out.feature->/analysis.par.in',
+        source: '/point',
+        target: '/analysis',
+        sourceHandle: 'out.feature',
+        targetHandle: 'par.in',
+      },
+      {
+        id: '/analysis/input.out.value->/analysis/read-coordinates.par.data',
+        source: '/analysis/input',
+        target: '/analysis/read-coordinates',
+        sourceHandle: 'out.value',
+        targetHandle: 'par.data',
+      },
+      {
+        id: '/analysis/read-coordinates.out.data->/analysis/output.par.value',
+        source: '/analysis/read-coordinates',
+        target: '/analysis/output',
+        sourceHandle: 'out.data',
+        targetHandle: 'par.value',
+      },
+      {
+        id: '/analysis.out.out->/viewer.par.data',
+        source: '/analysis',
+        target: '/viewer',
+        sourceHandle: 'out.out',
+        targetHandle: 'par.data',
+      },
+    ]
+
+    transformGraph({ nodes, edges })
+    const executor = getExecutor()!
+    executor.stop()
+
+    // Make the upstream value arrive after the child graph would otherwise
+    // read PointOp's empty FeatureCollection default. This deterministically
+    // reproduces the fresh-load race from the LA scale container.
+    const point = getOp('/point') as PointOp
+    const executePoint = point.execute.bind(point)
+    point.execute = (async inputs => {
+      await Promise.resolve()
+      await Promise.resolve()
+      return executePoint(inputs)
+    }) as typeof point.execute
+
+    await executor.executeFrame(performance.now())
+
+    const graphInput = getOp('/analysis/input') as GraphInputOp
+    const code = getOp('/analysis/read-coordinates') as CodeOp
+    const container = getOp('/analysis') as ContainerOp
+    const viewer = getOp('/viewer') as ViewerOp
+    expect(executor.getUpstream(graphInput.id)).toContain(point.id)
+    expect(code.executionState.value.status).toBe('success')
+    expect(container.outputs.out.value).toEqual([-117.94, 34.25])
+    expect(viewer.inputs.data.value).toEqual([-117.94, 34.25])
+
+    const edgesWithoutContainerInput = edges.filter(edge => edge.target !== '/analysis')
+    transformGraph({ nodes, edges: edgesWithoutContainerInput })
+
+    const operatorDependencies = (
+      getOp('/analysis/input') as unknown as {
+        _upstreamDependencies: Set<unknown>
+      }
+    )._upstreamDependencies
+    expect(executor.getUpstream(graphInput.id)).not.toContain(point.id)
+    expect(operatorDependencies.has(point)).toBe(false)
   })
 
   it('uses the same GraphOutput for scheduling and execution when a container has multiple', async () => {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4243,6 +4243,7 @@ export class GraphInputOp extends Operator<GraphInputOp> {
   static displayName = 'GraphInput'
   static description = 'Receives input from the parent Container.'
   private _containerSub: Subscription | null = null
+  private _containerInputDependencies = new Set<Operator<IOperator>>()
 
   createInputs() {
     return { parentValue: new UnknownField(null, { optional: true }) }
@@ -4261,6 +4262,34 @@ export class GraphInputOp extends Operator<GraphInputOp> {
       }
     }
     return result as ExtractProps<typeof this.outputs>
+  }
+
+  /**
+   * Mirror the operators feeding the parent container as direct pull
+   * dependencies. The value still flows through the container fields, but
+   * this relationship guarantees those fields are populated before the child
+   * graph reads them on its first pull.
+   */
+  setContainerInputDependencies(dependencies: Iterable<Operator<IOperator>>) {
+    const nextDependencies = new Set(dependencies)
+    let changed = false
+
+    for (const dependency of this._containerInputDependencies) {
+      if (nextDependencies.has(dependency)) continue
+      dependency.removeDownstreamDependent(this)
+      this.removeUpstreamDependency(dependency)
+      changed = true
+    }
+
+    for (const dependency of nextDependencies) {
+      if (this._containerInputDependencies.has(dependency)) continue
+      dependency.addDownstreamDependent(this)
+      this.addUpstreamDependency(dependency)
+      changed = true
+    }
+
+    this._containerInputDependencies = nextDependencies
+    if (changed) this.markDirty()
   }
 
   /**
@@ -4366,6 +4395,7 @@ export class GraphInputOp extends Operator<GraphInputOp> {
   }
 
   dispose() {
+    this.setContainerInputDependencies([])
     if (this._containerSub) {
       this._containerSub.unsubscribe()
     }

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -163,7 +163,73 @@ export function transformGraph<
       },
     ]
   })
-  const executorEdges = [...(edges as unknown as ExecutorEdge[]), ...implicitContainerOutputEdges]
+
+  // A container input is a field-level bridge: source -> Container.par -> GraphInput.par.
+  // The enclosing Container cannot be a pull dependency of its GraphInput because the
+  // output boundary points back from GraphOutput -> Container, which would form a cycle.
+  // Bridge external output dependencies directly to each GraphInput so the child graph
+  // waits for its parent inputs to be populated on the first pull.
+  const nodeById = new Map(nodes.map(node => [node.id, node]))
+  const graphInputNodeIdsByContainer = new Map<string, string[]>()
+  for (const node of nodes) {
+    if (node.type !== 'GraphInputOp') continue
+    const containerId = getParentPath(node.id)
+    if (!containerId || nodeById.get(containerId)?.type !== 'ContainerOp') continue
+    const inputNodeIds = graphInputNodeIdsByContainer.get(containerId) ?? []
+    inputNodeIds.push(node.id)
+    graphInputNodeIdsByContainer.set(containerId, inputNodeIds)
+  }
+
+  const containerInputSourceIdsByGraphInput = new Map<string, Set<string>>()
+  const existingPullRelations = new Set(
+    edges
+      .filter(edge => parseHandleId(String(edge.sourceHandle))?.namespace === 'out')
+      .map(edge => `${edge.source}->${edge.target}`)
+  )
+  const bridgeRelations = new Set<string>()
+  const implicitContainerInputEdges: ExecutorEdge[] = []
+  for (const edge of edges) {
+    const containerNode = nodeById.get(edge.target)
+    const sourceHandle = parseHandleId(String(edge.sourceHandle))
+    const targetHandle = parseHandleId(String(edge.targetHandle))
+    if (
+      containerNode?.type !== 'ContainerOp' ||
+      sourceHandle?.namespace !== 'out' ||
+      targetHandle?.namespace !== 'par' ||
+      edge.source === containerNode.id ||
+      edge.source.startsWith(`${containerNode.id}/`)
+    ) {
+      continue
+    }
+
+    const graphInputNodeIds = graphInputNodeIdsByContainer.get(containerNode.id) ?? []
+    if (graphInputNodeIds.length === 0) continue
+
+    for (const graphInputNodeId of graphInputNodeIds) {
+      const relation = `${edge.source}->${graphInputNodeId}`
+      if (existingPullRelations.has(relation) || bridgeRelations.has(relation)) continue
+      bridgeRelations.add(relation)
+
+      const sourceIds =
+        containerInputSourceIdsByGraphInput.get(graphInputNodeId) ?? new Set<string>()
+      sourceIds.add(edge.source)
+      containerInputSourceIdsByGraphInput.set(graphInputNodeId, sourceIds)
+
+      implicitContainerInputEdges.push({
+        id: `${edge.id}->${graphInputNodeId}.par.parentValue`,
+        source: edge.source,
+        target: graphInputNodeId,
+        sourceHandle: edge.sourceHandle,
+        targetHandle: 'par.parentValue',
+      })
+    }
+  }
+
+  const executorEdges = [
+    ...(edges as unknown as ExecutorEdge[]),
+    ...implicitContainerOutputEdges,
+    ...implicitContainerInputEdges,
+  ]
   const store = getOpStore()
 
   // Error about unknown node types — nodes present in the project file that aren't registered
@@ -441,6 +507,13 @@ export function transformGraph<
 
       for (const childOp of store.getAllOps()) {
         if (childOp instanceof GraphInputOp && isDirectChild(childOp.id, containerOp.id)) {
+          const inputDependencies = Array.from(
+            containerInputSourceIdsByGraphInput.get(childOp.id) ?? []
+          )
+            .map(sourceId => store.getOp(sourceId))
+            .filter((sourceOp): sourceOp is Operator<IOperator> => sourceOp !== undefined)
+          childOp.setContainerInputDependencies(inputDependencies)
+
           // Set up parent container relationship (triggers output rebuild)
           childOp.setParentContainer(containerOp)
 


### PR DESCRIPTION
Stacked on #561.

## Summary

- derive an ephemeral pull dependency from each external container input source to its direct GraphInput boundary
- mirror that relationship in the operator pull graph while keeping value propagation on the existing source → Container → GraphInput field path
- remove stale bridge dependencies when container input edges change
- add a deterministic regression for the fresh-load race reproduced by the LA scale container

## Why

On first load, an upstream PointOp and the container child graph could be pulled concurrently. GraphInput would then expose its empty default before PointOp published the connected value, allowing the child CodeOp to fail and remain in ERROR until another graph change (such as attaching Viewer) invalidated it.

## Validation

- npx vitest run src/noodles/container-integration.test.ts src/noodles/transform-graph.test.ts src/noodles/graph-executor.test.ts (168 passed)
- npm run lint
- npm run format:check
- npm run build