### PR TITLE
Add analytics tracking for user failure scenarios

### DIFF
--- a/noodles-editor/src/components/quick-start-modal.tsx
+++ b/noodles-editor/src/components/quick-start-modal.tsx
@@ -3,6 +3,7 @@ import { Cross2Icon } from '@radix-ui/react-icons'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useLocation } from 'wouter'
 import logoSvg from '/noodles-favicon.svg'
+import { extensionOf } from '../noodles/components/tools/import-pipelines'
 import { analytics } from '../utils/analytics'
 import { CURATED_EXAMPLES, ExamplesView } from './examples-view'
 import { ProjectsView, useRecentProjects } from './projects-view'
@@ -117,6 +118,15 @@ export function QuickStartModal({
         const file = files[0]
         const validationError = validateFile(file)
         if (validationError) {
+          const fileType = extensionOf(file.name) || 'unknown'
+          const reason = file.size > MAX_FILE_SIZE ? 'size_limit' : 'unsupported_type'
+          analytics.track('file_import_failed', {
+            fileType,
+            attemptedFormat: 'unknown',
+            reason,
+            source: 'quickstart',
+            fileSize: file.size,
+          })
           setError(validationError)
           return
         }
@@ -135,6 +145,15 @@ export function QuickStartModal({
         const file = files[0]
         const validationError = validateFile(file)
         if (validationError) {
+          const fileType = extensionOf(file.name) || 'unknown'
+          const reason = file.size > MAX_FILE_SIZE ? 'size_limit' : 'unsupported_type'
+          analytics.track('file_import_failed', {
+            fileType,
+            attemptedFormat: 'unknown',
+            reason,
+            source: 'quickstart',
+            fileSize: file.size,
+          })
           setError(validationError)
           return
         }

--- a/noodles-editor/src/noodles/components/error-boundary.tsx
+++ b/noodles-editor/src/noodles/components/error-boundary.tsx
@@ -64,9 +64,9 @@ export class ErrorBoundary extends Component<Props, State> {
       debugUI(
         `Maximum reset attempts (${maxResets}) reached. Please refresh the page or check for underlying issues.`
       )
+      // Only track that max resets was hit - error details may contain PII
       analytics.track('error_boundary_max_resets', {
         resetCount,
-        errorMessage: error?.message || 'Unknown error',
       })
       return
     }

--- a/noodles-editor/src/noodles/components/error-boundary.tsx
+++ b/noodles-editor/src/noodles/components/error-boundary.tsx
@@ -1,4 +1,5 @@
 import React, { Component, type ReactNode } from 'react'
+import { analytics } from '../../utils/analytics'
 import { debugUI } from '../../utils/debug'
 import s from './error-boundary.module.css'
 
@@ -56,13 +57,17 @@ export class ErrorBoundary extends Component<Props, State> {
 
   handleReset = () => {
     const now = Date.now()
-    const { resetCount } = this.state
+    const { resetCount, error } = this.state
     const maxResets = this.props.maxResets ?? DEFAULT_MAX_RESETS
 
     if (resetCount >= maxResets) {
       debugUI(
         `Maximum reset attempts (${maxResets}) reached. Please refresh the page or check for underlying issues.`
       )
+      analytics.track('error_boundary_max_resets', {
+        resetCount,
+        errorMessage: error?.message || 'Unknown error',
+      })
       return
     }
 

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -27,6 +27,7 @@ const CodeiumEditor = lazy(() =>
 )
 
 import { Temporal } from 'temporal-polyfill'
+import { analytics } from '../../utils/analytics'
 import { VectorKeyframeIndicator } from '../../timeline/components/KeyframeIndicator'
 import { getFieldPath } from '../../timeline/field-bindings'
 import { useTimelineStore } from '../../timeline/timeline-store'
@@ -61,6 +62,7 @@ import type { Edge } from '../noodles'
 import s from '../noodles.module.css'
 import { getFriendlyErrorMessage, type IOperator, type Operator } from '../operators'
 import { checkAssetExists, getAssetFileHandle, writeAsset } from '../storage'
+import { extensionOf } from './tools/import-pipelines'
 import { getOp, useEdgeConnectionStore } from '../store'
 import { type ExpressionContext, getExpressionContext } from '../utils/expression-context'
 import { projectScheme } from '../utils/filesystem'
@@ -71,11 +73,7 @@ import {
   firePropertyMutation,
   usePropertyHistory,
 } from '../utils/property-history'
-import {
-  formatReference,
-  parseReference,
-  type ReferenceFormat,
-} from '../utils/reference-utils'
+import { formatReference, parseReference, type ReferenceFormat } from '../utils/reference-utils'
 import { ColorSwatch } from './color-swatch'
 import { ExpressionEditorOverlay } from './ExpressionEditorOverlay'
 import { GeocodingDialog } from './geocoding-dialog'
@@ -1232,6 +1230,7 @@ export function FileUrlFieldComponent({
 
   const doUpload = async () => {
     const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
+
     if (!currentProjectName) {
       throw new Error('No project loaded. Please save or load a project first.')
     }
@@ -1246,6 +1245,8 @@ export function FileUrlFieldComponent({
 
     const [fileHandle] = await window.showOpenFilePicker(pickerOpts)
     const file = await fileHandle.getFile()
+    const fileType = extensionOf(file.name) || 'unknown'
+
     // Read as ArrayBuffer so binary files (e.g. .glb) are preserved
     const buffer = await file.arrayBuffer()
     const contents = new Blob([buffer], { type: file.type })
@@ -1263,6 +1264,12 @@ export function FileUrlFieldComponent({
         field.setValue(projectScheme + file.name)
         setValue(projectScheme + file.name)
         commitChange('Change file')
+        analytics.track('file_imported', {
+          fileType,
+          fileFormat: fileType,
+          source: 'field',
+          fileSize: file.size,
+        })
         return
       }
       captureStart()
@@ -1273,6 +1280,13 @@ export function FileUrlFieldComponent({
 
     const result = await writeAsset(activeStorageType, currentProjectName, file.name, contents)
     if (!result.success) {
+      analytics.track('file_import_failed', {
+        fileType,
+        attemptedFormat: fileType,
+        reason: 'write_failed',
+        source: 'field',
+        fileSize: file.size,
+      })
       throw new Error(result.error?.message || `Failed to write file: ${file.name}`)
     }
 
@@ -1280,6 +1294,12 @@ export function FileUrlFieldComponent({
     field.setValue(projectScheme + file.name)
     setValue(projectScheme + file.name)
     commitChange('Change file')
+    analytics.track('file_imported', {
+      fileType,
+      fileFormat: fileType,
+      source: 'field',
+      fileSize: file.size,
+    })
   }
 
   const onConfirmReplace = async () => {
@@ -1288,6 +1308,7 @@ export function FileUrlFieldComponent({
     const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
     if (!currentProjectName) return
 
+    const fileType = extensionOf(pendingFile.name) || 'unknown'
     const result = await writeAsset(
       activeStorageType,
       currentProjectName,
@@ -1295,6 +1316,13 @@ export function FileUrlFieldComponent({
       pendingFile.contents
     )
     if (!result.success) {
+      analytics.track('file_import_failed', {
+        fileType,
+        attemptedFormat: fileType,
+        reason: 'write_failed',
+        source: 'field',
+        fileSize: pendingFile.contents.size,
+      })
       throw new Error(result.error?.message || `Failed to write file: ${pendingFile.name}`)
     }
 
@@ -1303,6 +1331,12 @@ export function FileUrlFieldComponent({
     commitChange('Change file')
     setReplaceDialogOpen(false)
     setPendingFile(null)
+    analytics.track('file_imported', {
+      fileType,
+      fileFormat: fileType,
+      source: 'field',
+      fileSize: pendingFile.contents.size,
+    })
   }
 
   const onCancelReplace = () => {
@@ -3476,9 +3510,7 @@ export function BboxFieldComponent({
         {id}
       </label>
       <div id={id} className={s.fieldCompoundWrapper}>
-        <div className={s.fieldGroupLabel}>
-          Southwest
-        </div>
+        <div className={s.fieldGroupLabel}>Southwest</div>
         <div className={cx(s.fieldInputWrapper, s.fieldInputWrapperVector)}>
           <VectorNumberInput
             keyName="lng"
@@ -3514,9 +3546,7 @@ export function BboxFieldComponent({
           />
         </div>
 
-        <div className={cx(s.fieldGroupLabel, s.fieldGroupLabelSpaced)}>
-          Northeast
-        </div>
+        <div className={cx(s.fieldGroupLabel, s.fieldGroupLabelSpaced)}>Northeast</div>
         <div className={cx(s.fieldInputWrapper, s.fieldInputWrapperVector)}>
           <VectorNumberInput
             keyName="lng"

--- a/noodles-editor/src/noodles/components/graph-error-dialog.tsx
+++ b/noodles-editor/src/noodles/components/graph-error-dialog.tsx
@@ -1,6 +1,8 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { Cross2Icon } from '@radix-ui/react-icons'
 import cx from 'classnames'
+import { useEffect } from 'react'
+import { analytics } from '../../utils/analytics'
 import s from './menu.module.css'
 
 export interface GraphError {
@@ -25,6 +27,29 @@ export const GraphErrorDialog = ({
   const unknownOperators = errors.filter(e => e.type === 'unknown-operator')
   const staleEdges = errors.filter(e => e.type === 'stale-edge')
   const executionErrors = errors.filter(e => e.type === 'operator-execution')
+
+  useEffect(() => {
+    if (open) {
+      if (unknownOperators.length > 0) {
+        analytics.track('project_load_error', {
+          errorType: 'unknown_operators',
+          count: unknownOperators.length,
+        })
+      }
+      if (staleEdges.length > 0) {
+        analytics.track('project_load_error', {
+          errorType: 'broken_connections',
+          count: staleEdges.length,
+        })
+      }
+      if (executionErrors.length > 0) {
+        analytics.track('project_load_error', {
+          errorType: 'execution_errors',
+          count: executionErrors.length,
+        })
+      }
+    }
+  }, [open, unknownOperators.length, staleEdges.length, executionErrors.length])
 
   return (
     <Dialog.Root open={open} onOpenChange={open => !open && onClose()}>
@@ -120,8 +145,8 @@ export const GraphErrorDialog = ({
           </div>
           {validOperatorCount > 0 && (
             <p style={{ marginTop: '0.75rem', fontSize: '0.9em', color: 'var(--gray-11)' }}>
-              The valid operators have been loaded and the graph is functional. Skipped operators and
-              broken connections will not be available.
+              The valid operators have been loaded and the graph is functional. Skipped operators
+              and broken connections will not be available.
             </p>
           )}
           <Dialog.Close asChild>

--- a/noodles-editor/src/noodles/components/storage-error-handler.tsx
+++ b/noodles-editor/src/noodles/components/storage-error-handler.tsx
@@ -34,9 +34,9 @@ export function StorageErrorHandler() {
 
   useEffect(() => {
     if (error) {
+      // Don't send error.details or error.message - they may contain project names or file paths
       analytics.track('storage_error_encountered', {
         errorType: errorTypeMap[error.type],
-        operation: error.details || 'unknown',
       })
     }
   }, [error])

--- a/noodles-editor/src/noodles/components/storage-error-handler.tsx
+++ b/noodles-editor/src/noodles/components/storage-error-handler.tsx
@@ -1,5 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { Cross2Icon } from '@radix-ui/react-icons'
+import { useEffect } from 'react'
+import { analytics } from '../../utils/analytics'
 import { useFileSystemError, useFileSystemStore } from '../filesystem-store'
 import type { FileSystemError } from '../storage'
 import s from './menu.module.css'
@@ -15,9 +17,29 @@ const errorTitles: Record<FileSystemError['type'], string> = {
   unknown: 'Unknown Error',
 }
 
+const errorTypeMap: Record<FileSystemError['type'], string> = {
+  'permission-denied': 'permission_denied',
+  'not-found': 'not_found',
+  unsupported: 'not_supported',
+  'invalid-state': 'invalid_state',
+  'security-error': 'security_error',
+  'abort-error': 'abort_error',
+  'already-exists': 'file_exists',
+  unknown: 'unknown',
+}
+
 export function StorageErrorHandler() {
   const error = useFileSystemError()
   const { clearError } = useFileSystemStore()
+
+  useEffect(() => {
+    if (error) {
+      analytics.track('storage_error_encountered', {
+        errorType: errorTypeMap[error.type],
+        operation: error.details || 'unknown',
+      })
+    }
+  }, [error])
 
   if (!error) {
     return null

--- a/noodles-editor/src/noodles/components/tools/canvas-drop-import.tsx
+++ b/noodles-editor/src/noodles/components/tools/canvas-drop-import.tsx
@@ -1,8 +1,9 @@
 import { useReactFlow } from '@xyflow/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { analytics } from '../../../utils/analytics'
 import { useFileImport } from '../../hooks/use-file-import'
 import s from './canvas-drop-import.module.css'
-import { IMPORTABLE_EXTENSIONS, isImportable } from './import-pipelines'
+import { extensionOf, IMPORTABLE_EXTENSIONS, isImportable } from './import-pipelines'
 
 // Drop a data file anywhere on the graph canvas to build its pipeline, without
 // opening the Import Data dialog first. The pipeline lands where the file was
@@ -63,6 +64,15 @@ export function CanvasDropImport() {
 
       const supported = files.filter(file => isImportable(file.name))
       if (supported.length === 0) {
+        const unsupportedFile = files[0]
+        const fileType = extensionOf(unsupportedFile.name) || 'unknown'
+        analytics.track('file_import_failed', {
+          fileType,
+          attemptedFormat: 'unknown',
+          reason: 'unsupported_type',
+          source: 'canvas_drop',
+          fileSize: unsupportedFile.size,
+        })
         setState('idle')
         setError(`Can't import ${files[0].name}. Supported: ${IMPORTABLE_EXTENSIONS.join(', ')}`)
         return
@@ -81,7 +91,21 @@ export function CanvasDropImport() {
           )
         }
         const skipped = files.length - supported.length
-        if (skipped > 0) setError(`Skipped ${skipped} unsupported file${skipped > 1 ? 's' : ''}`)
+        if (skipped > 0) {
+          // Track each skipped file
+          const unsupportedFiles = files.filter(file => !isImportable(file.name))
+          for (const file of unsupportedFiles) {
+            const fileType = extensionOf(file.name) || 'unknown'
+            analytics.track('file_import_failed', {
+              fileType,
+              attemptedFormat: 'unknown',
+              reason: 'unsupported_type',
+              source: 'canvas_drop',
+              fileSize: file.size,
+            })
+          }
+          setError(`Skipped ${skipped} unsupported file${skipped > 1 ? 's' : ''}`)
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to import file')
       } finally {

--- a/noodles-editor/src/noodles/components/tools/data-importer-tool.tsx
+++ b/noodles-editor/src/noodles/components/tools/data-importer-tool.tsx
@@ -2,9 +2,10 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { Cross2Icon } from '@radix-ui/react-icons'
 import { useReactFlow } from '@xyflow/react'
 import { useCallback, useRef, useState } from 'react'
+import { analytics } from '../../../utils/analytics'
 import { useFileImport } from '../../hooks/use-file-import'
 import s from './data-importer-tool.module.css'
-import { FILE_INPUT_ACCEPT, isImportable } from './import-pipelines'
+import { extensionOf, FILE_INPUT_ACCEPT, isImportable } from './import-pipelines'
 
 const SAMPLE_DATASETS = [
   {
@@ -74,6 +75,17 @@ export function DataImporterTool({ open, onOpenChange, reactFlowRef }: DataImpor
     (files: File[], source: string) => {
       const supported = files.filter(file => isImportable(file.name))
       if (supported.length === 0) {
+        const unsupportedFile = files[0]
+        if (unsupportedFile) {
+          const fileType = extensionOf(unsupportedFile.name) || 'unknown'
+          analytics.track('file_import_failed', {
+            fileType,
+            attemptedFormat: 'unknown',
+            reason: 'unsupported_type',
+            source,
+            fileSize: unsupportedFile.size,
+          })
+        }
         setError(`Can't import ${files[0]?.name ?? 'that file'}. Supported: ${FILE_INPUT_ACCEPT}`)
         return
       }

--- a/noodles-editor/src/noodles/components/tools/import-pipelines.ts
+++ b/noodles-editor/src/noodles/components/tools/import-pipelines.ts
@@ -39,7 +39,7 @@ export function isBinaryFormat(format: DetectedFormat): boolean {
   return BINARY_FORMATS.has(format)
 }
 
-function extensionOf(filename: string): string {
+export function extensionOf(filename: string): string {
   const withoutQuery = filename.split(/[?#]/)[0]
   const parts = withoutQuery.toLowerCase().split('.')
   return parts.length > 1 ? parts[parts.length - 1] : ''

--- a/noodles-editor/src/noodles/hooks/use-file-import.ts
+++ b/noodles-editor/src/noodles/hooks/use-file-import.ts
@@ -68,6 +68,7 @@ export function useFileImport({ getBasePosition, onImported }: UseFileImportOpti
   const importFile = useCallback(
     async (file: File, basePosition: { x: number; y: number }, source: string) => {
       const fileType = extensionOf(file.name) || 'unknown'
+      let analyticsTracked = false
 
       try {
         const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
@@ -79,6 +80,7 @@ export function useFileImport({ getBasePosition, onImported }: UseFileImportOpti
             source,
             fileSize: file.size,
           })
+          analyticsTracked = true
           throw new Error('No project loaded. Please save or load a project first.')
         }
 
@@ -96,6 +98,7 @@ export function useFileImport({ getBasePosition, onImported }: UseFileImportOpti
             source,
             fileSize: file.size,
           })
+          analyticsTracked = true
           throw new Error(result.error?.message || `Failed to write file: ${file.name}`)
         }
 
@@ -118,12 +121,8 @@ export function useFileImport({ getBasePosition, onImported }: UseFileImportOpti
         onImported?.(format)
         return format
       } catch (error) {
-        // If analytics wasn't already tracked in specific error cases above, track generic failure
-        if (
-          error instanceof Error &&
-          !error.message.includes('No project loaded') &&
-          !error.message.includes('Failed to write file')
-        ) {
+        // Only track unknown failures if we haven't already tracked this error
+        if (!analyticsTracked) {
           analytics.track('file_import_failed', {
             fileType,
             attemptedFormat: detectFormat(file.name),
@@ -140,14 +139,9 @@ export function useFileImport({ getBasePosition, onImported }: UseFileImportOpti
 
   const importUrl = useCallback(
     (url: string, source: string, format = detectFormatFromUrl(url)) => {
-      const fileType = extensionOf(url) || 'unknown'
       addPipeline(url, format, getBasePosition())
-      analytics.track('file_imported', {
-        fileType,
-        fileFormat: format,
-        source,
-        fileSize: undefined, // URLs don't have size until loaded
-      })
+      // Don't track success here - FileOp will load the URL asynchronously and may fail
+      // We can't know if the import succeeded until FileOp actually fetches and parses the data
       analytics.track('data_imported', { source, format })
       onImported?.(format)
       return format

--- a/noodles-editor/src/noodles/hooks/use-file-import.ts
+++ b/noodles-editor/src/noodles/hooks/use-file-import.ts
@@ -7,6 +7,7 @@ import {
   type DetectedFormat,
   detectFormat,
   detectFormatFromUrl,
+  extensionOf,
   isBinaryFormat,
 } from '../components/tools/import-pipelines'
 import { useFileSystemStore } from '../filesystem-store'
@@ -66,40 +67,87 @@ export function useFileImport({ getBasePosition, onImported }: UseFileImportOpti
   // Copy a dropped or picked file into the project's data directory, then build its pipeline
   const importFile = useCallback(
     async (file: File, basePosition: { x: number; y: number }, source: string) => {
-      const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
-      if (!currentProjectName) {
-        throw new Error('No project loaded. Please save or load a project first.')
+      const fileType = extensionOf(file.name) || 'unknown'
+
+      try {
+        const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
+        if (!currentProjectName) {
+          analytics.track('file_import_failed', {
+            fileType,
+            attemptedFormat: detectFormat(file.name),
+            reason: 'no_project',
+            source,
+            fileSize: file.size,
+          })
+          throw new Error('No project loaded. Please save or load a project first.')
+        }
+
+        // Binary formats have to round-trip as a Blob; reading them as text corrupts them
+        const probableFormat = detectFormat(file.name)
+        const binary = isBinaryFormat(probableFormat)
+        const contents = binary ? file : await file.text()
+
+        const result = await writeAsset(activeStorageType, currentProjectName, file.name, contents)
+        if (!result.success) {
+          analytics.track('file_import_failed', {
+            fileType,
+            attemptedFormat: probableFormat,
+            reason: 'write_failed',
+            source,
+            fileSize: file.size,
+          })
+          throw new Error(result.error?.message || `Failed to write file: ${file.name}`)
+        }
+
+        debugUI('File imported: %s', file.name)
+        const format = binary ? probableFormat : detectFormat(file.name, contents as string)
+        addPipeline(
+          projectScheme + file.name,
+          format,
+          basePosition,
+          binary ? undefined : (contents as string)
+        )
+
+        analytics.track('file_imported', {
+          fileType,
+          fileFormat: format,
+          source,
+          fileSize: file.size,
+        })
+        analytics.track('data_imported', { source, format })
+        onImported?.(format)
+        return format
+      } catch (error) {
+        // If analytics wasn't already tracked in specific error cases above, track generic failure
+        if (
+          error instanceof Error &&
+          !error.message.includes('No project loaded') &&
+          !error.message.includes('Failed to write file')
+        ) {
+          analytics.track('file_import_failed', {
+            fileType,
+            attemptedFormat: detectFormat(file.name),
+            reason: 'unknown',
+            source,
+            fileSize: file.size,
+          })
+        }
+        throw error
       }
-
-      // Binary formats have to round-trip as a Blob; reading them as text corrupts them
-      const probableFormat = detectFormat(file.name)
-      const binary = isBinaryFormat(probableFormat)
-      const contents = binary ? file : await file.text()
-
-      const result = await writeAsset(activeStorageType, currentProjectName, file.name, contents)
-      if (!result.success) {
-        throw new Error(result.error?.message || `Failed to write file: ${file.name}`)
-      }
-
-      debugUI('File imported: %s', file.name)
-      const format = binary ? probableFormat : detectFormat(file.name, contents as string)
-      addPipeline(
-        projectScheme + file.name,
-        format,
-        basePosition,
-        binary ? undefined : (contents as string)
-      )
-
-      analytics.track('data_imported', { source, format })
-      onImported?.(format)
-      return format
     },
     [addPipeline, onImported]
   )
 
   const importUrl = useCallback(
     (url: string, source: string, format = detectFormatFromUrl(url)) => {
+      const fileType = extensionOf(url) || 'unknown'
       addPipeline(url, format, getBasePosition())
+      analytics.track('file_imported', {
+        fileType,
+        fileFormat: format,
+        source,
+        fileSize: undefined, // URLs don't have size until loaded
+      })
       analytics.track('data_imported', { source, format })
       onImported?.(format)
       return format

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -418,13 +418,18 @@ export function transformGraph<
         const validation = validateConnection(sourceField, targetField)
         if (!validation.valid && validation.error && sourceField.value !== undefined) {
           targetOp.addConnectionError(edge.id, validation.error)
-          analytics.track('connection_failed', {
-            failureType:
-              validation.severity === 'warning' ? 'constraint_violation' : 'type_mismatch',
-            sourceType: (sourceField.constructor as typeof Field).type,
-            targetType: (targetField.constructor as typeof Field).type,
-            constraintDetail: validation.severity === 'warning' ? validation.error : undefined,
-          })
+          // Only track if this edge hasn't been reported yet to avoid duplicates on graph rebuilds
+          const errorMap = targetOp.connectionErrors.value
+          const isNewError = !errorMap.has(edge.id)
+          if (isNewError) {
+            // Don't send constraint details - may contain user values
+            analytics.track('connection_failed', {
+              failureType:
+                validation.severity === 'warning' ? 'constraint_violation' : 'type_mismatch',
+              sourceType: (sourceField.constructor as typeof Field).type,
+              targetType: (targetField.constructor as typeof Field).type,
+            })
+          }
         } else {
           // Clear any existing error for this edge if it's now valid (or not yet computed)
           targetOp.removeConnectionError(edge.id)

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -1,6 +1,7 @@
 import { getIncomers, type Node as ReactFlowNode } from '@xyflow/react'
+import { analytics } from '../utils/analytics'
 import { debugExecutor } from '../utils/debug'
-import { getFieldReferences, ListField } from './fields'
+import { type Field, getFieldReferences, ListField } from './fields'
 import { type Edge as ExecutorEdge, updateGraph } from './graph-executor'
 import type { Edge } from './noodles'
 import type { IOperator, Operator, OpType } from './operators'
@@ -417,6 +418,13 @@ export function transformGraph<
         const validation = validateConnection(sourceField, targetField)
         if (!validation.valid && validation.error && sourceField.value !== undefined) {
           targetOp.addConnectionError(edge.id, validation.error)
+          analytics.track('connection_failed', {
+            failureType:
+              validation.severity === 'warning' ? 'constraint_violation' : 'type_mismatch',
+            sourceType: (sourceField.constructor as typeof Field).type,
+            targetType: (targetField.constructor as typeof Field).type,
+            constraintDetail: validation.severity === 'warning' ? validation.error : undefined,
+          })
         } else {
           // Clear any existing error for this edge if it's now valid (or not yet computed)
           targetOp.removeConnectionError(edge.id)

--- a/noodles-editor/src/utils/geocoding.ts
+++ b/noodles-editor/src/utils/geocoding.ts
@@ -1,4 +1,5 @@
 import { getKeysStore } from '../noodles/keys-store'
+import { analytics } from './analytics'
 import { debugGeocode } from './debug'
 
 export interface GeocodingResult {
@@ -156,6 +157,14 @@ export async function geocodeWithGooglePlaces(query: string): Promise<GeocodingR
     return results
   } catch (error) {
     debugGeocode('Google Places API error:', error)
+    analytics.track('geocoding_failed', {
+      service: 'google',
+      statusCode: undefined,
+      reason:
+        error instanceof Error && error.message.includes('API key')
+          ? 'api_key_missing'
+          : 'network_error',
+    })
     throw error
   }
 }
@@ -165,17 +174,30 @@ export async function geocodeWithMapbox(query: string, apiKey: string): Promise<
   const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(query)}.json?access_token=${apiKey}&limit=5`
   const response = await fetch(url)
   if (!response.ok) {
+    const reason =
+      response.status === 429
+        ? 'rate_limit'
+        : response.status === 404
+          ? 'not_found'
+          : 'network_error'
+    analytics.track('geocoding_failed', {
+      service: 'mapbox',
+      statusCode: response.status,
+      reason,
+    })
     throw new Error(`Mapbox geocoding failed: ${response.status} ${response.statusText}`)
   }
 
   const data: MapboxGeocodingResponse = await response.json()
-  return (data.features ?? []).map(feature => ({
+  const results = (data.features ?? []).map(feature => ({
     place_name: feature.place_name,
     coordinates: {
       longitude: feature.center[0],
       latitude: feature.center[1],
     },
   }))
+
+  return results
 }
 
 // Geocode using Photon API (free, OSM-based)


### PR DESCRIPTION
## Summary

Add privacy-preserving analytics events to track user failures and dead-end scenarios across the application. This helps identify where users get stuck and prioritize improvements.

**Events added:**
- `file_imported` / `file_import_failed` - Track file import successes/failures with file type, format, source, size, and failure reason (unsupported type, no project, write failed, size limit)
- `storage_error_encountered` - Track file system errors (permission denied, not found, unsupported, invalid state, security errors)
- `connection_failed` - Track connection validation failures (type mismatches, constraint violations)
- `error_boundary_max_resets` - Track when users hit maximum error boundary reset attempts
- `project_load_error` - Track project loading issues (unknown operators, broken connections, execution errors)
- `geocoding_failed` - Track geocoding API failures and rate limits

**Code improvements:**
- Exported `extensionOf()` utility from `import-pipelines.ts` for consistent file extension extraction (handles query strings and case normalization)
- Replaced inline `file.name.split('.').pop()` calls with centralized utility

**Privacy:**
- No file names, paths, or user data tracked
- Only file extensions, error types, and categorical data
- All events follow existing analytics conventions and automatic PII filtering

## Test plan

**Manual testing:**
1. Drop an unsupported file type (e.g., `.txt`, `.pdf`) onto canvas → verify `file_import_failed` event with `reason: 'unsupported_type'`
2. Try importing without a project loaded → verify `file_import_failed` with `reason: 'no_project'`
3. Import a valid `.csv` file → verify `file_imported` event with correct file type and format
4. Attempt to connect incompatible operator types → verify `connection_failed` event
5. Check PostHog events to confirm no PII (file names, paths) appears

**Verification:**
- Enable analytics debug logging: `localStorage.debug = 'noodles:analytics'` in browser console
- Reload page and perform above actions
- Check console for tracked events

🤖 Generated with [Claude Code](https://claude.com/claude-code)