### PR TITLE
Fix optional compound property connection validation

### DIFF
--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -69,6 +69,7 @@ import {
 } from './operators'
 import { deleteOp, getOpStore, setOp } from './store'
 import { isAccessor } from './utils/accessor-helpers'
+import { canConnect } from './utils/can-connect'
 
 describe('basic Operators', () => {
   it('creates an Operator', () => {
@@ -710,6 +711,13 @@ describe('AccessorOp op() error handling', () => {
 })
 
 describe('BoundingBoxOp', () => {
+  it('connects its viewState output to a MaplibreBasemap viewState input', () => {
+    const boundingBox = new BoundingBoxOp('/bbox-0')
+    const basemap = new MaplibreBasemapOp('/maplibre-0')
+
+    expect(canConnect(boundingBox.outputs.viewState, basemap.inputs.viewState)).toBe(true)
+  })
+
   it('finds the bounding box of a list of points', () => {
     const operator = new BoundingBoxOp('/bbox-0')
     const val = operator.execute({

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -69,7 +69,7 @@ import {
 } from './operators'
 import { deleteOp, getOpStore, setOp } from './store'
 import { isAccessor } from './utils/accessor-helpers'
-import { canConnect } from './utils/can-connect'
+import { canConnect, validateConnection } from './utils/can-connect'
 
 describe('basic Operators', () => {
   it('creates an Operator', () => {
@@ -716,6 +716,15 @@ describe('BoundingBoxOp', () => {
     const basemap = new MaplibreBasemapOp('/maplibre-0')
 
     expect(canConnect(boundingBox.outputs.viewState, basemap.inputs.viewState)).toBe(true)
+  })
+
+  it('identifies an incompatible MaplibreBasemap compound property', () => {
+    const boundingBox = new BoundingBoxOp('/bbox-0')
+    const basemap = new MaplibreBasemapOp('/maplibre-0')
+
+    expect(validateConnection(boundingBox.outputs.viewState, basemap.inputs.sky).error).toBe(
+      'Type mismatch at sky.enabled: expected boolean, received undefined'
+    )
   })
 
   it('finds the bounding box of a list of points', () => {

--- a/noodles-editor/src/noodles/utils/can-connect.test.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.test.ts
@@ -186,6 +186,19 @@ describe('ValidateConnection', () => {
     expect(result.error).toContain('number')
   })
 
+  it('identifies the incompatible property in compound fields', () => {
+    const source = new CompoundPropsField({ latitude: new StringField('north') })
+    const target = new CompoundPropsField({ latitude: new NumberField() })
+    target.pathToProps = ['/target', 'par', 'viewState']
+
+    const result = validateConnection(source, target)
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toBe(
+      'Type mismatch at viewState.latitude: expected number, received string'
+    )
+  })
+
   it('returns valid for UnknownField connecting to any field', () => {
     const unknownField = new UnknownField()
     const numberField = new NumberField(10)

--- a/noodles-editor/src/noodles/utils/can-connect.test.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.test.ts
@@ -323,6 +323,20 @@ describe('schemasAreCompatible', () => {
     expect(schemasAreCompatible(target, source)).toBe(false)
   })
 
+  it('allows optional target properties to be absent from the source', () => {
+    const source = z.object({ a: z.number() })
+    const target = z.object({ a: z.number(), b: z.string().optional() })
+
+    expect(schemasAreCompatible(source, target)).toBe(true)
+  })
+
+  it('still validates optional target properties when they exist in the source', () => {
+    const source = z.object({ a: z.number(), b: z.number() })
+    const target = z.object({ a: z.number(), b: z.string().optional() })
+
+    expect(schemasAreCompatible(source, target)).toBe(false)
+  })
+
   it('objects with incompatible property types are incompatible', () => {
     const source = z.object({ a: z.string() })
     const target = z.object({ a: z.number() })

--- a/noodles-editor/src/noodles/utils/can-connect.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.ts
@@ -191,6 +191,15 @@ export function schemasAreCompatible(from: z.ZodType, to: z.ZodType, depth = 0):
       for (const [key, toSchema] of Object.entries(toDef.shape)) {
         const fromSchema = fromDef.shape?.[key]
         if (!fromSchema) {
+          // Object properties whose schemas accept undefined are optional and do not
+          // need to be present in the source shape.
+          if (toSchema.safeParse(undefined).success) {
+            if (debugConnect.enabled) {
+              const indent = '  '.repeat(depth)
+              debugConnect(`${indent}✓ Optional property '${key}' may be omitted from source`)
+            }
+            continue
+          }
           if (debugConnect.enabled) {
             const indent = '  '.repeat(depth)
             debugConnect(`${indent}✗ Missing property '${key}' in source`)

--- a/noodles-editor/src/noodles/utils/can-connect.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.ts
@@ -27,6 +27,34 @@ function formatZodIssue(issue: z.core.$ZodIssue): string {
   }
 }
 
+function formatTypeMismatch(from: Field, to: Field, toSchema: z.ZodType): string {
+  if (from.value !== undefined) {
+    const result = toSchema.safeParse(from.value)
+    if (!result.success) {
+      const issue = result.error.issues[0]
+      const targetFieldName = to.pathToProps.at(-1)
+      const issuePath = issue.path.map(String).join('.')
+      const path = [targetFieldName, issuePath].filter(Boolean).join('.')
+      const detail = issue.message.replace(/^Invalid input: /, '')
+
+      return path ? `Type mismatch at ${path}: ${detail}` : `Type mismatch: ${detail}`
+    }
+  }
+
+  const fromFieldType = (from.constructor as typeof Field).type
+  const toFieldType = (to.constructor as typeof Field).type
+  const fromFieldName = from.pathToProps.at(-1)
+  const toFieldName = to.pathToProps.at(-1)
+
+  if (fromFieldName || toFieldName) {
+    return `Type mismatch: source ${fromFieldName || fromFieldType} schema is incompatible with target ${toFieldName || toFieldType} schema`
+  }
+  if (fromFieldType === toFieldType) {
+    return `Type mismatch: ${fromFieldType} field schemas are structurally incompatible`
+  }
+  return `Type mismatch: ${fromFieldType} cannot connect to ${toFieldType}`
+}
+
 type ZodDef = {
   type: string
   innerType?: z.ZodType
@@ -314,7 +342,7 @@ export function validateConnection(from: Field, to: Field): ConnectionValidation
     return {
       valid: false,
       severity: 'error',
-      error: `Type mismatch: ${fromFieldType} cannot connect to ${toFieldType}`,
+      error: formatTypeMismatch(from, to, toSchema),
     }
   }
   if (debugConnect.enabled) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything that does not work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #597

<!-- For other PRs without open issue -->
#### Background

Compound connections incorrectly reported a type mismatch when optional target properties were absent from the source.

Before
<img width="1118" height="325" alt="False compound type mismatch before the fix" src="https://github.com/user-attachments/assets/98a59797-efd2-435c-86a5-13f1506d939d" />

After
<img width="953" height="284" alt="Valid compound connection after the fix" src="https://github.com/user-attachments/assets/803bb244-9bb2-451a-beb5-08574c9c8246" />

#### Genuine type mismatch

When schemas are genuinely incompatible, the error now identifies the target property and expected and received types.

![Improved error message for a genuine compound type mismatch](https://github.com/user-attachments/assets/5ca84255-3ada-4ccc-886a-cff6c82ef5a3)

Reproduction project: [download `noodles.json`](https://github.com/user-attachments/assets/06a9f238-5a16-4fe6-9863-9462cecac689). The attachment API requires a media filename, so save the unchanged payload as `noodles.json` before opening it in Noodles.

<!-- For all the PRs -->
#### Change List
- Allow omitted target properties when their schemas accept `undefined`, while still validating supplied values.
- Report the first incompatible target property with runtime type details when available.
- Add structural and `BoundingBoxOp` to `MaplibreBasemapOp` regression tests.
- Verified with 339 focused tests, lint, formatting, and a production build.
