### PR TITLE
feat: inspect selected edge data in the properties panel

### DIFF
--- a/noodles-editor/src/noodles/components/__tests__/property-panel.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/property-panel.test.tsx
@@ -1,12 +1,12 @@
 // Tests for PropertyPanel selection rendering and NodeProperties nodeId interface
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import type { Edge, Node as ReactFlowNode } from '@xyflow/react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SheetContext } from '../../../utils/sheet-context'
-import { clearOps } from '../../store'
+import { clearOps, getOpStore, useUIStore } from '../../store'
 import { transformGraph } from '../../transform-graph'
-import { NodeProperties, PropertyPanel } from '../node-properties'
+import { formatEdgePreviewValue, NodeProperties, PropertyPanel } from '../node-properties'
 
 // Mock store state — controlled per test
 let mockNodes: ReactFlowNode[] = []
@@ -32,6 +32,10 @@ vi.mock('../../theatre-bindings', () => ({
   rebindOperatorToTheatre: vi.fn(),
 }))
 
+vi.mock('@microlink/react-json-view', () => ({
+  default: ({ src }: { src: unknown }) => <pre>{JSON.stringify(src)}</pre>,
+}))
+
 vi.mock('../node-properties.module.css', () => ({
   default: new Proxy({}, { get: (_, prop) => prop }),
 }))
