### PR TITLE
feat: add expression-driven, versioned render outputs

### DIFF
--- a/noodles-editor/src/noodles/components/render-settings-panel.module.css
+++ b/noodles-editor/src/noodles/components/render-settings-panel.module.css
@@ -64,6 +64,34 @@
   transition: all 0.2s;
 }
 
+.textInput {
+  min-width: 0;
+  flex: 1;
+  padding: 4px 6px;
+  background-color: rgba(255, 255, 255, 0.05);
+  color: var(--color-text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  font-size: 11px;
+}
+
+.textInput:focus {
+  outline: none;
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: #3b82f6;
+}
+
+.textInput:disabled {
+  color: rgba(255, 255, 255, 0.55);
+  cursor: not-allowed;
+}
+
+.expressionBadge {
+  color: #60a5fa;
+  font-size: 10px;
+  font-weight: 600;
+}
+
 .numberInput:hover {
   background-color: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.2);

--- a/noodles-editor/src/noodles/components/render-settings-panel.test.tsx
+++ b/noodles-editor/src/noodles/components/render-settings-panel.test.tsx
@@ -47,4 +47,14 @@ describe('RenderSettingsPanel preview scale', () => {
 
     expect(op.inputs.fileName.value).toBe('LA-vertistop')
   })
+
+  it('configures the photo format for direct exports', () => {
+    const op = new OutOp('/out')
+    const { container } = render(<RenderSettingsPanel op={op} />)
+    const format = container.querySelector<HTMLSelectElement>('#render-image-format')!
+
+    fireEvent.change(format, { target: { value: 'jpeg' } })
+
+    expect(op.inputs.imageFormat.value).toBe('jpeg')
+  })
 })

--- a/noodles-editor/src/noodles/components/render-settings-panel.test.tsx
+++ b/noodles-editor/src/noodles/components/render-settings-panel.test.tsx
@@ -24,4 +24,27 @@ describe('RenderSettingsPanel preview scale', () => {
     fireEvent.change(previewMode, { target: { value: 'manual' } })
     expect(screen.getByLabelText('Scale')).toHaveValue('0.65')
   })
+
+  it('shows the resolved filename and protects expression-driven values', () => {
+    const op = new OutOp('/out')
+    op.inputs.fileName.setValue('LA-vertistop')
+    op.inputs.fileName.setExpression("'FL-' + 'routes'")
+    const { container } = render(<RenderSettingsPanel op={op} />)
+
+    const fileName = container.querySelector<HTMLInputElement>('#render-file-name')!
+    expect(fileName).toHaveValue('FL-routes')
+    expect(fileName).toBeDisabled()
+    expect(container.textContent).toContain('fx')
+    expect(op.inputs.fileName.serialize()).toEqual({ $expr: "'FL-' + 'routes'" })
+  })
+
+  it('updates a literal filename from the output settings', () => {
+    const op = new OutOp('/out')
+    const { container } = render(<RenderSettingsPanel op={op} />)
+    const fileName = container.querySelector<HTMLInputElement>('#render-file-name')!
+
+    fireEvent.change(fileName, { target: { value: 'LA-vertistop' } })
+
+    expect(op.inputs.fileName.value).toBe('LA-vertistop')
+  })
 })

--- a/noodles-editor/src/noodles/components/render-settings-panel.tsx
+++ b/noodles-editor/src/noodles/components/render-settings-panel.tsx
@@ -43,6 +43,7 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
   const [captureDelay, setCaptureDelay] = useState(op.inputs.captureDelay.value)
   const [fileName, setFileName] = useState(op.inputs.fileName.value)
   const [fileNameExpression, setFileNameExpression] = useState(op.inputs.fileName.expression)
+  const [imageFormat, setImageFormat] = useState(op.inputs.imageFormat.value)
   const [rendersDirectory, setRendersDirectory] = useState(op.inputs.rendersDirectory.value)
 
   useEffect(() => {
@@ -61,6 +62,7 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
       op.inputs.captureDelay.subscribe(v => setCaptureDelay(v)),
       op.inputs.fileName.subscribe(v => setFileName(v)),
       op.inputs.fileName.expression$.subscribe(v => setFileNameExpression(v)),
+      op.inputs.imageFormat.subscribe(v => setImageFormat(v)),
       op.inputs.rendersDirectory.subscribe(v => setRendersDirectory(v)),
     ]
     return () => {
@@ -92,6 +94,7 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
     op.inputs.captureDelay.setValue(DEFAULT_RENDER_SETTINGS.captureDelay)
     op.inputs.fileName.clearExpression()
     op.inputs.fileName.setValue(DEFAULT_RENDER_SETTINGS.fileName)
+    op.inputs.imageFormat.setValue(DEFAULT_RENDER_SETTINGS.imageFormat)
     op.inputs.rendersDirectory.setValue(DEFAULT_RENDER_SETTINGS.rendersDirectory)
   }, [op])
 
@@ -325,6 +328,21 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
               fx
             </span>
           )}
+        </div>
+
+        <div className={s.settingRow}>
+          <label htmlFor="render-image-format" className={s.label}>
+            Photo Format
+          </label>
+          <select
+            id="render-image-format"
+            className={s.select}
+            value={imageFormat}
+            onChange={e => op.inputs.imageFormat.setValue(e.target.value as 'png' | 'jpeg')}
+          >
+            <option value="png">PNG</option>
+            <option value="jpeg">JPEG</option>
+          </select>
         </div>
 
         <div className={s.settingRow}>

--- a/noodles-editor/src/noodles/components/render-settings-panel.tsx
+++ b/noodles-editor/src/noodles/components/render-settings-panel.tsx
@@ -41,6 +41,8 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
   const [bitrateMode, setBitrateMode] = useState(op.inputs.bitrateMode.value)
   const [waitForData, setWaitForData] = useState(op.inputs.waitForData.value)
   const [captureDelay, setCaptureDelay] = useState(op.inputs.captureDelay.value)
+  const [fileName, setFileName] = useState(op.inputs.fileName.value)
+  const [fileNameExpression, setFileNameExpression] = useState(op.inputs.fileName.expression)
   const [rendersDirectory, setRendersDirectory] = useState(op.inputs.rendersDirectory.value)
 
   useEffect(() => {
@@ -57,6 +59,8 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
       op.inputs.bitrateMode.subscribe(v => setBitrateMode(v)),
       op.inputs.waitForData.subscribe(v => setWaitForData(v)),
       op.inputs.captureDelay.subscribe(v => setCaptureDelay(v)),
+      op.inputs.fileName.subscribe(v => setFileName(v)),
+      op.inputs.fileName.expression$.subscribe(v => setFileNameExpression(v)),
       op.inputs.rendersDirectory.subscribe(v => setRendersDirectory(v)),
     ]
     return () => {
@@ -86,6 +90,8 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
     op.inputs.bitrateMode.setValue(DEFAULT_RENDER_SETTINGS.bitrateMode)
     op.inputs.waitForData.setValue(DEFAULT_RENDER_SETTINGS.waitForData)
     op.inputs.captureDelay.setValue(DEFAULT_RENDER_SETTINGS.captureDelay)
+    op.inputs.fileName.clearExpression()
+    op.inputs.fileName.setValue(DEFAULT_RENDER_SETTINGS.fileName)
     op.inputs.rendersDirectory.setValue(DEFAULT_RENDER_SETTINGS.rendersDirectory)
   }, [op])
 
