### PR TITLE
Duplicate columns in TableEditor

### DIFF
--- a/noodles-editor/src/noodles/components/schema-editor-dialog.module.css
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.module.css
@@ -113,6 +113,10 @@
   margin-left: auto;
 }
 
+.dialogTooltip {
+  z-index: var(--z-index-top);
+}
+
 .typeOptions {
   display: flex;
   gap: 12px;

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
@@ -58,6 +58,32 @@ describe('SchemaEditorDialog', () => {
     expect(nameInputs[2]).toHaveValue('column_3')
   })
 
+  it('should duplicate a column with a unique editable name and source metadata', () => {
+    const onChange = vi.fn()
+    render(<SchemaEditorDialog schema={mockSchema} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate column name' }))
+
+    const nameInputs = screen.getAllByPlaceholderText('Column name')
+    expect(nameInputs).toHaveLength(3)
+    expect(nameInputs[1]).toHaveValue('name copy')
+
+    fireEvent.change(nameInputs[1], { target: { value: 'display_name' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    expect(onChange).toHaveBeenCalledWith(
+      {
+        columns: [
+          { name: 'name', type: 'string', defaultValue: '' },
+          { name: 'display_name', type: 'string', defaultValue: '' },
+          { name: 'age', type: 'number', defaultValue: 0 },
+        ],
+      },
+      { sourceColumnNames: ['name', 'name', 'age'] }
+    )
+  })
+
   it('should add Position XYZ quick template with Number type', () => {
     const onChange = vi.fn()
     render(<SchemaEditorDialog schema={mockSchema} onChange={onChange} />)

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
@@ -1,7 +1,12 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { analytics } from '../../utils/analytics'
 import type { TableSchema } from '../table-schema'
 import { SchemaEditorDialog } from './schema-editor-dialog'
+
+vi.mock('../../utils/analytics', () => ({
+  analytics: { track: vi.fn() },
+}))
 
 afterEach(() => {
   cleanup()
@@ -64,6 +69,8 @@ describe('SchemaEditorDialog', () => {
 
     fireEvent.click(screen.getByRole('button'))
     fireEvent.click(screen.getByRole('button', { name: 'Duplicate column name' }))
+
+    expect(analytics.track).toHaveBeenCalledWith('table_column_duplicated')
 
     const nameInputs = screen.getAllByPlaceholderText('Column name')
     expect(nameInputs).toHaveLength(3)

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { analytics } from '../../utils/analytics'
 import type { TableSchema } from '../table-schema'
 import { SchemaEditorDialog } from './schema-editor-dialog'
+import s from './schema-editor-dialog.module.css'
 
 vi.mock('../../utils/analytics', () => ({
   analytics: { track: vi.fn() },
@@ -10,6 +11,8 @@ vi.mock('../../utils/analytics', () => ({
 
 afterEach(() => {
   cleanup()
+  document.documentElement.style.removeProperty('--z-index-modal')
+  document.documentElement.style.removeProperty('--z-index-top')
 })
 
 describe('SchemaEditorDialog', () => {
@@ -74,7 +77,7 @@ describe('SchemaEditorDialog', () => {
 
     const nameInputs = screen.getAllByPlaceholderText('Column name')
     expect(nameInputs).toHaveLength(3)
-    expect(nameInputs[1]).toHaveValue('name copy')
+    expect(nameInputs[1]).toHaveValue('name-1')
 
     fireEvent.change(nameInputs[1], { target: { value: 'display_name' } })
     fireEvent.click(screen.getByText('Save'))
@@ -89,6 +92,37 @@ describe('SchemaEditorDialog', () => {
       },
       { sourceColumnNames: ['name', 'name', 'age'] }
     )
+  })
+
+  it('should increment a duplicate column numeric suffix', () => {
+    render(<SchemaEditorDialog schema={mockSchema} onChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate column name' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate column name-1' }))
+
+    const nameInputs = screen.getAllByPlaceholderText('Column name')
+    expect(nameInputs.map(input => (input as HTMLInputElement).value)).toEqual([
+      'name',
+      'name-1',
+      'name-2',
+      'age',
+    ])
+  })
+
+  it('should place dialog tooltips above modal content', () => {
+    document.documentElement.style.setProperty('--z-index-modal', '10000')
+    document.documentElement.style.setProperty('--z-index-top', '10001')
+    render(
+      <>
+        <div className={s.content} data-testid="dialog-layer" />
+        <div className={s.dialogTooltip} data-testid="tooltip-layer" />
+      </>
+    )
+
+    const dialogZIndex = Number(getComputedStyle(screen.getByTestId('dialog-layer')).zIndex)
+    const tooltipZIndex = Number(getComputedStyle(screen.getByTestId('tooltip-layer')).zIndex)
+    expect(tooltipZIndex).toBeGreaterThan(dialogZIndex)
   })
 
   it('should add Position XYZ quick template with Number type', () => {

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
@@ -5,6 +5,7 @@ import { InputNumber } from 'primereact/inputnumber'
 import { InputSwitch } from 'primereact/inputswitch'
 import { InputText } from 'primereact/inputtext'
 import { useEffect, useState } from 'react'
+import { analytics } from '../../utils/analytics'
 import type { ColumnSchema, ColumnType, DateTimeValue, TableSchema } from '../table-schema'
 import { getDefaultValue, validateValue } from '../table-schema'
 import { getTimezoneOptions } from '../utils/timezone-utils'
@@ -469,6 +470,7 @@ export function SchemaEditorDialog({ schema, onChange, onClose }: SchemaEditorDi
 
   const duplicateColumn = (index: number) => {
     const source = columnDrafts[index]
+    analytics.track('table_column_duplicated')
     const duplicate: ColumnSchema = {
       ...source.column,
       name: getDuplicateColumnName(

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
@@ -68,13 +68,13 @@ function createColumnDrafts(schema: TableSchema): ColumnDraft[] {
 
 function getDuplicateColumnName(name: string, columns: ColumnSchema[]): string {
   const existingNames = new Set(columns.map(column => column.name))
-  const baseName = `${name || 'column'} copy`
-  let duplicateName = baseName
-  let suffix = 2
+  const baseName = (name || 'column').replace(/-\d+$/, '')
+  let suffix = 1
+  let duplicateName = `${baseName}-${suffix}`
 
   while (existingNames.has(duplicateName)) {
-    duplicateName = `${baseName} ${suffix}`
     suffix += 1
+    duplicateName = `${baseName}-${suffix}`
   }
 
   return duplicateName
@@ -309,6 +309,7 @@ function ColumnEditor({
             className="p-button-text p-button-sm"
             onClick={onDuplicate}
             tooltip="Duplicate column"
+            tooltipOptions={{ autoZIndex: false, className: s.dialogTooltip }}
             aria-label={`Duplicate column ${column.name}`}
           />
           <Button

--- a/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
+++ b/noodles-editor/src/noodles/components/schema-editor-dialog.tsx
@@ -13,8 +13,13 @@ import s from './schema-editor-dialog.module.css'
 
 interface SchemaEditorDialogProps {
   schema: TableSchema
-  onChange: (schema: TableSchema) => void
+  onChange: (schema: TableSchema, metadata?: SchemaChangeMetadata) => void
   onClose?: () => void
+}
+
+export interface SchemaChangeMetadata {
+  // Aligned with the new schema, so renamed and duplicated columns can retain source values.
+  sourceColumnNames: Array<string | undefined>
 }
 
 const COLUMN_TYPES: Array<{ label: string; value: ColumnType }> = [
@@ -34,9 +39,15 @@ const COLUMN_TYPES: Array<{ label: string; value: ColumnType }> = [
 interface ColumnEditorProps {
   column: ColumnSchema
   onChange: (column: ColumnSchema) => void
+  onDuplicate: () => void
   onDelete: () => void
   onMoveUp?: () => void
   onMoveDown?: () => void
+}
+
+interface ColumnDraft {
+  column: ColumnSchema
+  sourceName?: string
 }
 
 function normalizeColumnDefault(column: ColumnSchema): ColumnSchema {
@@ -47,8 +58,25 @@ function normalizeColumnDefault(column: ColumnSchema): ColumnSchema {
   return { ...column, defaultValue: getDefaultValue(column) }
 }
 
-function normalizeSchemaDefaults(schema: TableSchema): TableSchema {
-  return { columns: schema.columns.map(normalizeColumnDefault) }
+function createColumnDrafts(schema: TableSchema): ColumnDraft[] {
+  return schema.columns.map(column => ({
+    column: normalizeColumnDefault(column),
+    sourceName: column.name,
+  }))
+}
+
+function getDuplicateColumnName(name: string, columns: ColumnSchema[]): string {
+  const existingNames = new Set(columns.map(column => column.name))
+  const baseName = `${name || 'column'} copy`
+  let duplicateName = baseName
+  let suffix = 2
+
+  while (existingNames.has(duplicateName)) {
+    duplicateName = `${baseName} ${suffix}`
+    suffix += 1
+  }
+
+  return duplicateName
 }
 
 function StringLiteralValuesInput({
@@ -224,7 +252,14 @@ function DefaultValueEditor({
   }
 }
 
-function ColumnEditor({ column, onChange, onDelete, onMoveUp, onMoveDown }: ColumnEditorProps) {
+function ColumnEditor({
+  column,
+  onChange,
+  onDuplicate,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: ColumnEditorProps) {
   return (
     <div className={s.columnRow}>
       <div className={s.columnControls}>
@@ -268,6 +303,13 @@ function ColumnEditor({ column, onChange, onDelete, onMoveUp, onMoveDown }: Colu
               disabled={!onMoveDown}
             />
           )}
+          <Button
+            icon="pi pi-copy"
+            className="p-button-text p-button-sm"
+            onClick={onDuplicate}
+            tooltip="Duplicate column"
+            aria-label={`Duplicate column ${column.name}`}
+          />
           <Button
             icon="pi pi-trash"
             className="p-button-text p-button-sm p-button-danger"
@@ -387,52 +429,77 @@ function ColumnEditor({ column, onChange, onDelete, onMoveUp, onMoveDown }: Colu
 
 export function SchemaEditorDialog({ schema, onChange, onClose }: SchemaEditorDialogProps) {
   const [open, setOpen] = useState(false)
-  const [localSchema, setLocalSchema] = useState<TableSchema>(() =>
-    normalizeSchemaDefaults(schema)
-  )
+  const [columnDrafts, setColumnDrafts] = useState<ColumnDraft[]>(() => createColumnDrafts(schema))
 
   const handleOpen = () => {
-    setLocalSchema(normalizeSchemaDefaults(schema)) // Reset to current schema
+    setColumnDrafts(createColumnDrafts(schema)) // Reset to current schema
     setOpen(true)
   }
 
   const handleSave = () => {
-    onChange(localSchema)
+    const newSchema = { columns: columnDrafts.map(draft => draft.column) }
+    const sourceColumnNames = columnDrafts.map(draft => draft.sourceName)
+    const hasRemappedColumns = columnDrafts.some(
+      ({ column, sourceName }) => sourceName !== undefined && sourceName !== column.name
+    )
+
+    if (hasRemappedColumns) {
+      onChange(newSchema, { sourceColumnNames })
+    } else {
+      onChange(newSchema)
+    }
     setOpen(false)
     onClose?.()
   }
 
   const addColumn = () => {
     const newColumn: ColumnSchema = {
-      name: `column_${localSchema.columns.length + 1}`,
+      name: `column_${columnDrafts.length + 1}`,
       type: 'string',
       defaultValue: '',
     }
-    setLocalSchema({
-      columns: [...localSchema.columns, newColumn],
-    })
+    setColumnDrafts([...columnDrafts, { column: newColumn }])
   }
 
   const updateColumn = (index: number, updates: ColumnSchema) => {
-    const newColumns = [...localSchema.columns]
-    newColumns[index] = normalizeColumnDefault(updates)
-    setLocalSchema({ columns: newColumns })
+    const newDrafts = [...columnDrafts]
+    newDrafts[index] = { ...newDrafts[index], column: normalizeColumnDefault(updates) }
+    setColumnDrafts(newDrafts)
+  }
+
+  const duplicateColumn = (index: number) => {
+    const source = columnDrafts[index]
+    const duplicate: ColumnSchema = {
+      ...source.column,
+      name: getDuplicateColumnName(
+        source.column.name,
+        columnDrafts.map(draft => draft.column)
+      ),
+      options: source.column.options ? { ...source.column.options } : undefined,
+      defaultValue: Array.isArray(source.column.defaultValue)
+        ? [...source.column.defaultValue]
+        : source.column.defaultValue,
+    }
+    const newDrafts = [...columnDrafts]
+    newDrafts.splice(index + 1, 0, {
+      column: duplicate,
+      sourceName: source.sourceName,
+    })
+    setColumnDrafts(newDrafts)
   }
 
   const deleteColumn = (index: number) => {
-    setLocalSchema({
-      columns: localSchema.columns.filter((_, i) => i !== index),
-    })
+    setColumnDrafts(columnDrafts.filter((_, i) => i !== index))
   }
 
   const moveColumn = (index: number, direction: 'up' | 'down') => {
-    const newColumns = [...localSchema.columns]
+    const newDrafts = [...columnDrafts]
     const targetIndex = direction === 'up' ? index - 1 : index + 1
-    if (targetIndex < 0 || targetIndex >= newColumns.length) return
+    if (targetIndex < 0 || targetIndex >= newDrafts.length) return
 
-    const [moved] = newColumns.splice(index, 1)
-    newColumns.splice(targetIndex, 0, moved)
-    setLocalSchema({ columns: newColumns })
+    const [moved] = newDrafts.splice(index, 1)
+    newDrafts.splice(targetIndex, 0, moved)
+    setColumnDrafts(newDrafts)
   }
 
   const addQuickTemplate = (template: 'position' | 'color' | 'latLng') => {
@@ -458,9 +525,7 @@ export function SchemaEditorDialog({ schema, onChange, onClose }: SchemaEditorDi
         break
     }
 
-    setLocalSchema({
-      columns: [...localSchema.columns, ...newColumns],
-    })
+    setColumnDrafts([...columnDrafts, ...newColumns.map(column => ({ column }))])
   }
 
   return (
@@ -482,23 +547,22 @@ export function SchemaEditorDialog({ schema, onChange, onClose }: SchemaEditorDi
           </Dialog.Description>
 
           <div className={s.body}>
-            {localSchema.columns.length === 0 ? (
+            {columnDrafts.length === 0 ? (
               <div className={s.emptyState}>
                 <p>No columns defined. Add columns to get started.</p>
               </div>
             ) : (
               <div className={s.columnList}>
-                {localSchema.columns.map((col, index) => (
+                {columnDrafts.map(({ column }, index) => (
                   <ColumnEditor
                     key={index}
-                    column={col}
+                    column={column}
                     onChange={updated => updateColumn(index, updated)}
+                    onDuplicate={() => duplicateColumn(index)}
                     onDelete={() => deleteColumn(index)}
                     onMoveUp={index > 0 ? () => moveColumn(index, 'up') : undefined}
                     onMoveDown={
-                      index < localSchema.columns.length - 1
-                        ? () => moveColumn(index, 'down')
-                        : undefined
+                      index < columnDrafts.length - 1 ? () => moveColumn(index, 'down') : undefined
                     }
                   />
                 ))}

--- a/noodles-editor/src/noodles/components/table-editor.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.test.tsx
@@ -215,6 +215,42 @@ describe('TableEditor', () => {
     // Actual schema editing is tested in schema-editor-dialog.test.tsx
   })
 
+  it('should copy column values when a duplicated column is renamed', () => {
+    const onDataChange = vi.fn()
+    const onSchemaChange = vi.fn()
+
+    const { container, getByRole, getAllByPlaceholderText, getByText } = render(
+      <TableEditor
+        op={mockOp}
+        data={simpleData}
+        schema={simpleSchema}
+        onDataChange={onDataChange}
+        onSchemaChange={onSchemaChange}
+      />
+    )
+
+    fireEvent.click(container.querySelector('.pi-cog') as Element)
+    fireEvent.click(getByRole('button', { name: 'Duplicate column name' }))
+
+    const nameInputs = getAllByPlaceholderText('Column name')
+    fireEvent.change(nameInputs[1], { target: { value: 'display_name' } })
+    fireEvent.click(getByText('Save'))
+
+    expect(onSchemaChange).toHaveBeenCalledWith(
+      {
+        columns: [
+          { name: 'name', type: 'string', defaultValue: '' },
+          { name: 'display_name', type: 'string', defaultValue: '' },
+          { name: 'count', type: 'number', defaultValue: 0 },
+        ],
+      },
+      [
+        { name: 'Alice', display_name: 'Alice', count: 10 },
+        { name: 'Bob', display_name: 'Bob', count: 20 },
+      ]
+    )
+  })
+
   it('should update tableData when data prop changes', () => {
     const onDataChange = vi.fn()
     const onSchemaChange = vi.fn()

--- a/noodles-editor/src/noodles/components/table-editor.test.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.test.tsx
@@ -251,6 +251,41 @@ describe('TableEditor', () => {
     )
   })
 
+  it('should use the default for a fresh column that reuses a renamed column name', () => {
+    const onSchemaChange = vi.fn()
+
+    const { container, getAllByPlaceholderText, getByRole, getByText } = render(
+      <TableEditor
+        op={mockOp}
+        data={simpleData}
+        schema={simpleSchema}
+        onDataChange={vi.fn()}
+        onSchemaChange={onSchemaChange}
+      />
+    )
+
+    fireEvent.click(container.querySelector('.pi-cog') as Element)
+    const nameInputs = getAllByPlaceholderText('Column name')
+    fireEvent.change(nameInputs[0], { target: { value: 'display_name' } })
+    fireEvent.click(getByRole('button', { name: 'Add Column' }))
+    fireEvent.change(getAllByPlaceholderText('Column name')[2], { target: { value: 'name' } })
+    fireEvent.click(getByText('Save'))
+
+    expect(onSchemaChange).toHaveBeenCalledWith(
+      {
+        columns: [
+          { name: 'display_name', type: 'string', defaultValue: '' },
+          { name: 'count', type: 'number', defaultValue: 0 },
+          { name: 'name', type: 'string', defaultValue: '' },
+        ],
+      },
+      [
+        { display_name: 'Alice', count: 10, name: '' },
+        { display_name: 'Bob', count: 20, name: '' },
+      ]
+    )
+  })
+
   it('should update tableData when data prop changes', () => {
     const onDataChange = vi.fn()
     const onSchemaChange = vi.fn()

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -18,7 +18,7 @@ import type { ColumnSchema, ColumnType, DateTimeValue, TableSchema } from '../ta
 import { convertValue, getDefaultValue, temporalToString } from '../table-schema'
 import { getTimezoneOptions } from '../utils/timezone-utils'
 import { ColorSwatch } from './color-swatch'
-import { SchemaEditorDialog } from './schema-editor-dialog'
+import { SchemaEditorDialog, type SchemaChangeMetadata } from './schema-editor-dialog'
 import s from './table-editor.module.css'
 
 // Cell editor components for each column type
@@ -890,13 +890,14 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
     commitData([...tableDataRef.current, newRow], 'Add table row')
   }
 
-  const handleSchemaChange = (newSchema: TableSchema) => {
+  const handleSchemaChange = (newSchema: TableSchema, metadata?: SchemaChangeMetadata) => {
     activeEdit.flush()
     // Update data to match new schema
     const newData = tableDataRef.current.map(row => {
       const newRow: Record<string, unknown> = {}
-      for (const col of newSchema.columns) {
-        const existingValue = row[col.name]
+      for (const [columnIndex, col] of newSchema.columns.entries()) {
+        const sourceColumnName = metadata?.sourceColumnNames[columnIndex] ?? col.name
+        const existingValue = row[sourceColumnName]
         // Convert existing value to new type, or use default if missing
         if (existingValue !== undefined) {
           newRow[col.name] = convertValue(existingValue, col.type)

--- a/noodles-editor/src/noodles/components/table-editor.tsx
+++ b/noodles-editor/src/noodles/components/table-editor.tsx
@@ -896,8 +896,8 @@ export function TableEditor({ data, schema, onDataChange, onSchemaChange }: Tabl
     const newData = tableDataRef.current.map(row => {
       const newRow: Record<string, unknown> = {}
       for (const [columnIndex, col] of newSchema.columns.entries()) {
-        const sourceColumnName = metadata?.sourceColumnNames[columnIndex] ?? col.name
-        const existingValue = row[sourceColumnName]
+        const sourceColumnName = metadata ? metadata.sourceColumnNames[columnIndex] : col.name
+        const existingValue = sourceColumnName === undefined ? undefined : row[sourceColumnName]
         // Convert existing value to new type, or use default if missing
         if (existingValue !== undefined) {
           newRow[col.name] = convertValue(existingValue, col.type)


### PR DESCRIPTION
#### Background
TableEditor users need to duplicate identifier columns before giving the copy a display-friendly name.

#### Change List
- Add a per-column duplicate action using the standard collision suffix pattern (`-1`, `-2`, …).
- Preserve schema settings and row values when duplicated or renamed columns are saved.
- Place dialog tooltips on the centralized `--z-index-top` tier above modal content.
- Add analytics and regression coverage for duplication, suffix collisions, tooltip layering, and mixed rename/add behavior.

#### Validation
- 394 focused tests pass after syncing with current `main`; lint succeeds.

![Table Schema Editor showing Location duplicated as Display Name](https://github.com/user-attachments/assets/341e0645-2620-475f-b22f-789ff94b94f0)