### PR TITLE
Fix TableEditor schema persistence and defaults

### DIFF
--- a/noodles-editor/src/noodles/components/table-editor.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.test.tsx
@@ -247,6 +247,84 @@ describe('TableEditor', () => {
     expect(getByText(/1 row × 2 columns/i)).toBeDefined()
   })
 
+  it('applies declared defaults when an inherited schema adds columns', () => {
+    const onDataChange = vi.fn()
+    const onSchemaChange = vi.fn()
+    const initialSchema: TableSchema = {
+      columns: [{ name: 'name', type: 'string', defaultValue: '' }],
+    }
+    const inheritedSchema: TableSchema = {
+      columns: [
+        { name: 'name', type: 'string', defaultValue: '' },
+        {
+          name: 'anchor',
+          type: 'stringLiteral',
+          defaultValue: 'start',
+          options: { values: ['start', 'end', 'middle'] },
+        },
+        { name: 'offset', type: 'vec2', defaultValue: [64, 0] },
+      ],
+    }
+    const data = [{ name: 'Downtown Skyport' }]
+
+    const { getByText, rerender } = render(
+      <TableEditor
+        op={mockOp}
+        data={data}
+        schema={initialSchema}
+        onDataChange={onDataChange}
+        onSchemaChange={onSchemaChange}
+      />
+    )
+
+    rerender(
+      <TableEditor
+        op={mockOp}
+        data={data}
+        schema={inheritedSchema}
+        onDataChange={onDataChange}
+        onSchemaChange={onSchemaChange}
+      />
+    )
+
+    expect(getByText('start')).toBeDefined()
+    expect(getByText('[64.0000, 0.0000]')).toBeDefined()
+  })
+
+  it('preserves compatible custom values when an unchanged schema is saved', () => {
+    const onSchemaChange = vi.fn()
+    const schema: TableSchema = {
+      columns: [
+        {
+          name: 'anchor',
+          type: 'stringLiteral',
+          defaultValue: 'start',
+          options: { values: ['start', 'end', 'middle'] },
+        },
+        { name: 'offset', type: 'vec2', defaultValue: [64, 0] },
+      ],
+    }
+    const data = [
+      { anchor: 'end', offset: [-64, 0] },
+      { anchor: 'middle', offset: [12, 24] },
+    ]
+
+    const { container, getByRole } = render(
+      <TableEditor
+        op={mockOp}
+        data={data}
+        schema={schema}
+        onDataChange={vi.fn()}
+        onSchemaChange={onSchemaChange}
+      />
+    )
+
+    fireEvent.click(container.querySelector('.pi-cog') as Element)
+    fireEvent.click(getByRole('button', { name: /save/i }))
+
+    expect(onSchemaChange).toHaveBeenCalledWith(schema, data)
+  })
+
   it('should add default values for all column types when adding row', () => {
     const complexSchema: TableSchema = {
       columns: [

--- a/noodles-editor/src/noodles/components/table-editor.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.test.tsx
@@ -325,6 +325,49 @@ describe('TableEditor', () => {
     expect(onSchemaChange).toHaveBeenCalledWith(schema, data)
   })
 
+  it('flushes an active edit before applying an inherited schema update', () => {
+    const onDataChange = vi.fn()
+    const initialSchema: TableSchema = {
+      columns: [{ name: 'name', type: 'string', defaultValue: '' }],
+    }
+    const inheritedSchema: TableSchema = {
+      columns: [
+        { name: 'name', type: 'string', defaultValue: '' },
+        { name: 'offset', type: 'vec2', defaultValue: [64, 0] },
+      ],
+    }
+    const data = [{ name: 'Downtown Skyport' }]
+
+    const { container, getByText, rerender } = render(
+      <TableEditor
+        op={mockOp}
+        data={data}
+        schema={initialSchema}
+        onDataChange={onDataChange}
+        onSchemaChange={vi.fn()}
+      />
+    )
+
+    fireEvent.click(getByText('Downtown Skyport'))
+    fireEvent.change(container.querySelector('input.p-inputtext') as HTMLInputElement, {
+      target: { value: 'Edited Skyport' },
+    })
+
+    rerender(
+      <TableEditor
+        op={mockOp}
+        data={data}
+        schema={inheritedSchema}
+        onDataChange={onDataChange}
+        onSchemaChange={vi.fn()}
+      />
+    )
+
+    expect(onDataChange).toHaveBeenCalledWith([{ name: 'Edited Skyport' }], 'Edit cell name')
+    expect(getByText('Edited Skyport')).toBeDefined()
+    expect(getByText('[64.0000, 0.0000]')).toBeDefined()
+  })
+
   it('should add default values for all column types when adding row', () => {
     const complexSchema: TableSchema = {
       columns: [

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -864,6 +864,8 @@ interface TableEditorProps {
 export function TableEditor({ data, schema, onDataChange, onSchemaChange }: TableEditorProps) {
   const [tableData, setTableData] = useState(() => validateTableData(data, schema))
   const activeEdit = useActiveEdit()
+  const previousDataRef = useRef(data)
+  const previousSchemaRef = useRef(schema)
 
   // Mirrors tableData so a flushed cell edit and the row mutation that triggered
   // it can both run in one tick without the second reading stale state
@@ -877,8 +879,20 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
   }
 
   useEffect(() => {
-    setTableData(validateTableData(data, schema))
-  }, [data, schema])
+    const dataChanged = previousDataRef.current !== data
+    const schemaChanged = previousSchemaRef.current !== schema
+
+    // Commit and clear any active cell editor before external props replace the
+    // table state. For a schema-only update, normalize the just-committed local
+    // rows so compatible edits survive the schema transition.
+    activeEdit.flush()
+    const sourceData = schemaChanged && !dataChanged ? tableDataRef.current : data
+    const newTableData = validateTableData(sourceData, schema)
+    tableDataRef.current = newTableData
+    setTableData(newTableData)
+    previousDataRef.current = data
+    previousSchemaRef.current = schema
+  }, [activeEdit, data, schema])
 
   const addRow = () => {
     activeEdit.flush()

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -10,14 +10,13 @@ import { AutoComplete } from 'primereact/autocomplete'
 import { Button } from 'primereact/button'
 import { InputSwitch } from 'primereact/inputswitch'
 import { InputText } from 'primereact/inputtext'
-import { GeocodingDialog } from './geocoding-dialog'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { Temporal } from 'temporal-polyfill'
 import type { TableEditorOp } from '../operators'
 import type { ColumnSchema, ColumnType, DateTimeValue, TableSchema } from '../table-schema'
-import { convertValue, getDefaultValue, temporalToString } from '../table-schema'
+import { getDefaultValue, validateTableData } from '../table-schema'
 import { getTimezoneOptions } from '../utils/timezone-utils'
 import { ColorSwatch } from './color-swatch'
+import { GeocodingDialog } from './geocoding-dialog'
 import { SchemaEditorDialog } from './schema-editor-dialog'
 import s from './table-editor.module.css'
 
@@ -863,7 +862,7 @@ interface TableEditorProps {
 }
 
 export function TableEditor({ data, schema, onDataChange, onSchemaChange }: TableEditorProps) {
-  const [tableData, setTableData] = useState(data)
+  const [tableData, setTableData] = useState(() => validateTableData(data, schema))
   const activeEdit = useActiveEdit()
 
   // Mirrors tableData so a flushed cell edit and the row mutation that triggered
@@ -878,8 +877,8 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
   }
 
   useEffect(() => {
-    setTableData(data)
-  }, [data])
+    setTableData(validateTableData(data, schema))
+  }, [data, schema])
 
   const addRow = () => {
     activeEdit.flush()
@@ -892,20 +891,10 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
 
   const handleSchemaChange = (newSchema: TableSchema) => {
     activeEdit.flush()
-    // Update data to match new schema
-    const newData = tableDataRef.current.map(row => {
-      const newRow: Record<string, unknown> = {}
-      for (const col of newSchema.columns) {
-        const existingValue = row[col.name]
-        // Convert existing value to new type, or use default if missing
-        if (existingValue !== undefined) {
-          newRow[col.name] = convertValue(existingValue, col.type)
-        } else {
-          newRow[col.name] = col.defaultValue ?? getDefaultValue(col)
-        }
-      }
-      return newRow
-    })
+    // Preserve valid cells and materialize the new schema's declared defaults for
+    // missing or invalid cells. This is the same path used when a schema arrives
+    // through a connection, so custom vector and string-literal defaults agree.
+    const newData = validateTableData(tableDataRef.current, newSchema)
 
     onSchemaChange(newSchema, newData)
     tableDataRef.current = newData

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -62,6 +62,7 @@ import {
   S2LayerOp,
   SmoothOp,
   SwitchOp,
+  TableEditorOp,
   Tile3DLayerOp,
   TimeSeriesOp,
   TripsLayerOp,
@@ -75,6 +76,28 @@ describe('basic Operators', () => {
     const operator = new NumberOp('/num-0')
     expect(operator.data.val).toEqual(0)
     expect(operator.outputData.val).toEqual(0)
+  })
+})
+
+describe('TableEditorOp', () => {
+  it('materializes declared schema defaults in output data', () => {
+    const operator = new TableEditorOp('/table')
+    const schema = {
+      columns: [
+        {
+          name: 'anchor',
+          type: 'stringLiteral' as const,
+          defaultValue: 'start',
+          options: { values: ['start', 'end', 'middle'] },
+        },
+        { name: 'offset2d', type: 'vec2' as const, defaultValue: [64, 0] },
+        { name: 'offset3d', type: 'vec3' as const, defaultValue: [64, 0, 10] },
+      ],
+    }
+
+    const result = operator.execute({ data: [{}], schema })
+
+    expect(result.data).toEqual([{ anchor: 'start', offset2d: [64, 0], offset3d: [64, 0, 10] }])
   })
 })
 

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -99,6 +99,28 @@ describe('TableEditorOp', () => {
 
     expect(result.data).toEqual([{ anchor: 'start', offset2d: [64, 0], offset3d: [64, 0, 10] }])
   })
+
+  it('preserves date-time values when TableEditors are chained', () => {
+    const first = new TableEditorOp('/first')
+    const second = new TableEditorOp('/second')
+    const schema = {
+      columns: [{ name: 'time', type: 'dateTime' as const }],
+    }
+    const storedValue = {
+      datetime: '2026-09-05T12:30:00.000',
+      timezone: 'America/Los_Angeles',
+    }
+
+    const firstResult = first.execute({ data: [{ time: storedValue }], schema })
+    const secondResult = second.execute({ data: firstResult.data, schema })
+    const chainedValue = secondResult.data[0].time as Temporal.ZonedDateTime
+
+    expect(chainedValue).toBeInstanceOf(Temporal.ZonedDateTime)
+    expect(chainedValue.toPlainDateTime().toString({ smallestUnit: 'millisecond' })).toBe(
+      storedValue.datetime
+    )
+    expect(chainedValue.timeZoneId).toBe(storedValue.timezone)
+  })
 })
 
 describe('Operator par and out', () => {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -152,7 +152,7 @@ import {
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE, safeMode } from './globals'
 import { getKeysStore } from './keys-store'
 import { getAllOps, getOp } from './store'
-import { prepareTableDataForOutput, type TableSchema } from './table-schema'
+import { prepareTableDataForOutput, type TableSchema, validateTableData } from './table-schema'
 import type { ExtensionConstructorArgs, LayerPropsValue } from './types'
 import { composeAccessor, isAccessor } from './utils/accessor-helpers'
 import { deepEqual } from './utils/deep-equal'
@@ -2326,9 +2326,12 @@ export class TableEditorOp extends Operator<TableEditorOp> {
   }
 
   execute({ data, schema }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    const validatedData = schema ? validateTableData(data, schema as TableSchema) : data
     // Convert dateTime strings to Temporal.ZonedDateTime for output
     // This happens at the operator boundary: internal storage = strings, output = Temporal
-    const outputData = schema ? prepareTableDataForOutput(data, schema as TableSchema) : data
+    const outputData = schema
+      ? prepareTableDataForOutput(validatedData, schema as TableSchema)
+      : validatedData
 
     return {
       data: outputData,

--- a/noodles-editor/src/noodles/table-schema.ts
+++ b/noodles-editor/src/noodles/table-schema.ts
@@ -375,6 +375,17 @@ export function validateTableData(data: unknown[], schema: TableSchema): unknown
         continue
       }
 
+      // A chained TableEditor receives the upstream editor's output representation.
+      // Convert Temporal values back to the editable storage representation before
+      // validating so a valid date-time is not replaced with the column default.
+      if (col.type === 'dateTime' && value instanceof Temporal.ZonedDateTime) {
+        validatedRow[col.name] = {
+          datetime: temporalToString(value),
+          timezone: value.timeZoneId,
+        } satisfies DateTimeValue
+        continue
+      }
+
       // Validate value
       if (!validateValue(value, col)) {
         console.warn(

--- a/noodles-editor/src/noodles/utils/serialization.test.ts
+++ b/noodles-editor/src/noodles/utils/serialization.test.ts
@@ -54,6 +54,16 @@ describe('safeStringify', () => {
     expect(result).toContain('"arr": [\n    null\n  ]')
   })
 
+  it('preserves repeated non-circular references', () => {
+    const shared = { name: 'shared' }
+    const result = safeStringify({ first: shared, second: shared })
+
+    expect(JSON.parse(result)).toEqual({
+      first: { name: 'shared' },
+      second: { name: 'shared' },
+    })
+  })
+
   it('preserves optional name field in project JSON', () => {
     const projectWithName: NoodlesProjectJSON = {
       version: NOODLES_VERSION,
@@ -305,6 +315,34 @@ describe('serializeNodes', () => {
     const [result] = serializeNodes(getOpStore(), [node], [])
     expect(result.width).toEqual(100)
     expect(result.height).toEqual(200)
+  })
+
+  it('serializes an inherited TableEditor schema after the schema edge is disconnected', () => {
+    const schema = {
+      columns: [
+        { name: 'Location', type: 'string' as const, defaultValue: '' },
+        { name: 'Phase', type: 'number' as const, defaultValue: 0 },
+      ],
+    }
+    const source = new TableEditorOp('/source', { schema }, false)
+    const target = new TableEditorOp('/target', {}, false)
+    const schemaEdgeId = '/source.out.schema->/target.par.schema'
+
+    source.outputs.schema.setValue(schema)
+    target.inputs.schema.addConnection(schemaEdgeId, source.outputs.schema)
+    target.inputs.schema.removeConnection(schemaEdgeId, 'reference')
+    setOp('/source', source)
+    setOp('/target', target)
+
+    const nodes = [
+      { id: '/source', type: 'TableEditorOp', data: {}, position: { x: 0, y: 0 } },
+      { id: '/target', type: 'TableEditorOp', data: {}, position: { x: 100, y: 0 } },
+    ]
+    const serializedNodes = serializeNodes(getOpStore(), nodes, [])
+    const project = JSON.parse(safeStringify({ nodes: serializedNodes }))
+
+    expect(project.nodes[0].data.inputs.schema).toEqual(schema)
+    expect(project.nodes[1].data.inputs.schema).toEqual(schema)
   })
 
   it('excludes ReferenceEdge connections when determining connected inputs', () => {

--- a/noodles-editor/src/noodles/utils/serialization.ts
+++ b/noodles-editor/src/noodles/utils/serialization.ts
@@ -47,17 +47,27 @@ export const EMPTY_PROJECT: NoodlesProjectJSON = {
   editorSettings: {},
 }
 
-// Replace functions and circular references
+// Replace functions and circular references while preserving repeated references.
+// A connected field can share the exact same object value with its source. Once the
+// field is disconnected, that value becomes local state and must serialize in full.
 function getJsonSanitizer() {
-  const seen = new Set()
-  return (_key: string, value: unknown) => {
+  const ancestors: unknown[] = []
+  return function (this: unknown, _key: string, value: unknown) {
+    if (typeof value === 'function') {
+      return undefined
+    }
+
     if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) {
+      // JSON.stringify calls the replacer with the containing object as `this`.
+      // Objects no longer in that containing object's ancestry are safe to visit
+      // again; only a value already in the current ancestry is truly circular.
+      while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+        ancestors.pop()
+      }
+      if (ancestors.includes(value)) {
         return undefined
       }
-      seen.add(value)
-    } else if (typeof value === 'function') {
-      return undefined
+      ancestors.push(value)
     }
     return value
   }


### PR DESCRIPTION
Closes #594

#### Background
TableEditor nodes could lose shared inherited schemas during serialization, render generic fallbacks instead of declared defaults, and reset custom cells during schema saves.

Previously, a schema connection that was later disconnected serialized columns to null:
<img width="371" height="447" alt="Screenshot 2026-09-05 at 8 57 51 AM" src="https://github.com/user-attachments/assets/7d368417-164a-472f-b4f1-65985f996607" />


#### Change List
- Preserve repeated non-circular values during project serialization so disconnected schemas persist.
- Normalize TableEditor data against connected and edited schemas while preserving compatible custom values.
- Add regression coverage for schema disconnects, string-literal and vector defaults, and unchanged schema saves.