@@ -292,6 +298,51 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
         </div>
       </div>
 
+      {/* Output Section */}
+      <div className={s.section}>
+        <h3 className={s.sectionTitle}>Output</h3>
+
+        <div className={s.settingRow}>
+          <label htmlFor="render-file-name" className={s.label}>
+            File Name
+          </label>
+          <input
+            id="render-file-name"
+            type="text"
+            className={s.textInput}
+            value={fileName}
+            placeholder="Project name"
+            disabled={fileNameExpression !== null}
+            title={
+              fileNameExpression === null
+                ? 'Base name; Noodles adds -v1, -v2, and the file extension'
+                : `Driven by expression: ${fileNameExpression}`
+            }
+            onChange={e => op.inputs.fileName.setValue(e.target.value)}
+          />
+          {fileNameExpression !== null && (
+            <span className={s.expressionBadge} title={fileNameExpression}>
+              fx
+            </span>
+          )}
+        </div>
+
+        <div className={s.settingRow}>
+          <label htmlFor="render-renders-directory" className={s.label}>
+            Output Dir
+          </label>
+          <button
+            id="render-renders-directory"
+            type="button"
+            className={s.directoryButton}
+            onClick={() => selectRendersDirectory?.()}
+          >
+            <i className="pi pi-folder" />
+            {rendersDirectory || 'renders'}
+          </button>
+        </div>
+      </div>
+
       {/* Advanced Section */}
       <div className={s.section}>
         <h3 className={s.sectionTitle}>Advanced</h3>
@@ -323,21 +374,6 @@ export function RenderSettingsPanel({ op }: RenderSettingsPanelProps) {
             onChange={e => op.inputs.captureDelay.setValue(Number(e.target.value))}
           />
           <span className={s.unit}>ms</span>
-        </div>
-
-        <div className={s.settingRow}>
-          <label htmlFor="render-renders-directory" className={s.label}>
-            Output Dir
-          </label>
-          <button
-            id="render-renders-directory"
-            type="button"
-            className={s.directoryButton}
-            onClick={() => selectRendersDirectory?.()}
-          >
-            <i className="pi pi-folder" />
-            {rendersDirectory || 'renders'}
-          </button>
         </div>
       </div>
 

--- a/noodles-editor/src/noodles/hooks/use-render-settings.ts
+++ b/noodles-editor/src/noodles/hooks/use-render-settings.ts
@@ -36,6 +36,7 @@ export function useRenderSettings(): RenderSettings {
       outOp.inputs.scaleControl.subscribe(() => updateSettings()),
       outOp.inputs.framerate.subscribe(() => updateSettings()),
       outOp.inputs.captureDelay.subscribe(() => updateSettings()),
+      outOp.inputs.fileName.subscribe(() => updateSettings()),
       outOp.inputs.rendersDirectory.subscribe(() => updateSettings()),
     ]
 
@@ -74,6 +75,7 @@ export function getRenderSettingsFromOutOp(outOp: OutOp): RenderSettings {
     scaleControl: outOp.inputs.scaleControl.value,
     framerate: outOp.inputs.framerate.value,
     captureDelay: outOp.inputs.captureDelay.value,
+    fileName: outOp.inputs.fileName.value,
     rendersDirectory: outOp.inputs.rendersDirectory.value,
   }
 }
@@ -114,6 +116,9 @@ export function setRenderSettingsOnOutOp(outOp: OutOp, settings: Partial<RenderS
   }
   if (settings.captureDelay !== undefined) {
     outOp.inputs.captureDelay.setValue(settings.captureDelay)
+  }
+  if (settings.fileName !== undefined) {
+    outOp.inputs.fileName.setValue(settings.fileName)
   }
   if (settings.rendersDirectory !== undefined) {
     outOp.inputs.rendersDirectory.setValue(settings.rendersDirectory)

--- a/noodles-editor/src/noodles/hooks/use-render-settings.ts
+++ b/noodles-editor/src/noodles/hooks/use-render-settings.ts
@@ -37,6 +37,7 @@ export function useRenderSettings(): RenderSettings {
       outOp.inputs.framerate.subscribe(() => updateSettings()),
       outOp.inputs.captureDelay.subscribe(() => updateSettings()),
       outOp.inputs.fileName.subscribe(() => updateSettings()),
+      outOp.inputs.imageFormat.subscribe(() => updateSettings()),
       outOp.inputs.rendersDirectory.subscribe(() => updateSettings()),
     ]
 
@@ -76,6 +77,7 @@ export function getRenderSettingsFromOutOp(outOp: OutOp): RenderSettings {
     framerate: outOp.inputs.framerate.value,
     captureDelay: outOp.inputs.captureDelay.value,
     fileName: outOp.inputs.fileName.value,
+    imageFormat: outOp.inputs.imageFormat.value as RenderSettings['imageFormat'],
     rendersDirectory: outOp.inputs.rendersDirectory.value,
   }
 }
@@ -119,6 +121,9 @@ export function setRenderSettingsOnOutOp(outOp: OutOp, settings: Partial<RenderS
   }
   if (settings.fileName !== undefined) {
     outOp.inputs.fileName.setValue(settings.fileName)
+  }
+  if (settings.imageFormat !== undefined) {
+    outOp.inputs.imageFormat.setValue(settings.imageFormat)
   }
   if (settings.rendersDirectory !== undefined) {
     outOp.inputs.rendersDirectory.setValue(settings.rendersDirectory)

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4903,6 +4903,7 @@ export class OutOp extends Operator<OutOp> {
       framerate: new NumberField(30, { min: 1, max: 120, step: 1 }),
       captureDelay: new NumberField(50, { min: 0, max: 10000, step: 10 }),
       fileName: new StringField(''),
+      imageFormat: new StringLiteralField('png', ['png', 'jpeg']),
       rendersDirectory: new StringField('renders'),
     }
   }

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -4902,6 +4902,7 @@ export class OutOp extends Operator<OutOp> {
       scaleControl: new NumberField(0.3, { min: 0.1, max: 1, step: 0.05 }),
       framerate: new NumberField(30, { min: 1, max: 120, step: 1 }),
       captureDelay: new NumberField(50, { min: 0, max: 10000, step: 10 }),
+      fileName: new StringField(''),
       rendersDirectory: new StringField('renders'),
     }
   }

