### PR TITLE
Make analytics and error tracking failures user-visible

### DIFF
--- a/noodles-editor/src/index.tsx
+++ b/noodles-editor/src/index.tsx
@@ -11,7 +11,55 @@ import { analytics } from './utils/analytics'
 // Initialize analytics
 analytics.initialize()
 
-// Log uncaught errors and unhandled promise rejections to the console
+// Show user-visible error notifications
+function showErrorNotification(message: string, details?: string) {
+  console.error('[Noodles] Error:', message, details)
+
+  const banner = document.createElement('div')
+  banner.style.cssText = `
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: #2d2d2d;
+    color: #ff6b6b;
+    padding: 16px 20px;
+    border-radius: 8px;
+    z-index: 10000;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 13px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+    max-width: 400px;
+    border: 1px solid #ff6b6b;
+  `
+  banner.innerHTML = `
+    <div style="display: flex; align-items: start; gap: 12px;">
+      <span style="font-size: 20px;">❌</span>
+      <div style="flex: 1;">
+        <div style="font-weight: 600; margin-bottom: 4px;">${message}</div>
+        ${details ? `<div style="font-size: 11px; color: #999; font-family: monospace;">${details}</div>` : ''}
+      </div>
+      <button style="
+        background: transparent;
+        border: none;
+        color: #999;
+        cursor: pointer;
+        font-size: 18px;
+        padding: 0;
+        line-height: 1;
+      ">×</button>
+    </div>
+  `
+
+  const dismissBtn = banner.querySelector('button')
+  dismissBtn?.addEventListener('click', () => banner.remove())
+
+  document.body.appendChild(banner)
+
+  // Auto-dismiss after 15 seconds
+  setTimeout(() => banner.remove(), 15000)
+}
+
+// Log uncaught errors and unhandled promise rejections
 window.addEventListener('error', e => {
   // Ignore benign ResizeObserver errors - these are harmless browser warnings
   // that occur when ResizeObserver callbacks trigger layout changes
@@ -21,10 +69,13 @@ window.addEventListener('error', e => {
     return
   }
   console.error('[Noodles] uncaught error:', e.error ?? e.message)
+  showErrorNotification('Uncaught error occurred', message)
 })
-window.addEventListener('unhandledrejection', e =>
+window.addEventListener('unhandledrejection', e => {
   console.error('[Noodles] unhandled rejection:', e.reason)
-)
+  const message = e.reason?.message || String(e.reason)
+  showErrorNotification('Unhandled promise rejection', message)
+})
 
 // Initialize keyboard manager
 keyboardManager.init()
@@ -66,3 +117,10 @@ root.render(
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals()
+
+// Listen for analytics errors and make them visible to the user
+window.addEventListener('noodles:analytics-error', ((e: CustomEvent) => {
+  const { message, error } = e.detail
+  const details = error?.message || error?.toString()
+  showErrorNotification(message, details)
+}) as EventListener)

--- a/noodles-editor/src/reportWebVitals.ts
+++ b/noodles-editor/src/reportWebVitals.ts
@@ -3,53 +3,102 @@ import { analytics } from './utils/analytics'
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   // Consolidate web-vitals import to avoid duplicate module loading
-  import('web-vitals').then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
-    // Register optional performance entry handler
-    if (onPerfEntry && onPerfEntry instanceof Function) {
-      onCLS(onPerfEntry)
-      onINP(onPerfEntry)
-      onFCP(onPerfEntry)
-      onLCP(onPerfEntry)
-      onTTFB(onPerfEntry)
-    }
+  import('web-vitals')
+    .then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
+      // Defensive wrapper to catch web-vitals internal errors
+      const safeMetricHandler = (handler: (metric: any) => void, metricName: string) => {
+        return (metric: any) => {
+          try {
+            handler(metric)
+          } catch (error) {
+            console.error(`Web vitals ${metricName} measurement failed:`, error)
+            // Make error visible to user
+            if (typeof window !== 'undefined') {
+              const errorMsg = `Performance tracking error (${metricName}): ${error instanceof Error ? error.message : 'Unknown error'}`
+              // Dispatch a custom event that the app can listen to
+              window.dispatchEvent(
+                new CustomEvent('noodles:analytics-error', {
+                  detail: { message: errorMsg, error },
+                })
+              )
+            }
+          }
+        }
+      }
 
-    // Send web vitals to PostHog analytics
-    onCLS(metric => {
-      analytics.track('web_vital_measured', {
-        name: metric.name,
-        value: metric.value,
-        rating: metric.rating,
-      })
+      // Register optional performance entry handler
+      if (onPerfEntry && onPerfEntry instanceof Function) {
+        try {
+          onCLS(safeMetricHandler(onPerfEntry, 'CLS'))
+          onINP(safeMetricHandler(onPerfEntry, 'INP'))
+          onFCP(safeMetricHandler(onPerfEntry, 'FCP'))
+          onLCP(safeMetricHandler(onPerfEntry, 'LCP'))
+          onTTFB(safeMetricHandler(onPerfEntry, 'TTFB'))
+        } catch (error) {
+          console.error('Failed to register web vitals handlers:', error)
+        }
+      }
+
+      // Send web vitals to PostHog analytics
+      onCLS(
+        safeMetricHandler(metric => {
+          analytics.track('web_vital_measured', {
+            name: metric.name,
+            value: metric.value,
+            rating: metric.rating,
+          })
+        }, 'CLS')
+      )
+      onINP(
+        safeMetricHandler(metric => {
+          analytics.track('web_vital_measured', {
+            name: metric.name,
+            value: metric.value,
+            rating: metric.rating,
+          })
+        }, 'INP')
+      )
+      onFCP(
+        safeMetricHandler(metric => {
+          analytics.track('web_vital_measured', {
+            name: metric.name,
+            value: metric.value,
+            rating: metric.rating,
+          })
+        }, 'FCP')
+      )
+      onLCP(
+        safeMetricHandler(metric => {
+          analytics.track('web_vital_measured', {
+            name: metric.name,
+            value: metric.value,
+            rating: metric.rating,
+          })
+        }, 'LCP')
+      )
+      onTTFB(
+        safeMetricHandler(metric => {
+          analytics.track('web_vital_measured', {
+            name: metric.name,
+            value: metric.value,
+            rating: metric.rating,
+          })
+        }, 'TTFB')
+      )
     })
-    onINP(metric => {
-      analytics.track('web_vital_measured', {
-        name: metric.name,
-        value: metric.value,
-        rating: metric.rating,
-      })
+    .catch(error => {
+      console.error('Failed to load web-vitals library:', error)
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+          new CustomEvent('noodles:analytics-error', {
+            detail: {
+              message: 'Performance tracking unavailable',
+              error,
+            },
+          })
+        )
+      }
     })
-    onFCP(metric => {
-      analytics.track('web_vital_measured', {
-        name: metric.name,
-        value: metric.value,
-        rating: metric.rating,
-      })
-    })
-    onLCP(metric => {
-      analytics.track('web_vital_measured', {
-        name: metric.name,
-        value: metric.value,
-        rating: metric.rating,
-      })
-    })
-    onTTFB(metric => {
-      analytics.track('web_vital_measured', {
-        name: metric.name,
-        value: metric.value,
-        rating: metric.rating,
-      })
-    })
-  })
 }
 
 export default reportWebVitals


### PR DESCRIPTION
Closes #

#### Background

Web vitals and analytics errors were failing silently in the console with no user feedback.

#### Change List

- Wrap web-vitals callbacks in try-catch to prevent silent failures
- Add `showErrorNotification()` for user-visible error banners
- Surface uncaught errors and unhandled rejections with dismissible notifications
- Display analytics errors via custom event system
- All error notifications auto-dismiss after 15 seconds
- Banners appear bottom-right with technical details for debugging