@@ -52,6 +56,7 @@ describe('PropertyPanel', () => {
     clearOps()
     mockNodes = []
     mockEdges = []
+    useUIStore.getState().setInspectedReferenceEdge(null)
   })
 
   afterEach(() => {
@@ -62,7 +67,7 @@ describe('PropertyPanel', () => {
   it('shows "Select a node" prompt when nothing is selected', () => {
     mockNodes = []
     wrapWithProviders(<PropertyPanel />)
-    expect(screen.getByText('Select a node to see properties')).toBeInTheDocument()
+    expect(screen.getByText('Select a node or edge to inspect it')).toBeInTheDocument()
   })
 
   it('shows multi-select node count when multiple nodes are selected', () => {
@@ -92,13 +97,94 @@ describe('PropertyPanel', () => {
     ]
     wrapWithProviders(<PropertyPanel />)
     expect(screen.getByText('2 nodes selected')).toBeInTheDocument()
-    expect(screen.getByText('1 edges selected')).toBeInTheDocument()
+    expect(screen.getByText('1 edge selected')).toBeInTheDocument()
   })
 
   it('shows Page header when nothing is selected', () => {
     mockNodes = []
     wrapWithProviders(<PropertyPanel />)
     expect(screen.getByText('Page')).toBeInTheDocument()
+  })
+
+  it('shows the live source value for one selected edge', () => {
+    transformGraph({
+      nodes: [
+        { id: '/source', type: 'NumberOp', position: { x: 0, y: 0 }, data: {} },
+        { id: '/target', type: 'NumberOp', position: { x: 100, y: 0 }, data: {} },
+      ],
+      edges: [],
+    })
+    mockEdges = [
+      {
+        id: '/source.out.val->/target.par.val',
+        source: '/source',
+        target: '/target',
+        sourceHandle: 'out.val',
+        targetHandle: 'par.val',
+        selected: true,
+      },
+    ]
+    const source = getOpStore().getOp('/source')!
+    source.outputs.val.next(42)
+
+    wrapWithProviders(<PropertyPanel />)
+
+    expect(screen.getByText('Edge')).toBeInTheDocument()
+    expect(screen.getByTitle('/source.out.val')).toHaveTextContent('source.out.val')
+    expect(screen.getByTitle('/target.par.val')).toHaveTextContent('target.par.val')
+    expect(screen.getByText('{"value":42}')).toBeInTheDocument()
+
+    act(() => source.outputs.val.next(84))
+    expect(screen.getByText('{"value":84}')).toBeInTheDocument()
+  })
+
+  it('inspects source inputs used by reference edges', () => {
+    transformGraph({
+      nodes: [
+        {
+          id: '/source',
+          type: 'NumberOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: { val: 7 } },
+        },
+        { id: '/target', type: 'CodeOp', position: { x: 100, y: 0 }, data: {} },
+      ],
+      edges: [],
+    })
+    useUIStore.getState().setInspectedReferenceEdge({
+      id: '/source.par.val->/target.par.code',
+      source: '/source',
+      target: '/target',
+      sourceHandle: 'par.val',
+      targetHandle: 'par.code',
+      type: 'ReferenceEdge',
+    })
+
+    wrapWithProviders(<PropertyPanel />)
+
+    expect(screen.getByText('Reference')).toBeInTheDocument()
+    expect(screen.getByText('{"value":7}')).toBeInTheDocument()
+  })
+
+  it('shows a summary instead of a value when multiple edges are selected', () => {
+    mockEdges = [
+      { id: 'e1', source: '/a', target: '/b', selected: true },
+      { id: 'e2', source: '/b', target: '/c', selected: true },
+    ]
+
+    wrapWithProviders(<PropertyPanel />)
+
+    expect(screen.getByText('2 edges selected')).toBeInTheDocument()
+    expect(screen.queryByText('Source field is unavailable')).not.toBeInTheDocument()
+  })
+
+  it('bounds large edge previews', () => {
+    const value = Array.from({ length: 30 }, (_, index) => index)
+
+    expect(formatEdgePreviewValue(value)).toEqual({
+      summary: 'Showing first 25 of 30 items',
+      items: value.slice(0, 25),
+    })
   })
 })
 
@@ -107,6 +193,7 @@ describe('NodeProperties', () => {
     clearOps()
     mockNodes = []
     mockEdges = []
+    useUIStore.getState().setInspectedReferenceEdge(null)
   })
 
   afterEach(() => {

--- a/noodles-editor/src/noodles/components/__tests__/property-panel.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/property-panel.test.tsx
@@ -186,6 +186,25 @@ describe('PropertyPanel', () => {
       items: value.slice(0, 25),
     })
   })
+
+  it('bounds large values nested inside operator previews', () => {
+    transformGraph({
+      nodes: [{ id: '/viewer', type: 'ViewerOp', position: { x: 0, y: 0 }, data: {} }],
+      edges: [],
+    })
+    const viewer = getOpStore().getOp('/viewer')!
+    const value = Array.from({ length: 30 }, (_, index) => index)
+    viewer.inputs.data.next(value)
+
+    expect(formatEdgePreviewValue(viewer)).toMatchObject({
+      inputs: {
+        data: {
+          summary: 'Showing first 25 of 30 items',
+          items: value.slice(0, 25),
+        },
+      },
+    })
+  })
 })
 
 describe('NodeProperties', () => {

--- a/noodles-editor/src/noodles/components/node-properties.module.css
+++ b/noodles-editor/src/noodles/components/node-properties.module.css
@@ -9,6 +9,7 @@
   gap: 0;
   flex: 1;
   min-height: 0;
+  overflow-y: auto;
 }
 
 /* Header */
@@ -95,6 +96,72 @@
 .opMeta {
   margin-bottom: 4px;
   padding: 0 6px;
+}
+
+/* Edge inspector */
+.edgeTypeBadge {
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: rgba(139, 92, 246, 0.18);
+  color: #c4b5fd;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.edgeEndpoints {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 6px 8px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.edgeEndpoint {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+}
+
+.edgeEndpointLabel {
+  color: var(--color-text-secondary);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.edgeEndpoint code {
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.edgeEndpointArrow {
+  margin-left: 11px;
+  color: var(--color-text-secondary);
+  line-height: 10px;
+}
+
+.edgeValuePreview {
+  min-width: 0;
+  margin: 8px 6px 0;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.edgeValueUnavailable {
+  margin: 8px 6px 0;
+  padding: 10px;
+  color: var(--color-text-secondary);
+  font-size: 11px;
 }
 
 .opDisplayName {

--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -26,8 +26,8 @@ import {
   type Vec2Field,
 } from '../fields'
 import { useObservable } from '../hooks/use-observable'
-import type { IOperator, OpType, Operator } from '../operators'
-import { OutOp } from '../operators'
+import type { IOperator, OpType } from '../operators'
+import { Operator, OutOp } from '../operators'
 import { getOp, getOpStore, useNestingStore, useUIStore } from '../store'
 import type { ConnectionPlan } from '../utils/auto-connect'
 import { edgeId } from '../utils/id-utils'
@@ -1330,21 +1330,93 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
 
 const EDGE_PREVIEW_ITEM_LIMIT = 25
 
+function limitEdgePreviewValue(value: unknown, ancestors: WeakSet<object>): unknown {
+  if (value instanceof Operator) {
+    return formatEdgePreviewValueInternal(value, ancestors)
+  }
+  if (value === null || typeof value !== 'object') return value
+  if (value instanceof Date) return value
+
+  const prototype = Object.getPrototypeOf(value)
+  if (
+    !Array.isArray(value) &&
+    !(value instanceof Set) &&
+    prototype !== Object.prototype &&
+    prototype !== null
+  ) {
+    return value
+  }
+
+  if (ancestors.has(value)) return '[Circular]'
+  ancestors.add(value)
+
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, EDGE_PREVIEW_ITEM_LIMIT)
+      .map(item => limitEdgePreviewValue(item, ancestors))
+    ancestors.delete(value)
+    if (value.length <= EDGE_PREVIEW_ITEM_LIMIT) return items
+    return {
+      summary: `Showing first ${EDGE_PREVIEW_ITEM_LIMIT} of ${value.length} items`,
+      items,
+    }
+  }
+
+  if (value instanceof Set) {
+    const items = Array.from(value)
+      .slice(0, EDGE_PREVIEW_ITEM_LIMIT)
+      .map(item => limitEdgePreviewValue(item, ancestors))
+    ancestors.delete(value)
+    if (value.size <= EDGE_PREVIEW_ITEM_LIMIT) return new Set(items)
+    return {
+      summary: `Showing first ${EDGE_PREVIEW_ITEM_LIMIT} of ${value.size} items`,
+      items,
+    }
+  }
+
+  const entries = Object.entries(value)
+  const properties = Object.fromEntries(
+    entries
+      .slice(0, EDGE_PREVIEW_ITEM_LIMIT)
+      .map(([key, item]) => [key, limitEdgePreviewValue(item, ancestors)])
+  )
+  ancestors.delete(value)
+  if (entries.length <= EDGE_PREVIEW_ITEM_LIMIT) return properties
+  return {
+    summary: `Showing first ${EDGE_PREVIEW_ITEM_LIMIT} of ${entries.length} properties`,
+    properties,
+  }
+}
+
+function formatEdgePreviewValueInternal(value: unknown, ancestors: WeakSet<object>): unknown {
+  if (value instanceof Operator) {
+    if (ancestors.has(value)) return '[Circular]'
+    ancestors.add(value)
+    const { displayName } = value.constructor as typeof Operator
+    const formatted = {
+      id: value.id,
+      type: displayName,
+      inputs: Object.fromEntries(
+        Object.entries(value.inputs).map(([key, field]) => [
+          key,
+          formatEdgePreviewValueInternal(field.value, ancestors),
+        ])
+      ),
+      outputs: Object.fromEntries(
+        Object.entries(value.outputs).map(([key, field]) => [
+          key,
+          formatEdgePreviewValueInternal(field.value, ancestors),
+        ])
+      ),
+    }
+    ancestors.delete(value)
+    return formatted
+  }
+  return limitEdgePreviewValue(formatViewerValue(value), ancestors)
+}
+
 export function formatEdgePreviewValue(value: unknown): unknown {
-  const formatted = formatViewerValue(value)
-  if (Array.isArray(formatted) && formatted.length > EDGE_PREVIEW_ITEM_LIMIT) {
-    return {
-      summary: `Showing first ${EDGE_PREVIEW_ITEM_LIMIT} of ${formatted.length} items`,
-      items: formatted.slice(0, EDGE_PREVIEW_ITEM_LIMIT),
-    }
-  }
-  if (formatted instanceof Set && formatted.size > EDGE_PREVIEW_ITEM_LIMIT) {
-    return {
-      summary: `Showing first ${EDGE_PREVIEW_ITEM_LIMIT} of ${formatted.size} items`,
-      items: Array.from(formatted).slice(0, EDGE_PREVIEW_ITEM_LIMIT),
-    }
-  }
-  return formatted
+  return formatEdgePreviewValueInternal(value, new WeakSet())
 }
 
 function EdgeFieldValue({ field, fieldName }: { field: Field; fieldName: string }) {

--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -59,7 +59,13 @@ import {
 } from './field-components'
 import menuStyles from './menu.module.css'
 import s from './node-properties.module.css'
-import { handleClass, headerClass, typeCategory } from './op-components'
+import {
+  formatViewerValue,
+  HandlePreviewContent,
+  handleClass,
+  headerClass,
+  typeCategory,
+} from './op-components'
 import { RenderSettingsPanel } from './render-settings-panel'
 import { SuggestedNodesSection } from './SuggestedNodes'
 
@@ -1322,39 +1328,141 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
   )
 }
 
+const EDGE_PREVIEW_ITEM_LIMIT = 25
+
+export function formatEdgePreviewValue(value: unknown): unknown {
+  const formatted = formatViewerValue(value)
+  if (Array.isArray(formatted) && formatted.length > EDGE_PREVIEW_ITEM_LIMIT) {
+    return {
+      summary: `Showing first ${EDGE_PREVIEW_ITEM_LIMIT} of ${formatted.length} items`,
+      items: formatted.slice(0, EDGE_PREVIEW_ITEM_LIMIT),
+    }
+  }
+  if (formatted instanceof Set && formatted.size > EDGE_PREVIEW_ITEM_LIMIT) {
+    return {
+      summary: `Showing first ${EDGE_PREVIEW_ITEM_LIMIT} of ${formatted.size} items`,
+      items: Array.from(formatted).slice(0, EDGE_PREVIEW_ITEM_LIMIT),
+    }
+  }
+  return formatted
+}
+
+function EdgeFieldValue({ field, fieldName }: { field: Field; fieldName: string }) {
+  const value = useObservable(field, field.value)
+  const { type } = field.constructor as typeof Field
+
+  return (
+    <div className={s.edgeValuePreview} data-testid="edge-value-preview">
+      <HandlePreviewContent
+        data={formatEdgePreviewValue(value)}
+        name={fieldName}
+        type={type}
+        collapsed={1}
+      />
+    </div>
+  )
+}
+
+// Exported for testing
+export function EdgeProperties({ edge }: { edge: Edge }) {
+  const sourceOp = getOp(edge.source)
+  const sourceHandle = parseHandleId(edge.sourceHandle ?? '')
+  const sourceField = sourceHandle
+    ? sourceHandle.namespace === IN_NS
+      ? sourceOp?.inputs[sourceHandle.fieldName]
+      : sourceOp?.outputs[sourceHandle.fieldName]
+    : undefined
+
+  return (
+    <>
+      <div className={s.header}>
+        <div className={s.title}>
+          Edge
+          {edge.type === 'ReferenceEdge' && <div className={s.edgeTypeBadge}>Reference</div>}
+        </div>
+      </div>
+      <div className={s.edgeEndpoints}>
+        <div className={s.edgeEndpoint}>
+          <span className={s.edgeEndpointLabel}>From</span>
+          <code title={`${edge.source}.${edge.sourceHandle ?? ''}`}>
+            {getBaseName(edge.source)}.{edge.sourceHandle ?? 'unknown'}
+          </code>
+        </div>
+        <div className={s.edgeEndpointArrow} aria-hidden="true">
+          ↓
+        </div>
+        <div className={s.edgeEndpoint}>
+          <span className={s.edgeEndpointLabel}>To</span>
+          <code title={`${edge.target}.${edge.targetHandle ?? ''}`}>
+            {getBaseName(edge.target)}.{edge.targetHandle ?? 'unknown'}
+          </code>
+        </div>
+      </div>
+      <div className={s.section}>
+        <div className={s.sectionTitle}>Data</div>
+        {sourceField && sourceHandle ? (
+          <EdgeFieldValue field={sourceField} fieldName={sourceHandle.fieldName} />
+        ) : (
+          <div className={s.edgeValueUnavailable}>Source field is unavailable</div>
+        )}
+      </div>
+    </>
+  )
+}
+
 export function PropertyPanel() {
   // Only re-renders when selection changes, not on position updates during drag
-  const { selectedNodeId, selectedNodeCount, selectedEdgeCount } = useStore(
+  const { selectedNodeId, selectedNodeCount, selectedEdge, selectedEdgeCount } = useStore(
     s => {
       const selectedNodes = s.nodes.filter(n => n.selected)
+      const selectedEdges = s.edges.filter(e => e.selected)
       return {
         selectedNodeId: selectedNodes.length === 1 ? selectedNodes[0].id : null,
         selectedNodeCount: selectedNodes.length,
-        selectedEdgeCount: s.edges.filter(e => e.selected).length,
+        selectedEdge: selectedEdges.length === 1 ? selectedEdges[0] : null,
+        selectedEdgeCount: selectedEdges.length,
       }
     },
     (a, b) =>
       a.selectedNodeId === b.selectedNodeId &&
       a.selectedNodeCount === b.selectedNodeCount &&
+      a.selectedEdge?.id === b.selectedEdge?.id &&
       a.selectedEdgeCount === b.selectedEdgeCount
   )
+  const inspectedReferenceEdge = useUIStore(state => state.inspectedReferenceEdge)
+  const inspectedEdge =
+    selectedNodeCount === 0
+      ? selectedEdgeCount === 0
+        ? inspectedReferenceEdge
+        : selectedEdge
+      : null
 
   return (
     <div className={s.panel}>
       {selectedNodeId != null ? (
         <NodeProperties nodeId={selectedNodeId} />
+      ) : inspectedEdge != null ? (
+        <EdgeProperties edge={inspectedEdge} />
       ) : (
         <>
           <div className={s.header}>
             <div className={s.title}>Page</div>
           </div>
-          {selectedNodeCount > 1 ? (
+          {selectedNodeCount > 1 || selectedEdgeCount > 1 ? (
             <div className={s.opMeta}>
-              <div>{selectedNodeCount} nodes selected</div>
-              <div>{selectedEdgeCount} edges selected</div>
+              {selectedNodeCount > 0 && (
+                <div>
+                  {selectedNodeCount} {selectedNodeCount === 1 ? 'node' : 'nodes'} selected
+                </div>
+              )}
+              {selectedEdgeCount > 0 && (
+                <div>
+                  {selectedEdgeCount} {selectedEdgeCount === 1 ? 'edge' : 'edges'} selected
+                </div>
+              )}
             </div>
           ) : (
-            <div className={s.opMeta}>Select a node to see properties</div>
+            <div className={s.opMeta}>Select a node or edge to inspect it</div>
           )}
         </>
       )}

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -267,6 +267,7 @@ function DefaultEdgeComponent({
 }
 
 function ReferenceEdgeComponent({
+  id,
   sourceX,
   sourceY,
   targetX,
@@ -274,6 +275,7 @@ function ReferenceEdgeComponent({
   style = {},
   markerEnd,
 }: EdgeProps) {
+  const isInspected = useUIStore(s => s.inspectedReferenceEdge?.id === id)
   const [edgePath] = getStraightPath({
     sourceX,
     sourceY,
@@ -282,7 +284,12 @@ function ReferenceEdgeComponent({
   })
 
   return (
-    <BaseEdge path={edgePath} markerEnd={markerEnd} className={s.referenceEdge} style={style} />
+    <BaseEdge
+      path={edgePath}
+      markerEnd={markerEnd}
+      className={cx(s.referenceEdge, { [s.inspectedReferenceEdge]: isInspected })}
+      style={style}
+    />
   )
 }
 
@@ -515,7 +522,17 @@ export function useFieldVisibility(op: Operator<IOperator> | undefined) {
   }, [op])
 }
 
-function HandlePreviewContent({ data, name, type }: { data: unknown; name: string; type: string }) {
+export function HandlePreviewContent({
+  data,
+  name,
+  type,
+  collapsed,
+}: {
+  data: unknown
+  name: string
+  type: string
+  collapsed?: boolean | number
+}) {
   return (
     <>
       <div className={previewStyles.handlePreviewHeader}>
@@ -528,7 +545,7 @@ function HandlePreviewContent({ data, name, type }: { data: unknown; name: strin
         ) : data instanceof Element ? (
           <ViewerDOMContent content={data} />
         ) : data instanceof Set ? (
-          <ReactJson src={Array.from(data)} theme="twilight" collapsed={1} />
+          <ReactJson src={Array.from(data)} theme="twilight" collapsed={collapsed ?? 1} />
         ) : Array.isArray(data) &&
           data.length > 0 &&
           data.length < 10 &&
@@ -573,11 +590,11 @@ function HandlePreviewContent({ data, name, type }: { data: unknown; name: strin
             )
           })()
         ) : data instanceof Operator ? (
-          <ReactJson src={data} theme="twilight" />
+          <ReactJson src={data} theme="twilight" collapsed={collapsed} />
         ) : data instanceof Promise ? (
           <div className={previewStyles.handlePreviewEmpty}>Loading...</div>
         ) : (
-          <ReactJson src={data} theme="twilight" />
+          <ReactJson src={data} theme="twilight" collapsed={collapsed} />
         )}
       </div>
     </>
@@ -608,7 +625,7 @@ export function OutputHandle({ id, field }: { id: string; field: Field<IField> }
         // Get the handle's position in the viewport
         const rect = currentTarget.getBoundingClientRect()
         setPreviewPosition({ x: rect.right, y: rect.top })
-        setPreviewData(viewerFormatter(field.value))
+        setPreviewData(formatViewerValue(field.value))
       }, 1000)
     },
     [field, nid, qualifiedFieldId]
@@ -1864,7 +1881,7 @@ export function TableEditorOpComponent({
 }
 
 // Helper for ViewerOp to format Layer and Operator instances
-const viewerFormatter = (value: unknown) => {
+export const formatViewerValue = (value: unknown): unknown => {
   if (value instanceof Layer) {
     // Guard against ReactJson crash since layer.props has no `hasOwnProperty` method
     const { lifecycle, count, isLoaded, props } = value
@@ -1876,10 +1893,10 @@ const viewerFormatter = (value: unknown) => {
       id: value.id,
       type: displayName,
       inputs: Object.fromEntries(
-        Object.entries(value.inputs).map(([key, field]) => [key, viewerFormatter(field.value)])
+        Object.entries(value.inputs).map(([key, field]) => [key, formatViewerValue(field.value)])
       ),
       outputs: Object.fromEntries(
-        Object.entries(value.outputs).map(([key, field]) => [key, viewerFormatter(field.value)])
+        Object.entries(value.outputs).map(([key, field]) => [key, formatViewerValue(field.value)])
       ),
     }
   }
@@ -1923,13 +1940,13 @@ function ViewerOpComponent({
 
   // TODO: use react-flow helpers
   const [viewerData, setViewerData] = useState(() =>
-    op ? viewerFormatter(op.inputs.data.value) : null
+    op ? formatViewerValue(op.inputs.data.value) : null
   )
 
   useEffect(() => {
     if (!op) return
     const sub = op.inputs.data.subscribe(newVal => {
-      setViewerData(viewerFormatter(newVal))
+      setViewerData(formatViewerValue(newVal))
     })
     return () => sub.unsubscribe()
   }, [op])
@@ -1993,7 +2010,7 @@ function ViewerOpComponent({
       </table>
     )
   } else if (viewerData instanceof Operator) {
-    content = <ReactJson src={viewerFormatter(viewerData)} theme="twilight" />
+    content = <ReactJson src={formatViewerValue(viewerData)} theme="twilight" />
   } else if (viewerData instanceof Promise) {
     content = 'Loading...'
   } else {

--- a/noodles-editor/src/noodles/noodles.module.css
+++ b/noodles-editor/src/noodles/noodles.module.css
@@ -1105,8 +1105,13 @@
 .referenceEdge {
   stroke-dasharray: 5 5;
   stroke-width: 1.5;
-  pointer-events: none;
+  pointer-events: stroke;
   stroke: #888;
+}
+
+.inspectedReferenceEdge {
+  stroke: var(--node-selected-color);
+  stroke-width: 3;
 }
 
 .targetedEdge {

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -236,6 +236,13 @@ export function getNoodles(): Visualization {
 
   useEffect(() => () => referenceDependencyModel.reset(), [])
 
+  useEffect(() => {
+    const inspectedEdge = getUIStore().inspectedReferenceEdge
+    if (inspectedEdge && !referenceEdges.some(edge => edge.id === inspectedEdge.id)) {
+      getUIStore().setInspectedReferenceEdge(null)
+    }
+  }, [referenceEdges])
+
   // Single ref providing synchronous access to the full graph state.
   // Used by CopyControls, UndoRedoHandler, and hooks that need all nodes/edges
   // without triggering re-renders or being limited to the displayed scope.
@@ -273,6 +280,7 @@ export function getNoodles(): Visualization {
       // Track selection changes
       const selectedChanges = changes.filter(change => change.type === 'select' && change.selected)
       if (selectedChanges.length > 0) {
+        getUIStore().setInspectedReferenceEdge(null)
         analytics.track('node_selected', { count: selectedChanges.length })
       }
 
@@ -683,7 +691,23 @@ export function getNoodles(): Visualization {
   const onDeselectAll = useCallback(() => {
     setNodes(nodes => nodes.map(node => ({ ...node, selected: false })))
     setEdges(edges => edges.map(edge => ({ ...edge, selected: false })))
+    getUIStore().setInspectedReferenceEdge(null)
   }, [setNodes, setEdges])
+
+  const onEdgeClick = useCallback(
+    (_event: React.MouseEvent, edge: ReactFlowEdge) => {
+      analytics.track('edge_selected', { type: edge.type ?? 'default' })
+      if (edge.type === 'ReferenceEdge') {
+        onDeselectAll()
+        getUIStore().setInspectedReferenceEdge(
+          referenceEdges.find(referenceEdge => referenceEdge.id === edge.id) ?? edge
+        )
+      } else {
+        getUIStore().setInspectedReferenceEdge(null)
+      }
+    },
+    [onDeselectAll, referenceEdges]
+  )
 
   const onPaneClick = useCallback(() => {
     blockLibraryRef.current?.closeModal()
@@ -1621,6 +1645,7 @@ export function getNoodles(): Visualization {
                 onReconnect={onReconnect}
                 onReconnectEnd={onReconnectEnd}
                 onNodeContextMenu={onNodeContextMenu}
+                onEdgeClick={onEdgeClick}
                 onNodesDelete={onNodesDelete}
                 onNodeDrag={onNodeDrag}
                 onNodeDragStop={onNodeDragStop}

--- a/noodles-editor/src/noodles/store.tsx
+++ b/noodles-editor/src/noodles/store.tsx
@@ -136,6 +136,8 @@ interface UIStoreState {
   setTargetedEdge: (edge: { id: string; compatible: boolean } | null) => void
   nodeDragState: NodeDragState | null
   setNodeDragState: (state: NodeDragState | null) => void
+  inspectedReferenceEdge: ReactFlowEdge | null
+  setInspectedReferenceEdge: (edge: ReactFlowEdge | null) => void
   sidebarSearchFocusTrigger: number
   triggerSidebarSearch: () => void
   settingsDialogOpen: boolean
@@ -175,6 +177,8 @@ export const useUIStore = create<UIStoreState>(set => ({
   setTargetedEdge: edge => set({ targetedEdge: edge }),
   nodeDragState: null,
   setNodeDragState: state => set({ nodeDragState: state }),
+  inspectedReferenceEdge: null,
+  setInspectedReferenceEdge: edge => set({ inspectedReferenceEdge: edge }),
   sidebarSearchFocusTrigger: 0,
   triggerSidebarSearch: () =>
     set(state => ({ sidebarSearchFocusTrigger: state.sidebarSearchFocusTrigger + 1 })),


### PR DESCRIPTION
#### Background

Inspecting data on distant or reference-connected source nodes currently requires adding or navigating to a viewer.

<img width="709" height="612" alt="image" src="https://github.com/user-attachments/assets/11d6897c-24c8-4ce6-bddd-325bfda79b9e" />

#### Change List
- Show source, target, type, and live source-field data for a selected edge in the properties panel.
- Make reference edges inspectable with persistent selection styling while preserving their derived source handles.
- Bound large previews and add focused coverage for live values, references, and multi-selection.

Validated with 51 passing focused tests, a production build, and browser checks for normal and reference edges.