### PR TITLE
fix: only show FileOp autoType input for csv/tsv formats

### DIFF
--- a/noodles-editor/src/noodles/components/__tests__/field-subscription-optimization.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/field-subscription-optimization.test.tsx
@@ -73,20 +73,26 @@ describe('field subscription optimization', () => {
       // Add custom field definitions with enable expressions
       op.customInputDefinitions = [
         {
+          id: crypto.randomUUID(),
           name: 'conditionalField',
           type: 'number',
-          default: 0,
+          defaultValue: 0,
+          order: 1,
           enableExpression: "par.mode === 'advanced'",
         },
         {
+          id: crypto.randomUUID(),
           name: 'mode',
           type: 'string',
-          default: 'simple',
+          order: 2,
+          defaultValue: 'simple',
         },
         {
+          id: crypto.randomUUID(),
           name: 'unused',
           type: 'number',
-          default: 0,
+          order: 3,
+          defaultValue: 0,
         },
       ]
 
@@ -135,37 +141,49 @@ describe('field subscription optimization', () => {
 
       op.customInputDefinitions = [
         {
+          id: crypto.randomUUID(),
           name: 'field1',
           type: 'number',
-          default: 0,
+          defaultValue: 0,
+          order: 1,
           enableExpression: 'par.enabled',
         },
         {
+          id: crypto.randomUUID(),
           name: 'field2',
           type: 'number',
-          default: 0,
+          defaultValue: 0,
+          order: 2,
           enableExpression: 'par.mode === "advanced"',
         },
         {
+          id: crypto.randomUUID(),
           name: 'field3',
           type: 'number',
-          default: 0,
+          defaultValue: 0,
+          order: 3,
           enableExpression: 'par.enabled && par.value > 10',
         },
         {
+          id: crypto.randomUUID(),
           name: 'enabled',
           type: 'boolean',
-          default: false,
+          order: 4,
+          defaultValue: false,
         },
         {
+          id: crypto.randomUUID(),
           name: 'mode',
           type: 'string',
-          default: 'simple',
+          order: 5,
+          defaultValue: 'simple',
         },
         {
+          id: crypto.randomUUID(),
           name: 'value',
           type: 'number',
-          default: 0,
+          order: 6,
+          defaultValue: 0,
         },
       ]
 
@@ -208,26 +226,32 @@ describe('field subscription optimization', () => {
       // Add fields with enable expressions (only 2)
       for (let i = 0; i < expressionFieldCount; i++) {
         op.customInputDefinitions.push({
+          id: crypto.randomUUID(),
           name: `conditionalField${i}`,
           type: 'number',
-          default: 0,
+          defaultValue: 0,
+          order: i,
           enableExpression: 'par.masterEnabled',
         })
       }
 
       // Add control field
       op.customInputDefinitions.push({
+        id: crypto.randomUUID(),
         name: 'masterEnabled',
         type: 'boolean',
-        default: false,
+        order: expressionFieldCount,
+        defaultValue: false,
       })
 
       // Add many fields without enable expressions
       for (let i = expressionFieldCount; i < fieldCount; i++) {
         op.customInputDefinitions.push({
+          id: crypto.randomUUID(),
           name: `field${i}`,
           type: 'number',
-          default: 0,
+          order: i,
+          defaultValue: 0,
         })
       }
 

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -2718,6 +2718,7 @@ describe('FileOp', () => {
         format: 'json',
         url: '',
         text: JSON.stringify(testData),
+        autoType: true,
         pulse: 0,
       })
       expect(result.data).toEqual(testData)
@@ -2734,6 +2735,7 @@ describe('FileOp', () => {
         format: 'json',
         url: 'https://example.com/data.json',
         text: '',
+        autoType: true,
         pulse: 0,
       })
       expect(result.data).toEqual(testData)
@@ -2747,6 +2749,7 @@ describe('FileOp', () => {
           format: 'json',
           url: '',
           text: 'invalid json',
+          autoType: true,
           pulse: 0,
         })
       ).rejects.toThrow()
@@ -2754,11 +2757,15 @@ describe('FileOp', () => {
   })
 
   describe('CSV format', () => {
-    it('should create autoType input when type set to csv', () => {
-      const operator = new FileOp('/file-csv-autotype')
-      expect(operator.inputs).not.toHaveKey('autoType')
+    it('should only show autoType input when format is csv or tsv', () => {
+      const operator = new FileOp('/file-format-autotype-visibility')
+      expect(operator.isFieldVisible('autoType')).toBe(false)
       operator.inputs.format.setValue('csv')
-      expect(operator.inputs).toHaveKey('autoType')
+      expect(operator.isFieldVisible('autoType')).toBe(true)
+      operator.inputs.format.setValue('tsv')
+      expect(operator.isFieldVisible('autoType')).toBe(true)
+      operator.inputs.format.setValue('json')
+      expect(operator.isFieldVisible('autoType')).toBe(false)
     })
 
     it('should parse CSV from text input', async () => {
@@ -2778,7 +2785,7 @@ describe('FileOp', () => {
     })
 
     it('should parse CSV without autoType as strings', async () => {
-      const operator = new FileOp('/file-csv-autotype')
+      const operator = new FileOp('/file-csv-no-autotype')
       const csvText = 'name,value\nJohn,30\nJane,25'
       const result = await operator.execute({
         format: 'csv',

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -2712,20 +2712,19 @@ describe('FileOp', () => {
 
   describe('JSON format', () => {
     it('should parse JSON from text input', async () => {
-      const operator = new FileOp('/file-0')
+      const operator = new FileOp('/file-json-text')
       const testData = { test: 'data', value: 123 }
       const result = await operator.execute({
         format: 'json',
         url: '',
         text: JSON.stringify(testData),
-        autoType: true,
         pulse: 0,
       })
       expect(result.data).toEqual(testData)
     })
 
     it('should fetch and parse JSON from URL', async () => {
-      const operator = new FileOp('/file-1')
+      const operator = new FileOp('/file-json-url')
       const testData = { test: 'remote', value: 456 }
       global.fetch = vi.fn().mockResolvedValue({
         json: () => Promise.resolve(testData),
@@ -2735,7 +2734,6 @@ describe('FileOp', () => {
         format: 'json',
         url: 'https://example.com/data.json',
         text: '',
-        autoType: true,
         pulse: 0,
       })
       expect(result.data).toEqual(testData)
@@ -2743,13 +2741,12 @@ describe('FileOp', () => {
     })
 
     it('should throw error for invalid JSON', async () => {
-      const operator = new FileOp('/file-2')
+      const operator = new FileOp('/file-invalid-json')
       await expect(
         operator.execute({
           format: 'json',
           url: '',
           text: 'invalid json',
-          autoType: true,
           pulse: 0,
         })
       ).rejects.toThrow()
@@ -2757,8 +2754,15 @@ describe('FileOp', () => {
   })
 
   describe('CSV format', () => {
+    it('should create autoType input when type set to csv', () => {
+      const operator = new FileOp('/file-csv-autotype')
+      expect(operator.inputs).not.toHaveKey('autoType')
+      operator.inputs.format.setValue('csv')
+      expect(operator.inputs).toHaveKey('autoType')
+    })
+
     it('should parse CSV from text input', async () => {
-      const operator = new FileOp('/file-3')
+      const operator = new FileOp('/file-csv-text')
       const csvText = 'name,value\nJohn,30\nJane,25'
       const result = await operator.execute({
         format: 'csv',
@@ -2773,8 +2777,8 @@ describe('FileOp', () => {
       expect(result.data[1]).toEqual({ name: 'Jane', value: 25 })
     })
 
-    it('should parse CSV without autoType', async () => {
-      const operator = new FileOp('/file-4')
+    it('should parse CSV without autoType as strings', async () => {
+      const operator = new FileOp('/file-csv-autotype')
       const csvText = 'name,value\nJohn,30\nJane,25'
       const result = await operator.execute({
         format: 'csv',
@@ -2792,7 +2796,7 @@ describe('FileOp', () => {
 
   describe('TSV format', () => {
     it('should parse TSV from text input', async () => {
-      const operator = new FileOp('/file-tsv-0')
+      const operator = new FileOp('/file-tsv-text')
       const tsvText = 'name\tvalue\nJohn\t30\nJane\t25'
       const result = await operator.execute({
         format: 'tsv',
@@ -2806,8 +2810,8 @@ describe('FileOp', () => {
       expect(result.data[1]).toEqual({ name: 'Jane', value: 25 })
     })
 
-    it('should parse TSV without autoType', async () => {
-      const operator = new FileOp('/file-tsv-1')
+    it('should parse TSV without autoType as strings', async () => {
+      const operator = new FileOp('/file-tsv-no-autotype')
       const tsvText = 'name\tvalue\nJohn\t30\nJane\t25'
       const result = await operator.execute({
         format: 'tsv',
@@ -2824,7 +2828,7 @@ describe('FileOp', () => {
 
   describe('Text format', () => {
     it('should return text from text input', async () => {
-      const operator = new FileOp('/file-5')
+      const operator = new FileOp('/file-text')
       const textContent = 'This is plain text content\nwith multiple lines'
       const result = await operator.execute({
         format: 'text',
@@ -2837,7 +2841,7 @@ describe('FileOp', () => {
     })
 
     it('should fetch text from URL', async () => {
-      const operator = new FileOp('/file-6')
+      const operator = new FileOp('/file-text-url')
       const textContent = 'Remote text content'
       global.fetch = vi.fn().mockResolvedValue({
         text: () => Promise.resolve(textContent),
@@ -2855,7 +2859,7 @@ describe('FileOp', () => {
     })
 
     it('should return empty string when no input provided', async () => {
-      const operator = new FileOp('/file-7')
+      const operator = new FileOp('/file-text-empty')
       const result = await operator.execute({
         format: 'text',
         url: '',
@@ -2869,7 +2873,7 @@ describe('FileOp', () => {
 
   describe('Binary format', () => {
     it('should convert text input to Uint8Array', async () => {
-      const operator = new FileOp('/file-8')
+      const operator = new FileOp('/file-binary-uint8')
       const textContent = 'Binary data as text'
       const result = await operator.execute({
         format: 'binary',
@@ -2888,7 +2892,7 @@ describe('FileOp', () => {
     })
 
     it('should fetch binary data from URL', async () => {
-      const operator = new FileOp('/file-9')
+      const operator = new FileOp('/file-binary-url')
       const binaryData = new ArrayBuffer(8)
       const view = new Uint8Array(binaryData)
       view.set([1, 2, 3, 4, 5, 6, 7, 8])
@@ -2910,7 +2914,7 @@ describe('FileOp', () => {
     })
 
     it('should return empty Uint8Array when no input provided', async () => {
-      const operator = new FileOp('/file-10')
+      const operator = new FileOp('/file-uint8-empty')
       const result = await operator.execute({
         format: 'binary',
         url: '',
@@ -2924,7 +2928,7 @@ describe('FileOp', () => {
     })
 
     it('should handle UTF-8 encoded text in binary format', async () => {
-      const operator = new FileOp('/file-11')
+      const operator = new FileOp('/file-utf8-binary')
       const textWithEmoji = 'Hello 👋 World'
       const result = await operator.execute({
         format: 'binary',
@@ -2944,7 +2948,7 @@ describe('FileOp', () => {
 
   describe('Error handling', () => {
     it('should throw error with descriptive message on fetch failure', async () => {
-      const operator = new FileOp('/file-12')
+      const operator = new FileOp('/file-fetch-error')
       global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
 
       await expect(
@@ -2959,7 +2963,7 @@ describe('FileOp', () => {
     })
 
     it('should throw error for unsupported format', async () => {
-      const operator = new FileOp('/file-13')
+      const operator = new FileOp('/file-unsupported-error')
       await expect(
         operator.execute({
           format: 'unsupported' as any,

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -1904,11 +1904,26 @@ export class FileOp extends Operator<FileOp> {
   asDownload = () => this.outputData
 
   createInputs() {
+    const fileFormat = new StringLiteralField('json', { values: ['json', 'csv', 'tsv', 'text', 'binary'] })
+
+    fileFormat.subscribe((val) => {
+      if (val === 'csv' || val === 'tsv') {
+        this.addCustomInput({
+          id: crypto.randomUUID(),
+          name: 'autoType',
+          type: 'boolean',
+          order: 4,
+          defaultValue: true,
+        })
+      } else {
+        this.removeCustomInput('autoType')
+      }
+    })
+
     return {
-      format: new StringLiteralField('json', { values: ['json', 'csv', 'tsv', 'text', 'binary'] }),
+      format: fileFormat,
       url: new FileUrlField(),
-      text: new StringField(),
-      autoType: new BooleanField(true), // TODO: Make this only available for csv
+      text: new StringField(), // TODO: make this mutually exclusive with `url`
       pulse: new NumberField(0, { min: 0, step: 1, showByDefault: false }),
     }
   }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -1909,7 +1909,7 @@ export class FileOp extends Operator<FileOp> {
       url: new FileUrlField(),
       text: new StringField(),
       autoType: new BooleanField(true), // TODO: Make this only available for csv
-      pulse: new NumberField(0, { min: 0, step: 1 }),
+      pulse: new NumberField(0, { min: 0, step: 1, showByDefault: false }),
     }
   }
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -1903,27 +1903,21 @@ export class FileOp extends Operator<FileOp> {
     'Fetch a file from a URL or text. Supports csv, tsv, json, text, and binary formats'
   asDownload = () => this.outputData
 
-  createInputs() {
-    const fileFormat = new StringLiteralField('json', { values: ['json', 'csv', 'tsv', 'text', 'binary'] })
+  constructor(id: OpId, inputs?: unknown, locked?: boolean) {
+    super(id, inputs, locked)
 
-    fileFormat.subscribe((val) => {
-      if (val === 'csv' || val === 'tsv') {
-        this.addCustomInput({
-          id: crypto.randomUUID(),
-          name: 'autoType',
-          type: 'boolean',
-          order: 4,
-          defaultValue: true,
-        })
-      } else {
-        this.removeCustomInput('autoType')
-      }
+    const sub = this.inputs.format.subscribe(format => {
+      this.setFieldVisibility('autoType', format === 'csv' || format === 'tsv')
     })
+    this.subs.push(sub)
+  }
 
+  createInputs() {
     return {
-      format: fileFormat,
+      format: new StringLiteralField('json', { values: ['json', 'csv', 'tsv', 'text', 'binary'] }),
       url: new FileUrlField(),
       text: new StringField(), // TODO: make this mutually exclusive with `url`
+      autoType: new BooleanField(true, { showByDefault: false }),
       pulse: new NumberField(0, { min: 0, step: 1, showByDefault: false }),
     }
   }


### PR DESCRIPTION
## Summary
- `autoType` now only appears in the FileOp UI when `format` is `csv` or `tsv`, hidden otherwise.
- Fixes a bug in the original approach: routing the toggle through `addCustomInput`/`removeCustomInput` (with the subscription set up inside `createInputs()`) caused an infinite `rebuildInputs()` recursion — every rebuild recreated the `format` field, whose fresh subscription fired immediately and re-triggered the rebuild. This crashed the browser tab as soon as `format` was set to `csv`.
- Fix: keep `autoType` as a normal, always-present input (as before) and toggle its visibility once via the existing `showField`/`hideField`/`isFieldVisible` mechanism (same one used for hiding `pulse` by default), subscribing in the constructor rather than inside `createInputs()`.
- Also fixes a non-existent `toHaveKey` matcher in the new test (real one is `toHaveProperty`), and de-duplicates a reused test id.

## Test plan
- [x] `npm test src/noodles/operators.test.ts` — 293/293 passing
- [x] Manually reproduced the crash on the prior version by calling `operator.inputs.format.setValue('csv')` in a scratch test; confirmed fixed on this branch
- [ ] Load a project with a FileOp node, switch format between json/csv/tsv/text/binary in the browser and confirm `autoType` shows only for csv/tsv

🤖 Generated with [Claude Code](https://claude.com/claude-code)