### PR TITLE
docs: Move API keys to separate page and add NYC Taxis CTA

### DIFF
--- a/docs/users/ai-assistant.md
+++ b/docs/users/ai-assistant.md
@@ -201,6 +201,7 @@ Your conversation history is preserved when switching.
 - Get an API key from [console.anthropic.com](https://console.anthropic.com/)
 - Check "Remember key" to save it across sessions (stored in your browser)
 - Click "Get API key" for help signing up
+- For general API key management (Mapbox, Google Maps, etc.), see [API Keys Configuration](./api-keys.md)
 
 ### Conversation Settings
 

--- a/docs/users/api-keys.md
+++ b/docs/users/api-keys.md
@@ -1,0 +1,52 @@
+# API Keys Configuration
+
+Configure API keys for external services used by Noodles.gl. Access settings via the gear icon in the top menu bar.
+
+## Key Sources
+
+Keys are resolved in priority order:
+1. **Browser** - Stored in localStorage, persists across sessions
+2. **Project** - Loaded from and retained in the project file until explicitly removed
+3. **Environment** - Set via environment variables
+
+The first source with a valid key is used automatically.
+
+## Supported Keys
+
+| Key | Purpose | Required For |
+|-----|---------|--------------|
+| Mapbox Access Token | Basemaps, directions | MaplibreBasemapOp with Mapbox styles |
+| Google Maps API Key | Places geocoding | Create Point wizard, DirectionsOp |
+| Anthropic API Key | Claude AI assistant | [AI chat features](./ai-assistant.md) |
+
+### Mapbox Access Token
+
+Used for Mapbox basemap styles and routing directions. Create a free account at [mapbox.com](https://www.mapbox.com/) to obtain a token.
+
+### Google Maps API Key
+
+Required for the Create Point geocoding wizard and DirectionsOp. Enable the Places API in the [Google Cloud Console](https://console.cloud.google.com/).
+
+### Anthropic API Key
+
+Powers the in-app AI assistant. See the [AI Assistant guide](./ai-assistant.md) for detailed setup instructions.
+
+## Privacy and Security
+
+API keys are stored locally and never sent to Noodles.gl servers. Browser keys are stored in localStorage. 
+
+### Sharing Projects with Keys
+
+Enabling **Add browser keys to this project** copies them into `noodles.json`, where they are stored in plain text and travel with the project. Only share projects containing keys with trusted collaborators. Loaded project keys remain in subsequent saves until removed from App Settings.
+
+## Environment Variables
+
+For development or CI/CD, set keys via environment variables:
+
+```bash
+VITE_MAPBOX_ACCESS_TOKEN=your_token_here
+VITE_GOOGLE_MAPS_API_KEY=your_key_here
+VITE_CLAUDE_API_KEY=your_key_here
+```
+
+These are read at build time and bundled into the application.

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -57,34 +57,19 @@ Drag-and-drop or browse for CSV/JSON files. The importer automatically creates a
 4. **Animate**: [Add timeline keyframes](./animation-and-rendering.md) to create smooth animations
 5. **Export**: Generate images, videos, or interactive applications
 
-## API Keys Configuration
+## Try the NYC Taxis Example
 
-Access API key settings via the gear icon in the top menu bar.
+See Noodles.gl in action with a real-world dataset:
 
-### Key Sources
+[**Open NYC Taxis Example →**](https://noodles.gl/examples/nyc-taxis)
 
-Keys are resolved in priority order:
-1. **Browser** - Stored in localStorage, persists across sessions
-2. **Project** - Loaded from and retained in the project file until explicitly removed
-3. **Environment** - Set via environment variables
+This example visualizes millions of NYC taxi trips using:
+- Arc layers connecting pickup and dropoff locations
+- Brushing interaction to filter trips
+- Timeline animation showing temporal patterns
 
-The first source with a valid key is used automatically.
+If running locally: `http://localhost:5173/examples/nyc-taxis`
 
-### Supported Keys
+## Need API Keys?
 
-| Key | Purpose | Required For |
-|-----|---------|--------------|
-| Mapbox Access Token | Basemaps, directions | MaplibreBasemapOp with Mapbox styles |
-| Google Maps API Key | Places geocoding | Create Point wizard, DirectionsOp |
-| Anthropic API Key | Claude AI assistant | AI chat features |
-
-### Privacy
-
-API keys are stored locally and never sent to Noodles.gl servers. Browser keys are stored in localStorage. Enabling **Add browser keys to this project** copies them into `noodles.json`, where they are stored in plain text and travel with the project. Only share projects containing keys with trusted collaborators. Loaded project keys remain in subsequent saves until removed from App Settings.
-
-### Environment Variables
-
-For development or CI/CD, set keys via environment variables:
-- `VITE_MAPBOX_ACCESS_TOKEN`
-- `VITE_GOOGLE_MAPS_API_KEY`
-- `VITE_CLAUDE_API_KEY`
+Some features require API keys for external services. See [API Keys Configuration](./api-keys.md) for setup instructions.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -20,6 +20,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'users/getting-started',
+        'users/api-keys',
         'users/workflows-intro',
         'users/properties-panel',
         'users/expressions',


### PR DESCRIPTION
#### Background
The getting started guide included a lengthy API keys section that interrupted the onboarding flow. Users should see a quick path to trying the app before diving into configuration.

#### Change List
- Created new `/docs/users/api-keys.md` with dedicated API keys reference
- Removed API keys section from getting-started.md (lines 60-91)
- Added prominent "Try the NYC Taxis Example" call-to-action in getting started
- Added api-keys page to sidebar navigation after getting-started
- Cross-referenced api-keys page from ai-assistant.md