--- a/noodles-editor/src/noodles/utils/render-settings-constants.ts
+++ b/noodles-editor/src/noodles/utils/render-settings-constants.ts
@@ -14,6 +14,7 @@ export type RenderSettings = {
   framerate: number
   captureDelay: number
   fileName: string
+  imageFormat: 'png' | 'jpeg'
   rendersDirectory: string
 }
 
@@ -30,5 +31,6 @@ export const DEFAULT_RENDER_SETTINGS: RenderSettings = {
   framerate: 30,
   captureDelay: 50,
   fileName: '',
+  imageFormat: 'png',
   rendersDirectory: 'renders',
 }

--- a/noodles-editor/src/noodles/utils/render-settings-constants.ts
+++ b/noodles-editor/src/noodles/utils/render-settings-constants.ts
@@ -13,6 +13,7 @@ export type RenderSettings = {
   scaleControl: number
   framerate: number
   captureDelay: number
+  fileName: string
   rendersDirectory: string
 }
 
@@ -28,5 +29,6 @@ export const DEFAULT_RENDER_SETTINGS: RenderSettings = {
   scaleControl: 0.3,
   framerate: 30,
   captureDelay: 50,
+  fileName: '',
   rendersDirectory: 'renders',
 }

--- a/noodles-editor/src/render/render-output.test.ts
+++ b/noodles-editor/src/render/render-output.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getNextRenderVersion,
+  getVersionedRenderFileName,
+  sanitizeRenderBaseName,
+} from './render-output'
+
+function mockDirectory(names: string[]): FileSystemDirectoryHandle {
+  return {
+    async *entries() {
+      for (const name of names) {
+        yield [name, { kind: 'file', name }] as [string, FileSystemFileHandle]
+      }
+    },
+  } as FileSystemDirectoryHandle
+}
+
+describe('render output names', () => {
+  it('sanitizes file names and removes render extensions', () => {
+    expect(sanitizeRenderBaseName('  Florida/routes:v2.png  ')).toBe('Florida-routes-v2')
+    expect(sanitizeRenderBaseName('', 'my-project')).toBe('my-project')
+  })
+
+  it('increments versions across render formats and image sequences', async () => {
+    const directory = mockDirectory([
+      'LA-vertistop-v1.png',
+      'LA-vertistop-v2.mp4',
+      'LA-vertistop-v4_0000.png',
+      'another-render-v20.png',
+    ])
+
+    await expect(getNextRenderVersion(directory, 'LA-vertistop')).resolves.toEqual({
+      baseName: 'LA-vertistop',
+      version: 5,
+    })
+    await expect(getVersionedRenderFileName(directory, 'LA-vertistop', '.png')).resolves.toBe(
+      'LA-vertistop-v5.png'
+    )
+  })
+
+  it('starts new render names at version one', async () => {
+    await expect(getVersionedRenderFileName(mockDirectory([]), 'new-render', 'mp4')).resolves.toBe(
+      'new-render-v1.mp4'
+    )
+  })
+})

--- a/noodles-editor/src/render/render-output.test.ts
+++ b/noodles-editor/src/render/render-output.test.ts
@@ -6,11 +6,16 @@ import {
 } from './render-output'
 
 function mockDirectory(names: string[]): FileSystemDirectoryHandle {
+  const files = new Set(names)
   return {
     async *entries() {
-      for (const name of names) {
+      for (const name of files) {
         yield [name, { kind: 'file', name }] as [string, FileSystemFileHandle]
       }
+    },
+    async getFileHandle(name: string) {
+      files.add(name)
+      return { kind: 'file', name } as FileSystemFileHandle
     },
   } as FileSystemDirectoryHandle
 }
@@ -42,5 +47,16 @@ describe('render output names', () => {
     await expect(getVersionedRenderFileName(mockDirectory([]), 'new-render', 'mp4')).resolves.toBe(
       'new-render-v1.mp4'
     )
+  })
+
+  it('reserves distinct versions for concurrent exports', async () => {
+    const directory = mockDirectory([])
+
+    await expect(
+      Promise.all([
+        getVersionedRenderFileName(directory, 'shared-render', 'png'),
+        getVersionedRenderFileName(directory, 'shared-render', 'mp4'),
+      ])
+    ).resolves.toEqual(['shared-render-v1.png', 'shared-render-v2.mp4'])
   })
 })

