### PR TITLE
Fix expression autocomplete UX

### DIFF
--- a/noodles-editor/src/noodles/components/ExpressionEditorOverlay.test.tsx
+++ b/noodles-editor/src/noodles/components/ExpressionEditorOverlay.test.tsx
@@ -45,7 +45,11 @@ describe('ExpressionEditorOverlay', () => {
         value="d."
         onChange={onChange}
         onClose={onClose}
-        context={{ dataKeys: ['value'], globals: [], operatorPaths: [] }}
+        context={{
+          dataKeys: [{ label: 'value', path: ['value'] }],
+          globals: [],
+          operatorPaths: [],
+        }}
         anchorRect={null}
       />
     )
@@ -71,7 +75,11 @@ describe('ExpressionEditorOverlay', () => {
         value="d."
         onChange={vi.fn()}
         onClose={onClose}
-        context={{ dataKeys: ['value'], globals: [], operatorPaths: [] }}
+        context={{
+          dataKeys: [{ label: 'value', path: ['value'] }],
+          globals: [],
+          operatorPaths: [],
+        }}
         anchorRect={null}
       />
     )

--- a/noodles-editor/src/noodles/components/ExpressionEditorOverlay.test.tsx
+++ b/noodles-editor/src/noodles/components/ExpressionEditorOverlay.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ExpressionEditorOverlay } from './ExpressionEditorOverlay'
+
+const mocks = vi.hoisted(() => {
+  const addCommand = vi.fn()
+  const editor = {
+    addCommand,
+    focus: vi.fn(),
+    getModel: () => ({ getFullModelRange: () => ({}) }),
+    getValue: () => 'd.value',
+    setSelection: vi.fn(),
+  }
+  const monaco = {
+    KeyCode: { Enter: 3, Escape: 9 },
+    languages: {
+      CompletionItemKind: {},
+      registerCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+  }
+
+  return { addCommand, editor, monaco }
+})
+
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: {
+    onMount: (editor: typeof mocks.editor, monaco: typeof mocks.monaco) => void
+  }) => {
+    props.onMount(mocks.editor, mocks.monaco)
+    return <div data-testid="mock-monaco" />
+  },
+}))
+
+describe('ExpressionEditorOverlay', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('lets Monaco accept a visible suggestion with Enter', () => {
+    const onChange = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <ExpressionEditorOverlay
+        value="d."
+        onChange={onChange}
+        onClose={onClose}
+        context={{ dataKeys: ['value'], globals: [], operatorPaths: [] }}
+        anchorRect={null}
+      />
+    )
+
+    expect(mocks.addCommand).toHaveBeenCalledWith(
+      mocks.monaco.KeyCode.Enter,
+      expect.any(Function),
+      '!suggestWidgetVisible'
+    )
+
+    const enterCommand = mocks.addCommand.mock.calls.find(
+      ([keyCode]) => keyCode === mocks.monaco.KeyCode.Enter
+    )
+    enterCommand?.[1]()
+    expect(onChange).toHaveBeenCalledWith('d.value')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('lets Monaco dismiss visible suggestions before Escape cancels the editor', () => {
+    const onClose = vi.fn()
+    render(
+      <ExpressionEditorOverlay
+        value="d."
+        onChange={vi.fn()}
+        onClose={onClose}
+        context={{ dataKeys: ['value'], globals: [], operatorPaths: [] }}
+        anchorRect={null}
+      />
+    )
+
+    expect(mocks.addCommand).toHaveBeenCalledWith(
+      mocks.monaco.KeyCode.Escape,
+      expect.any(Function),
+      '!suggestWidgetVisible'
+    )
+
+    const escapeCommand = mocks.addCommand.mock.calls.find(
+      ([keyCode]) => keyCode === mocks.monaco.KeyCode.Escape
+    )
+    escapeCommand?.[1]()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/noodles-editor/src/noodles/components/ExpressionEditorOverlay.tsx
+++ b/noodles-editor/src/noodles/components/ExpressionEditorOverlay.tsx
@@ -96,17 +96,21 @@ export function ExpressionEditorOverlay({
         editor.setSelection(fullRange)
       }
 
-      // Handle Enter key (without modifier) to confirm
-      editor.addCommand(monaco.KeyCode.Enter, () => {
-        const currentValue = editor.getValue()
-        onChange(currentValue)
-        onClose()
-      })
+      // Confirm with Enter only when autocomplete is closed. When suggestions
+      // are visible, Monaco's built-in Enter command accepts the selected item.
+      editor.addCommand(
+        monaco.KeyCode.Enter,
+        () => {
+          const currentValue = editor.getValue()
+          onChange(currentValue)
+          onClose()
+        },
+        '!suggestWidgetVisible'
+      )
 
-      // Handle Escape to cancel
-      editor.addCommand(monaco.KeyCode.Escape, () => {
-        onClose()
-      })
+      // Cancel only when autocomplete is closed. When suggestions are visible,
+      // Monaco's built-in Escape command dismisses the suggestion widget first.
+      editor.addCommand(monaco.KeyCode.Escape, () => onClose(), '!suggestWidgetVisible')
 
       // Note: Tab key is NOT overridden here to allow Monaco's autocomplete to work
       // Users can accept autocomplete suggestions with Tab (standard IDE behavior)
@@ -188,7 +192,7 @@ export function ExpressionEditorOverlay({
       </div>
       {validationError && <div className={s.expressionEditorError}>{validationError}</div>}
       <div className={s.expressionEditorHint}>
-        Enter to confirm • Escape to cancel • Tab to accept suggestion
+        Enter accepts or confirms • Tab accepts • Escape cancels
       </div>
     </div>,
     document.body

--- a/noodles-editor/src/noodles/components/expression-completions.test.ts
+++ b/noodles-editor/src/noodles/components/expression-completions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ExpressionContext } from '../utils/expression-context'
+import type { DataKeyDefinition, ExpressionContext } from '../utils/expression-context'
 import { createExpressionCompletionProvider } from './expression-completions'
 
 const monaco = {
@@ -28,7 +28,7 @@ interface TestCompletionItem {
   }
 }
 
-function complete(text: string, dataKeys: string[]) {
+function complete(text: string, dataKeys: DataKeyDefinition[]) {
   const context: ExpressionContext = {
     dataKeys,
     globals: [],
@@ -50,7 +50,7 @@ function complete(text: string, dataKeys: string[]) {
 
 describe('expression data-property completions', () => {
   it('replaces dot notation with bracket notation for keys containing spaces', () => {
-    const suggestion = complete('d.Dis', ['Display Name']).find(
+    const suggestion = complete('d.Dis', [{ label: 'Display Name', path: ['Display Name'] }]).find(
       item => item.label === 'Display Name'
     )
 
@@ -66,7 +66,9 @@ describe('expression data-property completions', () => {
   })
 
   it('keeps dot notation for valid JavaScript property identifiers', () => {
-    const suggestion = complete('d.Dis', ['DisplayName']).find(item => item.label === 'DisplayName')
+    const suggestion = complete('d.Dis', [{ label: 'DisplayName', path: ['DisplayName'] }]).find(
+      item => item.label === 'DisplayName'
+    )
 
     expect(suggestion).toMatchObject({
       insertText: 'DisplayName',
@@ -78,12 +80,32 @@ describe('expression data-property completions', () => {
   })
 
   it('uses bracket notation in top-level data-property shortcuts', () => {
-    const suggestion = complete('', ['Display Name']).find(
+    const suggestion = complete('', [{ label: 'Display Name', path: ['Display Name'] }]).find(
       item => item.label === 'd["Display Name"]'
     )
 
     expect(suggestion).toMatchObject({
       insertText: 'd["Display Name"]',
+    })
+  })
+
+  it('preserves periods in literal property names', () => {
+    const suggestion = complete('d.Dis', [{ label: 'Display.Name', path: ['Display.Name'] }]).find(
+      item => item.label === 'Display.Name'
+    )
+
+    expect(suggestion).toMatchObject({
+      insertText: '["Display.Name"]',
+    })
+  })
+
+  it('keeps nested object paths distinct from literal dotted properties', () => {
+    const suggestion = complete('d.pro', [
+      { label: 'profile.Display Name', path: ['profile', 'Display Name'] },
+    ]).find(item => item.label === 'profile.Display Name')
+
+    expect(suggestion).toMatchObject({
+      insertText: 'profile["Display Name"]',
     })
   })
 })

--- a/noodles-editor/src/noodles/components/expression-completions.test.ts
+++ b/noodles-editor/src/noodles/components/expression-completions.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { ExpressionContext } from '../utils/expression-context'
+import { createExpressionCompletionProvider } from './expression-completions'
+
+const monaco = {
+  languages: {
+    CompletionItemKind: {
+      Property: 1,
+      Snippet: 2,
+      Text: 3,
+      Function: 4,
+      Module: 5,
+      Variable: 6,
+      Method: 7,
+      Reference: 8,
+    },
+  },
+}
+
+interface TestCompletionItem {
+  label: string
+  insertText: string
+  range: {
+    startLineNumber: number
+    endLineNumber: number
+    startColumn: number
+    endColumn: number
+  }
+}
+
+function complete(text: string, dataKeys: string[]) {
+  const context: ExpressionContext = {
+    dataKeys,
+    globals: [],
+    operatorPaths: [],
+  }
+  const provider = createExpressionCompletionProvider(monaco, () => context)
+  const word = text.match(/[$\w]*$/)?.[0] ?? ''
+  const position = { lineNumber: 1, column: text.length + 1 }
+  const model = {
+    getWordUntilPosition: () => ({
+      startColumn: position.column - word.length,
+      endColumn: position.column,
+    }),
+    getValueInRange: () => text,
+  }
+
+  return provider.provideCompletionItems(model, position).suggestions as TestCompletionItem[]
+}
+
+describe('expression data-property completions', () => {
+  it('replaces dot notation with bracket notation for keys containing spaces', () => {
+    const suggestion = complete('d.Dis', ['Display Name']).find(
+      item => item.label === 'Display Name'
+    )
+
+    expect(suggestion).toMatchObject({
+      insertText: '["Display Name"]',
+      range: {
+        startLineNumber: 1,
+        endLineNumber: 1,
+        startColumn: 2,
+        endColumn: 6,
+      },
+    })
+  })
+
+  it('keeps dot notation for valid JavaScript property identifiers', () => {
+    const suggestion = complete('d.Dis', ['DisplayName']).find(item => item.label === 'DisplayName')
+
+    expect(suggestion).toMatchObject({
+      insertText: 'DisplayName',
+      range: {
+        startColumn: 3,
+        endColumn: 6,
+      },
+    })
+  })
+
+  it('uses bracket notation in top-level data-property shortcuts', () => {
+    const suggestion = complete('', ['Display Name']).find(
+      item => item.label === 'd["Display Name"]'
+    )
+
+    expect(suggestion).toMatchObject({
+      insertText: 'd["Display Name"]',
+    })
+  })
+})

--- a/noodles-editor/src/noodles/components/expression-completions.ts
+++ b/noodles-editor/src/noodles/components/expression-completions.ts
@@ -2,6 +2,7 @@
 // Provides autocomplete suggestions for data keys, globals, and operator paths
 
 import type {
+  DataKeyDefinition,
   ExpressionContext,
   GlobalDefinition,
   TargetFieldInfo,
@@ -32,9 +33,8 @@ const SAFE_DOT_PROPERTY = /^[$A-Z_a-z][$\w]*$/
 
 // Build a property-access suffix that is valid JavaScript. Data keys may include
 // spaces or punctuation, so dot notation is only safe for identifier segments.
-function dataPropertyAccess(key: string): string {
-  return key
-    .split('.')
+function dataPropertyAccess(key: DataKeyDefinition): string {
+  return key.path
     .map(segment =>
       SAFE_DOT_PROPERTY.test(segment) ? `.${segment}` : `[${JSON.stringify(segment)}]`
     )
@@ -42,7 +42,7 @@ function dataPropertyAccess(key: string): string {
 }
 
 function dataPropertyCompletion(
-  key: string,
+  key: DataKeyDefinition,
   range: CompletionRange,
   CompletionItemKind: MonacoInstance,
   detail: string,
@@ -52,7 +52,7 @@ function dataPropertyCompletion(
   const usesDotNotation = access.startsWith('.')
 
   return {
-    label: key,
+    label: key.label,
     kind: CompletionItemKind.Property,
     detail,
     insertText: usesDotNotation ? access.slice(1) : access,
@@ -68,7 +68,7 @@ function dataPropertyCompletion(
   }
 }
 
-function dataPropertyExpression(key: string): string {
+function dataPropertyExpression(key: DataKeyDefinition): string {
   return `d${dataPropertyAccess(key)}`
 }
 
@@ -124,9 +124,9 @@ const COLOR_KEY_PATTERNS = ['color', 'fill', 'stroke', 'rgb', 'rgba']
 
 // Prioritize data keys based on target field type
 function prioritizeDataKeys(
-  dataKeys: string[],
+  dataKeys: DataKeyDefinition[],
   targetField?: TargetFieldInfo
-): { prioritized: string[]; other: string[] } {
+): { prioritized: DataKeyDefinition[]; other: DataKeyDefinition[] } {
   if (!targetField) return { prioritized: [], other: dataKeys }
 
   let priorityPatterns: string[] = []
@@ -142,7 +142,7 @@ function prioritizeDataKeys(
   if (priorityPatterns.length === 0) return { prioritized: [], other: dataKeys }
 
   const prioritized = dataKeys.filter(key => {
-    const baseKey = key.split('.').pop() || key
+    const baseKey = key.path.at(-1) ?? key.label
     return priorityPatterns.some(pattern => baseKey.toLowerCase().includes(pattern.toLowerCase()))
   })
   const other = dataKeys.filter(key => !prioritized.includes(key))
@@ -153,7 +153,7 @@ function prioritizeDataKeys(
 // Create template completions based on target field type
 function createTemplateCompletions(
   targetField: TargetFieldInfo | undefined,
-  dataKeys: string[],
+  dataKeys: DataKeyDefinition[],
   range: CompletionRange,
   CompletionItemKind: MonacoInstance
 ): CompletionItem[] {
@@ -166,11 +166,13 @@ function createTemplateCompletions(
     // Find lng/lat-like keys for position template
     const lngKey = prioritized.find(k =>
       ['lng', 'longitude', 'lon', 'x', 'start_lng', 'source_lng'].some(p =>
-        k.toLowerCase().endsWith(p)
+        (k.path.at(-1) ?? k.label).toLowerCase().endsWith(p)
       )
     )
     const latKey = prioritized.find(k =>
-      ['lat', 'latitude', 'y', 'start_lat', 'source_lat'].some(p => k.toLowerCase().endsWith(p))
+      ['lat', 'latitude', 'y', 'start_lat', 'source_lat'].some(p =>
+        (k.path.at(-1) ?? k.label).toLowerCase().endsWith(p)
+      )
     )
 
     // Suggest a concrete template if we found coordinate keys
@@ -286,7 +288,7 @@ function createBracketCompletions(
 
 // Create completion items for data keys (d.lat, d.lng, etc.)
 function createDataKeyCompletions(
-  dataKeys: string[],
+  dataKeys: DataKeyDefinition[],
   range: CompletionRange,
   CompletionItemKind: MonacoInstance
 ): CompletionItem[] {
@@ -452,7 +454,7 @@ export function createExpressionCompletionProvider(
               range,
               monaco.languages.CompletionItemKind,
               'Data property',
-              `1${key}` // Sort after prioritized
+              `1${key.label}` // Sort after prioritized
             )
           )
         }

--- a/noodles-editor/src/noodles/components/expression-completions.ts
+++ b/noodles-editor/src/noodles/components/expression-completions.ts
@@ -28,6 +28,50 @@ interface CompletionItem {
   insertTextRules?: number
 }
 
+const SAFE_DOT_PROPERTY = /^[$A-Z_a-z][$\w]*$/
+
+// Build a property-access suffix that is valid JavaScript. Data keys may include
+// spaces or punctuation, so dot notation is only safe for identifier segments.
+function dataPropertyAccess(key: string): string {
+  return key
+    .split('.')
+    .map(segment =>
+      SAFE_DOT_PROPERTY.test(segment) ? `.${segment}` : `[${JSON.stringify(segment)}]`
+    )
+    .join('')
+}
+
+function dataPropertyCompletion(
+  key: string,
+  range: CompletionRange,
+  CompletionItemKind: MonacoInstance,
+  detail: string,
+  sortText?: string
+): CompletionItem {
+  const access = dataPropertyAccess(key)
+  const usesDotNotation = access.startsWith('.')
+
+  return {
+    label: key,
+    kind: CompletionItemKind.Property,
+    detail,
+    insertText: usesDotNotation ? access.slice(1) : access,
+    // When switching to bracket notation, replace the dot before the partially
+    // typed word as well (d.Dis -> d["Display Name"]).
+    range: usesDotNotation
+      ? range
+      : {
+          ...range,
+          startColumn: Math.max(1, range.startColumn - 1),
+        },
+    sortText,
+  }
+}
+
+function dataPropertyExpression(key: string): string {
+  return `d${dataPropertyAccess(key)}`
+}
+
 // Field types that expect position/coordinate arrays
 const POSITION_FIELD_TYPES = ['geopoint-3d', 'geopoint-2d', 'vec2', 'vec3']
 // Field types that expect colors
@@ -131,11 +175,13 @@ function createTemplateCompletions(
 
     // Suggest a concrete template if we found coordinate keys
     if (lngKey && latKey) {
+      const lngExpression = dataPropertyExpression(lngKey)
+      const latExpression = dataPropertyExpression(latKey)
       templates.push({
-        label: `[d.${lngKey}, d.${latKey}]`,
+        label: `[${lngExpression}, ${latExpression}]`,
         kind: CompletionItemKind.Snippet,
         detail: 'Position array [lng, lat]',
-        insertText: `[d.${lngKey}, d.${latKey}]`,
+        insertText: `[${lngExpression}, ${latExpression}]`,
         range,
         sortText: '!0000', // Sort to top
       })
@@ -170,11 +216,12 @@ function createTemplateCompletions(
 
   if (SCALAR_FIELD_TYPES.includes(targetField.fieldType) && prioritized.length > 0) {
     // Scalar expression template
+    const dataExpression = dataPropertyExpression(prioritized[0])
     templates.push({
-      label: `d.${prioritized[0]} * 10`,
+      label: `${dataExpression} * 10`,
       kind: CompletionItemKind.Snippet,
       detail: 'Scaled value expression',
-      insertText: `d.${prioritized[0]} * \${1:10}`,
+      insertText: `${dataExpression} * \${1:10}`,
       insertTextRules: 4,
       range,
       sortText: '!0000',
@@ -243,13 +290,9 @@ function createDataKeyCompletions(
   range: CompletionRange,
   CompletionItemKind: MonacoInstance
 ): CompletionItem[] {
-  return dataKeys.map(key => ({
-    label: key,
-    kind: CompletionItemKind.Property,
-    detail: 'Data property',
-    insertText: key,
-    range,
-  }))
+  return dataKeys.map(key =>
+    dataPropertyCompletion(key, range, CompletionItemKind, 'Data property')
+  )
 }
 
 // Create completion items for global variables and libraries
@@ -390,26 +433,28 @@ export function createExpressionCompletionProvider(
 
         // Add prioritized keys first with sort order to appear at top
         for (let i = 0; i < prioritized.length; i++) {
-          suggestions.push({
-            label: prioritized[i],
-            kind: monaco.languages.CompletionItemKind.Property,
-            detail: 'Data property (suggested)',
-            insertText: prioritized[i],
-            range,
-            sortText: `0${String(i).padStart(4, '0')}`, // Sort to top
-          })
+          suggestions.push(
+            dataPropertyCompletion(
+              prioritized[i],
+              range,
+              monaco.languages.CompletionItemKind,
+              'Data property (suggested)',
+              `0${String(i).padStart(4, '0')}` // Sort to top
+            )
+          )
         }
 
         // Add other keys with lower priority
         for (const key of other) {
-          suggestions.push({
-            label: key,
-            kind: monaco.languages.CompletionItemKind.Property,
-            detail: 'Data property',
-            insertText: key,
-            range,
-            sortText: `1${key}`, // Sort after prioritized
-          })
+          suggestions.push(
+            dataPropertyCompletion(
+              key,
+              range,
+              monaco.languages.CompletionItemKind,
+              'Data property',
+              `1${key}` // Sort after prioritized
+            )
+          )
         }
 
         return { suggestions }
@@ -475,13 +520,14 @@ export function createExpressionCompletionProvider(
         const keysToShow = [...prioritized, ...other].slice(0, 10) // Limit to prevent overwhelming
 
         for (const key of keysToShow) {
+          const expression = dataPropertyExpression(key)
           suggestions.push({
-            label: `d.${key}`,
+            label: expression,
             kind: monaco.languages.CompletionItemKind.Property,
             detail: prioritized.includes(key)
               ? 'Data property (suggested)'
               : 'Data property shortcut',
-            insertText: `d.${key}`,
+            insertText: expression,
             range,
           })
         }

--- a/noodles-editor/src/noodles/utils/expression-context.ts
+++ b/noodles-editor/src/noodles/utils/expression-context.ts
@@ -29,8 +29,13 @@ export interface TargetFieldInfo {
   returnType?: 'object' | 'tuple' // For point/vec fields
 }
 
+export interface DataKeyDefinition {
+  label: string
+  path: string[]
+}
+
 export interface ExpressionContext {
-  dataKeys: string[] // Keys from upstream data: ['lat', 'lng', 'count']
+  dataKeys: DataKeyDefinition[] // Keys from upstream data, preserving literal vs nested paths
   globals: GlobalDefinition[] // d, data, op, utils, d3, turf, etc.
   operatorPaths: string[] // Available operator paths for op() autocomplete
   targetField?: TargetFieldInfo // For AccessorOp: info about the field it connects to
@@ -104,7 +109,7 @@ const ACCESSOR_GLOBALS: GlobalDefinition[] = [
 ]
 
 // Extract keys from a data object/array
-function extractDataKeys(data: unknown): string[] {
+function extractDataKeys(data: unknown): DataKeyDefinition[] {
   if (!data) return []
 
   // If it's an array, look at the first item
@@ -113,13 +118,13 @@ function extractDataKeys(data: unknown): string[] {
   if (!item || typeof item !== 'object') return []
 
   // Get all keys, including nested ones (one level deep)
-  const keys: string[] = []
-  for (const [key, value] of Object.entries(item)) {
-    keys.push(key)
+  const keys: DataKeyDefinition[] = []
+  for (const [key, value] of Object.entries(item as Record<string, unknown>)) {
+    keys.push({ label: key, path: [key] })
     // Add nested keys for objects (not arrays)
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       for (const nestedKey of Object.keys(value)) {
-        keys.push(`${key}.${nestedKey}`)
+        keys.push({ label: `${key}.${nestedKey}`, path: [key, nestedKey] })
       }
     }
   }
@@ -226,7 +231,7 @@ export function getExpressionContext(operatorId: OpId, edges: Edge[]): Expressio
   }
 
   const displayName = (op.constructor as { displayName?: string }).displayName || ''
-  let dataKeys: string[] = []
+  let dataKeys: DataKeyDefinition[] = []
   let globals = EXPRESSION_GLOBALS
 
   let targetField: TargetFieldInfo | undefined


### PR DESCRIPTION
#### UX notes
- Property suggestions with spaces now insert valid bracket notation, such as d["Display Name"].
- Enter and Tab accept the highlighted suggestion; Escape dismisses suggestions before a later Enter confirms or Escape cancels.

#### Background
Expression autocomplete previously produced invalid JavaScript for non-identifier property names and intercepted Monaco keyboard conventions.

<img width="468" height="249" alt="Screenshot 2026-09-04 at 11 27 58 AM" src="https://github.com/user-attachments/assets/385e40c2-8504-40b4-8821-2f0ed76e0d13" />

#### Change List
- Generate safe dot or bracket access while distinguishing literal dotted column names from nested object paths.
- Defer Enter and Escape to Monaco while its suggestion widget is visible.
- Add focused regression coverage for insertion syntax and keyboard commands.