--- a/noodles-editor/src/render/render-output.ts
+++ b/noodles-editor/src/render/render-output.ts
@@ -1,0 +1,65 @@
+const RENDER_EXTENSION_RE = /\.(?:jpe?g|png|mp4)$/i
+const INVALID_FILENAME_CHARS_RE = /[\\/:*?"<>|]+/g
+
+function stripControlCharacters(value: string): string {
+  return Array.from(value)
+    .filter(character => character.charCodeAt(0) >= 32)
+    .join('')
+}
+
+export function sanitizeRenderBaseName(value: string, fallback = 'render'): string {
+  const sanitized = stripControlCharacters(value)
+    .trim()
+    .replace(RENDER_EXTENSION_RE, '')
+    .replace(INVALID_FILENAME_CHARS_RE, '-')
+    .replace(/[.\s]+$/g, '')
+
+  if (sanitized) return sanitized
+
+  const sanitizedFallback = stripControlCharacters(fallback)
+    .trim()
+    .replace(RENDER_EXTENSION_RE, '')
+    .replace(INVALID_FILENAME_CHARS_RE, '-')
+    .replace(/[.\s]+$/g, '')
+
+  return sanitizedFallback || 'render'
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export async function getNextRenderVersion(
+  directoryHandle: FileSystemDirectoryHandle,
+  requestedBaseName: string,
+  fallback = 'render'
+): Promise<{ baseName: string; version: number }> {
+  const baseName = sanitizeRenderBaseName(requestedBaseName, fallback)
+  const versionPattern = new RegExp(`^${escapeRegExp(baseName)}-v(\\d+)(?:[_.]|$)`, 'i')
+  let highestVersion = 0
+
+  for await (const [name, handle] of directoryHandle.entries()) {
+    if (handle.kind !== 'file') continue
+    const match = name.match(versionPattern)
+    if (!match) continue
+
+    highestVersion = Math.max(highestVersion, Number(match[1]))
+  }
+
+  return { baseName, version: highestVersion + 1 }
+}
+
+export async function getVersionedRenderFileName(
+  directoryHandle: FileSystemDirectoryHandle,
+  requestedBaseName: string,
+  extension: string,
+  fallback = 'render'
+): Promise<string> {
+  const { baseName, version } = await getNextRenderVersion(
+    directoryHandle,
+    requestedBaseName,
+    fallback
+  )
+  const normalizedExtension = extension.replace(/^\./, '')
+  return `${baseName}-v${version}.${normalizedExtension}`
+}

--- a/noodles-editor/src/render/render-output.ts
+++ b/noodles-editor/src/render/render-output.ts
@@ -1,5 +1,6 @@
 const RENDER_EXTENSION_RE = /\.(?:jpe?g|png|mp4)$/i
 const INVALID_FILENAME_CHARS_RE = /[\\/:*?"<>|]+/g
+let allocationLock = Promise.resolve()
 
 function stripControlCharacters(value: string): string {
   return Array.from(value)
@@ -49,17 +50,53 @@ export async function getNextRenderVersion(
   return { baseName, version: highestVersion + 1 }
 }
 
+async function withAllocationLock<T>(allocate: () => Promise<T>): Promise<T> {
+  const previous = allocationLock
+  let release = () => {}
+  const current = new Promise<void>(resolve => {
+    release = resolve
+  })
+  allocationLock = current
+
+  await previous.catch(() => {})
+  try {
+    return await allocate()
+  } finally {
+    release()
+    if (allocationLock === current) {
+      allocationLock = Promise.resolve()
+    }
+  }
+}
+
+export async function reserveNextRenderVersion(
+  directoryHandle: FileSystemDirectoryHandle,
+  requestedBaseName: string,
+  reservationSuffix: string,
+  fallback = 'render'
+): Promise<{ baseName: string; version: number }> {
+  return withAllocationLock(async () => {
+    const allocation = await getNextRenderVersion(directoryHandle, requestedBaseName, fallback)
+    await directoryHandle.getFileHandle(
+      `${allocation.baseName}-v${allocation.version}${reservationSuffix}`,
+      { create: true }
+    )
+    return allocation
+  })
+}
+
 export async function getVersionedRenderFileName(
   directoryHandle: FileSystemDirectoryHandle,
   requestedBaseName: string,
   extension: string,
   fallback = 'render'
 ): Promise<string> {
-  const { baseName, version } = await getNextRenderVersion(
+  const normalizedExtension = extension.replace(/^\./, '')
+  const { baseName, version } = await reserveNextRenderVersion(
     directoryHandle,
     requestedBaseName,
+    `.${normalizedExtension}`,
     fallback
   )
-  const normalizedExtension = extension.replace(/^\./, '')
   return `${baseName}-v${version}.${normalizedExtension}`
 }

--- a/noodles-editor/src/render/renderer.test.ts
+++ b/noodles-editor/src/render/renderer.test.ts
@@ -1,6 +1,23 @@
 import { renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { useRenderer } from './renderer'
+import { captureScreenshot, useRenderer } from './renderer'
+
+function mockRenderDirectory(names: string[] = []) {
+  const write = vi.fn().mockResolvedValue(undefined)
+  const close = vi.fn().mockResolvedValue(undefined)
+  const createWritable = vi.fn().mockResolvedValue({ write, close })
+  const getFileHandle = vi.fn().mockResolvedValue({ createWritable })
+  const directoryHandle = {
+    async *entries() {
+      for (const name of names) {
+        yield [name, { kind: 'file', name }] as [string, FileSystemFileHandle]
+      }
+    },
+    getFileHandle,
+  } as unknown as FileSystemDirectoryHandle
+
+  return { directoryHandle, getFileHandle, write, close }
+}
 
 describe('useRenderer', () => {
   it('handles cancellation of the file save dialog', async () => {
@@ -40,5 +57,21 @@ describe('useRenderer', () => {
 
     // Clean up mocks
     mockShowSaveFilePicker.mockRestore()
+  })
+
+  it('writes screenshots directly to the next versioned file in the renders directory', async () => {
+    const { directoryHandle, getFileHandle, write, close } = mockRenderDirectory([
+      'route-map-v1.png',
+      'route-map-v2.mp4',
+    ])
+    const canvas = document.createElement('canvas')
+    vi.spyOn(canvas, 'toBlob').mockImplementation(callback => {
+      callback(new Blob(['image'], { type: 'image/png' }))
+    })
+    await captureScreenshot('route/map.png', () => canvas, 1, directoryHandle)
+
+    expect(getFileHandle).toHaveBeenCalledWith('route-map-v3.png', { create: true })
+    expect(write).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
   })
 })

--- a/noodles-editor/src/render/renderer.test.ts
+++ b/noodles-editor/src/render/renderer.test.ts
@@ -74,4 +74,17 @@ describe('useRenderer', () => {
     expect(write).toHaveBeenCalledOnce()
     expect(close).toHaveBeenCalledOnce()
   })
+
+  it('preserves JPEG export for directory-backed screenshots', async () => {
+    const { directoryHandle, getFileHandle } = mockRenderDirectory()
+    const canvas = document.createElement('canvas')
+    const toBlob = vi.spyOn(canvas, 'toBlob').mockImplementation(callback => {
+      callback(new Blob(['image'], { type: 'image/jpeg' }))
+    })
+
+    await captureScreenshot('photo', () => canvas, 1, directoryHandle, 'jpeg')
+
+    expect(getFileHandle).toHaveBeenCalledWith('photo-v1.jpeg', { create: true })
+    expect(toBlob).toHaveBeenCalledWith(expect.any(Function), 'image/jpeg', 1)
+  })
 })

--- a/noodles-editor/src/render/renderer.ts
+++ b/noodles-editor/src/render/renderer.ts
@@ -3,8 +3,8 @@ import { useCallback, useRef, useState } from 'react'
 import { getTimelineStore, useTimelineStore } from '../timeline/timeline-store'
 import { debugRender, debugRenderFrame } from '../utils/debug'
 import {
-  getNextRenderVersion,
   getVersionedRenderFileName,
+  reserveNextRenderVersion,
   sanitizeRenderBaseName,
 } from './render-output'
 
@@ -209,7 +209,7 @@ export const useRenderer = ({
       const mapContainer = await getContainer(fileName).catch(error => {
         setIsRendering(false)
         debugRender('Failed to prepare render output: %o', error)
-        return null
+        throw error
       })
       if (!mapContainer) {
         setIsRendering(false)
@@ -370,9 +370,11 @@ export const useRenderer = ({
 
       const totalFrames = endFrame - startFrame + 1
       const padLength = Math.max(4, String(endFrame).length)
-      const { baseName, version } = await getNextRenderVersion(
+      const firstFrameNumber = String(startFrame).padStart(padLength, '0')
+      const { baseName, version } = await reserveNextRenderVersion(
         directoryHandle,
         fileName,
+        `_${firstFrameNumber}.png`,
         projectName
       )
       const versionedBaseName = `${baseName}-v${version}`
@@ -544,15 +546,20 @@ export const captureScreenshot = async (
   suggestedName: string,
   getBufferedCanvas: () => HTMLCanvasElement,
   quality = 1,
-  directoryHandle?: FileSystemDirectoryHandle
+  directoryHandle?: FileSystemDirectoryHandle,
+  imageFormat: 'png' | 'jpeg' = 'png'
 ) => {
   const baseName = sanitizeRenderBaseName(suggestedName, 'screenshot')
+  const imageExtension = imageFormat === 'jpeg' ? 'jpeg' : 'png'
   const imageHandle = directoryHandle
-    ? await getVersionedRenderFileName(directoryHandle, baseName, 'png', 'screenshot').then(
-        versionedName => directoryHandle.getFileHandle(versionedName, { create: true })
-      )
+    ? await getVersionedRenderFileName(
+        directoryHandle,
+        baseName,
+        imageExtension,
+        'screenshot'
+      ).then(versionedName => directoryHandle.getFileHandle(versionedName, { create: true }))
     : await window.showSaveFilePicker({
-        suggestedName: `${baseName}-v1.png`,
+        suggestedName: `${baseName}-v1.${imageExtension}`,
         types: [
           {
             description: 'PNG',
@@ -565,7 +572,11 @@ export const captureScreenshot = async (
         ],
       })
 
-  const imageType = directoryHandle ? 'image/png' : (await imageHandle.getFile()).type
+  const imageType = directoryHandle
+    ? imageFormat === 'jpeg'
+      ? 'image/jpeg'
+      : 'image/png'
+    : (await imageHandle.getFile()).type
 
   const blob = await new Promise<Blob>((resolve, reject) => {
     // canvas needs to redrawn immediately before capture or else buffer will be empty.

--- a/noodles-editor/src/render/renderer.ts
+++ b/noodles-editor/src/render/renderer.ts
@@ -2,6 +2,11 @@ import { assert, type Deck } from '@deck.gl/core'
 import { useCallback, useRef, useState } from 'react'
 import { getTimelineStore, useTimelineStore } from '../timeline/timeline-store'
 import { debugRender, debugRenderFrame } from '../utils/debug'
+import {
+  getNextRenderVersion,
+  getVersionedRenderFileName,
+  sanitizeRenderBaseName,
+} from './render-output'
 
 export const rafDriver = {
   tick: (_timestamp: number) => {},
@@ -49,6 +54,8 @@ export const useRenderer = ({
       width,
       height,
       codec,
+      directoryHandle,
+      fileName = projectName,
       startFrame = 0,
       endFrame = Math.floor(sequenceLength * fps),
     }: {
@@ -56,6 +63,8 @@ export const useRenderer = ({
       width: number
       height: number
       codec: 'hevc' | 'avc' | 'vp9' | 'av1'
+      directoryHandle?: FileSystemDirectoryHandle
+      fileName?: string
       startFrame?: number
       endFrame?: number
     }) => {
@@ -66,24 +75,29 @@ export const useRenderer = ({
       setIsRendering(true)
 
       const getContainer = async (name: string) => {
-        const fileHandle = await window
-          .showSaveFilePicker({
-            suggestedName: `${name}.mp4`,
-            types: [
-              {
-                description: 'Video File',
-                accept: { 'video/mp4': ['.mp4'] },
-              },
-            ],
-          })
-          .catch(error => {
-            if (error.name === 'AbortError') {
-              debugRender('File picker cancelled by user for: %s', name)
-            } else {
-              debugRender('Error in showSaveFilePicker for', name, ':', error)
-            }
-            return null // Signal cancellation/failure
-          })
+        const baseName = sanitizeRenderBaseName(name, projectName)
+        const fileHandle = directoryHandle
+          ? await getVersionedRenderFileName(directoryHandle, baseName, 'mp4', projectName).then(
+              versionedName => directoryHandle.getFileHandle(versionedName, { create: true })
+            )
+          : await window
+              .showSaveFilePicker({
+                suggestedName: `${baseName}-v1.mp4`,
+                types: [
+                  {
+                    description: 'Video File',
+                    accept: { 'video/mp4': ['.mp4'] },
+                  },
+                ],
+              })
+              .catch(error => {
+                if (error.name === 'AbortError') {
+                  debugRender('File picker cancelled by user for: %s', name)
+                } else {
+                  debugRender('Error in showSaveFilePicker for', name, ':', error)
+                }
+                return null // Signal cancellation/failure
+              })
 
         if (!fileHandle) {
           return null
@@ -192,7 +206,11 @@ export const useRenderer = ({
         return { track, reader }
       }
 
-      const mapContainer = await getContainer(`${projectName}-map`)
+      const mapContainer = await getContainer(fileName).catch(error => {
+        setIsRendering(false)
+        debugRender('Failed to prepare render output: %o', error)
+        return null
+      })
       if (!mapContainer) {
         setIsRendering(false)
         debugRender('Render setup cancelled by user (map container)')
@@ -328,6 +346,7 @@ export const useRenderer = ({
       canvas,
       getDeck,
       directoryHandle,
+      fileName = projectName,
       captureDelay = 200,
       waitForData = true,
       startFrame = 0,
@@ -338,6 +357,7 @@ export const useRenderer = ({
       canvas: HTMLCanvasElement
       getDeck?: () => Deck | null
       directoryHandle: FileSystemDirectoryHandle
+      fileName?: string
       captureDelay?: number
       waitForData?: boolean
       startFrame?: number
@@ -348,10 +368,16 @@ export const useRenderer = ({
       assert(canvas, 'canvas is required')
       assert(directoryHandle, 'directoryHandle is required')
 
-      setIsRendering(true)
-
       const totalFrames = endFrame - startFrame + 1
       const padLength = Math.max(4, String(endFrame).length)
+      const { baseName, version } = await getNextRenderVersion(
+        directoryHandle,
+        fileName,
+        projectName
+      )
+      const versionedBaseName = `${baseName}-v${version}`
+
+      setIsRendering(true)
 
       // For pure-deck scenes (no basemap), install a temporary onAfterRender that fires captureFrame().
       // Basemap scenes already drive frame readiness via mapProps.onIdle.
@@ -420,7 +446,7 @@ export const useRenderer = ({
           totalWaitTime += waitEnd - waitStart
 
           const frameNumber = String(i).padStart(padLength, '0')
-          const filename = `${projectName}_${frameNumber}.png`
+          const filename = `${versionedBaseName}_${frameNumber}.png`
 
           // Drain oldest write if the queue is full before capturing the next frame
           if (pendingWrites.length >= MAX_CONCURRENT_WRITES) {
@@ -517,29 +543,35 @@ export default useRenderer
 export const captureScreenshot = async (
   suggestedName: string,
   getBufferedCanvas: () => HTMLCanvasElement,
-  quality = 1
+  quality = 1,
+  directoryHandle?: FileSystemDirectoryHandle
 ) => {
-  const imageHandle = await window.showSaveFilePicker({
-    suggestedName,
-    types: [
-      {
-        description: 'PNG',
-        accept: { 'image/png': ['.png'] },
-      },
-      {
-        description: 'JPEG',
-        accept: { 'image/jpeg': ['.jpeg'] },
-      },
-    ],
-  })
+  const baseName = sanitizeRenderBaseName(suggestedName, 'screenshot')
+  const imageHandle = directoryHandle
+    ? await getVersionedRenderFileName(directoryHandle, baseName, 'png', 'screenshot').then(
+        versionedName => directoryHandle.getFileHandle(versionedName, { create: true })
+      )
+    : await window.showSaveFilePicker({
+        suggestedName: `${baseName}-v1.png`,
+        types: [
+          {
+            description: 'PNG',
+            accept: { 'image/png': ['.png'] },
+          },
+          {
+            description: 'JPEG',
+            accept: { 'image/jpeg': ['.jpeg'] },
+          },
+        ],
+      })
 
-  const file = await imageHandle.getFile()
+  const imageType = directoryHandle ? 'image/png' : (await imageHandle.getFile()).type
 
   const blob = await new Promise<Blob>((resolve, reject) => {
     // canvas needs to redrawn immediately before capture or else buffer will be empty.
     getBufferedCanvas().toBlob(
       blob => (blob ? resolve(blob) : reject('canvas is empty')),
-      file.type,
+      imageType,
       quality
     )
   })

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -16,14 +16,14 @@ import { useActiveOutOp } from './noodles/hooks/use-active-outop'
 import { useRenderSettings } from './noodles/hooks/use-render-settings'
 import { getNoodles } from './noodles/noodles'
 import { fnWithSource } from './noodles/operators'
+import { useUIStore } from './noodles/store'
 import type { RenderSettings } from './noodles/utils/serialization'
 import { useDeckDrawLoop } from './render/draw-loop'
 import { captureScreenshot, useRenderer } from './render/renderer'
 import { deckRenderingDefaults, mapRenderingDefaults } from './render/rendering-defaults'
 import { TransformScale } from './render/transform-scale'
-import { useUIStore } from './noodles/store'
 import { TimelinePanel } from './timeline/components/TimelinePanel'
-import { getTimelineStore, useTimelineStore } from './timeline/timeline-store'
+import { useTimelineStore } from './timeline/timeline-store'
 import s from './timeline-editor.module.css'
 import { debugRender } from './utils/debug'
 import setRef from './utils/set-ref'
@@ -120,6 +120,7 @@ export default function TimelineEditor() {
     lod,
     waitForData,
     captureDelay,
+    fileName,
     rendersDirectory,
   } = renderSettings
 
@@ -384,6 +385,29 @@ export default function TimelineEditor() {
     props: deckProps,
   })
 
+  const resolveRendersDirectory = useCallback(async () => {
+    if (rendersDirectoryHandleRef.current) return rendersDirectoryHandleRef.current
+
+    if (activeStorageType !== 'publicFolder' && currentDirectory) {
+      try {
+        return await currentDirectory.getDirectoryHandle(rendersDirectory || 'renders', {
+          create: true,
+        })
+      } catch (error) {
+        debugRender('Failed to create renders directory: %o, falling back to picker', error)
+      }
+    }
+
+    try {
+      const handle = await window.showDirectoryPicker({ mode: 'readwrite' })
+      rendersDirectoryHandleRef.current = handle
+      return handle
+    } catch (error) {
+      if ((error as DOMException).name === 'AbortError') return null
+      throw error
+    }
+  }, [activeStorageType, currentDirectory, rendersDirectory])
+
   const startRender = useCallback(async () => {
     let canvas: HTMLCanvasElement | null = null
 
@@ -408,9 +432,14 @@ export default function TimelineEditor() {
       return
     }
 
+    const directoryHandle = await resolveRendersDirectory()
+    if (!directoryHandle) return
+
     await startCapture({
       canvas,
       codec,
+      directoryHandle,
+      fileName: fileName || noodles.projectName || 'render',
       // This always scales the video to the specified value, regardless of `canvas` size
       ...resolution,
       startFrame: Math.floor((inPoint ?? 0) * framerate),
@@ -425,6 +454,9 @@ export default function TimelineEditor() {
     inPoint,
     outPoint,
     sequenceLength,
+    resolveRendersDirectory,
+    fileName,
+    noodles.projectName,
   ])
 
   const takeScreenshot = useCallback(async () => {
@@ -437,13 +469,21 @@ export default function TimelineEditor() {
       return
     }
 
-    const suggestedName = noodles.projectName ?? 'screenshot'
-    await captureScreenshot(suggestedName, () => {
-      redraw()
-      // @ts-expect-error canvas is protected
-      return deckRef.current.canvas!
-    })
-  }, [noodles.projectName, redraw, basemapEnabled])
+    const directoryHandle = await resolveRendersDirectory()
+    if (!directoryHandle) return
+
+    const suggestedName = fileName || noodles.projectName || 'screenshot'
+    await captureScreenshot(
+      suggestedName,
+      () => {
+        redraw()
+        // @ts-expect-error canvas is protected
+        return deckRef.current.canvas!
+      },
+      1,
+      directoryHandle
+    )
+  }, [noodles.projectName, redraw, basemapEnabled, resolveRendersDirectory, fileName])
 
   const selectRendersDirectory = useCallback(async () => {
     try {
@@ -466,32 +506,8 @@ export default function TimelineEditor() {
       return
     }
 
-    // Resolve the target directory: session-picked handle > project subdir > user picker
-    let rendersDir: FileSystemDirectoryHandle
-    if (rendersDirectoryHandleRef.current) {
-      rendersDir = rendersDirectoryHandleRef.current
-    } else if (activeStorageType !== 'publicFolder' && currentDirectory) {
-      try {
-        rendersDir = await currentDirectory.getDirectoryHandle(rendersDirectory || 'renders', {
-          create: true,
-        })
-      } catch (e) {
-        debugRender('Failed to create renders directory: %o, falling back to picker', e)
-        try {
-          rendersDir = await window.showDirectoryPicker({ mode: 'readwrite' })
-        } catch (err) {
-          if ((err as DOMException).name === 'AbortError') return
-          throw err
-        }
-      }
-    } else {
-      try {
-        rendersDir = await window.showDirectoryPicker({ mode: 'readwrite' })
-      } catch (e) {
-        if ((e as DOMException).name === 'AbortError') return
-        throw e
-      }
-    }
+    const rendersDir = await resolveRendersDirectory()
+    if (!rendersDir) return
 
     let canvas: HTMLCanvasElement
     if (basemapEnabled) {
@@ -507,6 +523,7 @@ export default function TimelineEditor() {
       // onAfterRender wired up inside startSequenceCapture via getDeck.
       getDeck: basemapEnabled ? undefined : () => deckRef.current,
       directoryHandle: rendersDir,
+      fileName: fileName || noodles.projectName || 'render',
       captureDelay,
       waitForData,
       startFrame: Math.floor((inPoint ?? 0) * framerate),
@@ -522,10 +539,10 @@ export default function TimelineEditor() {
     framerate,
     captureDelay,
     waitForData,
-    rendersDirectory,
     basemapEnabled,
-    currentDirectory,
-    activeStorageType,
+    resolveRendersDirectory,
+    fileName,
+    noodles.projectName,
   ])
 
   // Increase the render target resolution to increase map tile detail.

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -11,7 +11,11 @@ import { SpreadsheetPane } from './noodles/components/spreadsheet-pane/spreadshe
 import { MapToolLayer } from './noodles/components/tools/map-tool-layer'
 import { TopMenuBar } from './noodles/components/top-menu-bar'
 import { ExportActionsProvider } from './noodles/contexts/export-actions-context'
-import { useActiveStorageType, useCurrentDirectory } from './noodles/filesystem-store'
+import {
+  useActiveStorageType,
+  useCurrentDirectory,
+  useFileSystemStore,
+} from './noodles/filesystem-store'
 import { useActiveOutOp } from './noodles/hooks/use-active-outop'
 import { useRenderSettings } from './noodles/hooks/use-render-settings'
 import { getNoodles } from './noodles/noodles'
@@ -78,6 +82,7 @@ export default function TimelineEditor() {
   const isRenderingRef = useRef(false)
   // Session-only handle set by selectRendersDirectory; takes priority over project subdir
   const rendersDirectoryHandleRef = useRef<FileSystemDirectoryHandle | null>(null)
+  const rendersDirectoryContextRef = useRef<string | null>(null)
   const customLayersRef = useRef<Set<string>>(new Set())
   // Track style version to trigger layer re-addition after style changes
   const [styleVersion, setStyleVersion] = useState(0)
@@ -103,9 +108,11 @@ export default function TimelineEditor() {
   const renderSettings = useRenderSettings()
   // Active OutOp for updating rendersDirectory when user picks a directory
   const activeOutOp = useActiveOutOp()
+  const rendersDirectoryContext = `${noodles.projectName ?? ''}:${activeOutOp?.id ?? ''}`
   // File system state for resolving the renders directory
   const currentDirectory = useCurrentDirectory()
   const activeStorageType = useActiveStorageType()
+  const setFileSystemError = useFileSystemStore(state => state.setError)
 
   const sequenceLength = useSequenceLength()
   const inPoint = useTimelineStore(state => state.sequence.inPoint)
@@ -121,8 +128,29 @@ export default function TimelineEditor() {
     waitForData,
     captureDelay,
     fileName,
+    imageFormat,
     rendersDirectory,
   } = renderSettings
+
+  const reportExportError = useCallback(
+    (error: unknown) => {
+      const errorName = error instanceof DOMException ? error.name : ''
+      const type =
+        errorName === 'NotAllowedError'
+          ? 'permission-denied'
+          : errorName === 'NotFoundError'
+            ? 'not-found'
+            : 'unknown'
+      debugRender('Render export failed: %o', error)
+      setFileSystemError({
+        type,
+        message: 'Failed to export the render.',
+        details: 'Check that the output folder still exists and that Noodles has write access.',
+        originalError: error,
+      })
+    },
+    [setFileSystemError]
+  )
 
   const { startCapture, startSequenceCapture, captureFrame, currentFrame, isRendering } =
     useRenderer({
@@ -386,7 +414,14 @@ export default function TimelineEditor() {
   })
 
   const resolveRendersDirectory = useCallback(async () => {
-    if (rendersDirectoryHandleRef.current) return rendersDirectoryHandleRef.current
+    if (
+      rendersDirectoryHandleRef.current &&
+      rendersDirectoryContextRef.current === rendersDirectoryContext
+    ) {
+      return rendersDirectoryHandleRef.current
+    }
+    rendersDirectoryHandleRef.current = null
+    rendersDirectoryContextRef.current = null
 
     if (activeStorageType !== 'publicFolder' && currentDirectory) {
       try {
@@ -401,50 +436,55 @@ export default function TimelineEditor() {
     try {
       const handle = await window.showDirectoryPicker({ mode: 'readwrite' })
       rendersDirectoryHandleRef.current = handle
+      rendersDirectoryContextRef.current = rendersDirectoryContext
       return handle
     } catch (error) {
       if ((error as DOMException).name === 'AbortError') return null
       throw error
     }
-  }, [activeStorageType, currentDirectory, rendersDirectory])
+  }, [activeStorageType, currentDirectory, rendersDirectory, rendersDirectoryContext])
 
   const startRender = useCallback(async () => {
-    let canvas: HTMLCanvasElement | null = null
+    try {
+      let canvas: HTMLCanvasElement | null = null
 
-    if (basemapEnabled) {
-      if (!mapRef.current) {
-        debugRender('Start Render: maplibre is not defined (when basemapEnabled is true)')
+      if (basemapEnabled) {
+        if (!mapRef.current) {
+          debugRender('Start Render: maplibre is not defined (when basemapEnabled is true)')
+          return
+        }
+        canvas = mapRef.current.getCanvas()
+      } else {
+        // Pure Deck.gl mode
+        if (!deckRef.current) {
+          debugRender('Start Render: deckRef is not defined (when basemapEnabled is false)')
+          return
+        }
+        // @ts-expect-error canvas is protected but accessible
+        canvas = deckRef.current.canvas
+      }
+
+      if (!canvas) {
+        debugRender('Start Render: Failed to get canvas element')
         return
       }
-      canvas = mapRef.current.getCanvas()
-    } else {
-      // Pure Deck.gl mode
-      if (!deckRef.current) {
-        debugRender('Start Render: deckRef is not defined (when basemapEnabled is false)')
-        return
-      }
-      // @ts-expect-error canvas is protected but accessible
-      canvas = deckRef.current.canvas
+
+      const directoryHandle = await resolveRendersDirectory()
+      if (!directoryHandle) return
+
+      await startCapture({
+        canvas,
+        codec,
+        directoryHandle,
+        fileName: fileName || noodles.projectName || 'render',
+        // This always scales the video to the specified value, regardless of `canvas` size
+        ...resolution,
+        startFrame: Math.floor((inPoint ?? 0) * framerate),
+        endFrame: Math.floor((outPoint ?? sequenceLength) * framerate),
+      })
+    } catch (error) {
+      reportExportError(error)
     }
-
-    if (!canvas) {
-      debugRender('Start Render: Failed to get canvas element')
-      return
-    }
-
-    const directoryHandle = await resolveRendersDirectory()
-    if (!directoryHandle) return
-
-    await startCapture({
-      canvas,
-      codec,
-      directoryHandle,
-      fileName: fileName || noodles.projectName || 'render',
-      // This always scales the video to the specified value, regardless of `canvas` size
-      ...resolution,
-      startFrame: Math.floor((inPoint ?? 0) * framerate),
-      endFrame: Math.floor((outPoint ?? sequenceLength) * framerate),
-    })
   }, [
     startCapture,
     codec,
@@ -457,80 +497,99 @@ export default function TimelineEditor() {
     resolveRendersDirectory,
     fileName,
     noodles.projectName,
+    reportExportError,
   ])
 
   const takeScreenshot = useCallback(async () => {
-    if (!deckRef.current) {
-      debugRender('Take Screenshot: deck is not defined')
-      return
-    }
-    if (basemapEnabled && !mapRef.current) {
-      debugRender('Take Screenshot: maplibre is not defined')
-      return
-    }
+    try {
+      if (!deckRef.current) {
+        debugRender('Take Screenshot: deck is not defined')
+        return
+      }
+      if (basemapEnabled && !mapRef.current) {
+        debugRender('Take Screenshot: maplibre is not defined')
+        return
+      }
 
-    const directoryHandle = await resolveRendersDirectory()
-    if (!directoryHandle) return
+      const directoryHandle = await resolveRendersDirectory()
+      if (!directoryHandle) return
 
-    const suggestedName = fileName || noodles.projectName || 'screenshot'
-    await captureScreenshot(
-      suggestedName,
-      () => {
-        redraw()
-        // @ts-expect-error canvas is protected
-        return deckRef.current.canvas!
-      },
-      1,
-      directoryHandle
-    )
-  }, [noodles.projectName, redraw, basemapEnabled, resolveRendersDirectory, fileName])
+      const suggestedName = fileName || noodles.projectName || 'screenshot'
+      await captureScreenshot(
+        suggestedName,
+        () => {
+          redraw()
+          // @ts-expect-error canvas is protected
+          return deckRef.current.canvas!
+        },
+        1,
+        directoryHandle,
+        imageFormat
+      )
+    } catch (error) {
+      reportExportError(error)
+    }
+  }, [
+    noodles.projectName,
+    redraw,
+    basemapEnabled,
+    resolveRendersDirectory,
+    fileName,
+    imageFormat,
+    reportExportError,
+  ])
 
   const selectRendersDirectory = useCallback(async () => {
     try {
       const handle = await window.showDirectoryPicker({ mode: 'readwrite' })
       rendersDirectoryHandleRef.current = handle
+      rendersDirectoryContextRef.current = rendersDirectoryContext
       // Persist the folder name to the OutOp so it survives project reloads
       activeOutOp?.inputs.rendersDirectory.setValue(handle.name)
     } catch (e) {
-      if ((e as DOMException).name !== 'AbortError') throw e
+      if ((e as DOMException).name !== 'AbortError') reportExportError(e)
     }
-  }, [activeOutOp])
+  }, [activeOutOp, rendersDirectoryContext, reportExportError])
 
   const exportSequence = useCallback(async () => {
-    if (!deckRef.current) {
-      debugRender('Export Sequence: deck is not defined')
-      return
-    }
-    if (basemapEnabled && !mapRef.current) {
-      debugRender('Export Sequence: maplibre is not defined')
-      return
-    }
+    try {
+      if (!deckRef.current) {
+        debugRender('Export Sequence: deck is not defined')
+        return
+      }
+      if (basemapEnabled && !mapRef.current) {
+        debugRender('Export Sequence: maplibre is not defined')
+        return
+      }
 
-    const rendersDir = await resolveRendersDirectory()
-    if (!rendersDir) return
+      const rendersDir = await resolveRendersDirectory()
+      if (!rendersDir) return
 
-    let canvas: HTMLCanvasElement
-    if (basemapEnabled) {
-      canvas = mapRef.current!.getCanvas()
-    } else {
-      // @ts-expect-error canvas is protected
-      canvas = deckRef.current.canvas!
+      let canvas: HTMLCanvasElement
+      if (basemapEnabled) {
+        canvas = mapRef.current!.getCanvas()
+      } else {
+        // @ts-expect-error canvas is protected
+        canvas = deckRef.current.canvas!
+      }
+
+      await startSequenceCapture({
+        canvas,
+        // Basemap scenes use mapProps.onIdle for frame readiness; pure-deck scenes need
+        // onAfterRender wired up inside startSequenceCapture via getDeck.
+        getDeck: basemapEnabled ? undefined : () => deckRef.current,
+        directoryHandle: rendersDir,
+        fileName: fileName || noodles.projectName || 'render',
+        captureDelay,
+        waitForData,
+        startFrame: Math.floor((inPoint ?? 0) * framerate),
+        endFrame: Math.floor((outPoint ?? sequenceLength) * framerate),
+        onFrameStart: (frame, total) => debugRender('Exporting frame %d/%d', frame + 1, total),
+        onFrameComplete: (frame, total) => debugRender('Completed frame %d/%d', frame, total),
+      })
+    } catch (error) {
+      reportExportError(error)
     }
-
-    await startSequenceCapture({
-      canvas,
-      // Basemap scenes use mapProps.onIdle for frame readiness; pure-deck scenes need
-      // onAfterRender wired up inside startSequenceCapture via getDeck.
-      getDeck: basemapEnabled ? undefined : () => deckRef.current,
-      directoryHandle: rendersDir,
-      fileName: fileName || noodles.projectName || 'render',
-      captureDelay,
-      waitForData,
-      startFrame: Math.floor((inPoint ?? 0) * framerate),
-      endFrame: Math.floor((outPoint ?? sequenceLength) * framerate),
-      onFrameStart: (frame, total) => debugRender('Exporting frame %d/%d', frame + 1, total),
-      onFrameComplete: (frame, total) => debugRender('Completed frame %d/%d', frame, total),
-    })
   }, [
     startSequenceCapture,
     sequenceLength,
@@ -543,6 +602,7 @@ export default function TimelineEditor() {
     resolveRendersDirectory,
     fileName,
     noodles.projectName,
+    reportExportError,
   ])
 
   // Increase the render target resolution to increase map tile detail.


### PR DESCRIPTION
#### Background

Render exports need reusable names and a project-local destination so repeated variants do not require manual save-dialog edits.

#### Change List
- Add an expression-compatible file name setting to OutOp and route photos, videos, and image sequences to the configured renders directory.
- Sanitize output names and assign a shared collision-free `-vN` suffix across render formats, with focused UI and filesystem tests.
- Verify with the production build and render/operator/migration test coverage.