### PR TITLE
debugger: trace operator dirty-wave origins

### DIFF
--- a/dev-docs/developing.md
+++ b/dev-docs/developing.md
@@ -67,6 +67,28 @@ The project uses:
 - **Vitest** for unit testing
 - **Playwright** for end-to-end testing
 
+### Tracing Dirty Operators
+
+To diagnose a graph that keeps executing, enable pull logs together with the causal dirty trace
+in the browser console, then reload:
+
+```javascript
+localStorage.debug = 'noodles:executor:pull,noodles-trace:dirty'
+location.reload()
+```
+
+`noodles-trace:dirty` records the operator's prior state, the field or subsystem that started the
+dirty wave, its downstream count, and the caller stack. It is intentionally excluded from
+`noodles:*` because collecting stacks is expensive. When the namespace is disabled, no stacks are
+captured and no trace state is retained.
+
+Disable it after investigating:
+
+```javascript
+localStorage.debug = ''
+location.reload()
+```
+
 ## Code Style Guidelines
 
 - **TypeScript**: Use strict typing with detailed interfaces/types

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -262,7 +262,7 @@ export abstract class Field<
       this.next(parsed.data)
 
       // Mark the owning operator as dirty
-      this.op?.markDirty()
+      this.op?.markDirty(this)
     } else {
       debugSetValue('%s: %O -> %O [PARSE FAILED]', path, oldValue, value)
       debugSetValue('Parse error', parsed.error.issues)
@@ -317,7 +317,7 @@ export abstract class Field<
       } else {
         this.next(this.value)
         // For reference connections, also mark dirty
-        this.op?.markDirty()
+        this.op?.markDirty(this)
       }
     })
     this.subscriptions.set(id, subscription)

--- a/noodles-editor/src/noodles/graph-executor.test.ts
+++ b/noodles-editor/src/noodles/graph-executor.test.ts
@@ -1,5 +1,6 @@
 // Test file for GraphExecutor implementation
 import { describe, expect, it, vi } from 'vitest'
+import { debugDirtyTrace } from '../utils/debug'
 import { NumberField } from './fields'
 import { GraphExecutor, GraphScope, topologicalSort } from './graph-executor'
 import type { IOperator } from './operators'
@@ -840,6 +841,35 @@ describe('Operator dirty flag', () => {
     // Now markDirty should set dirty to true
     op.markDirty()
     expect(op.dirty).toBe(true)
+  })
+
+  it('traces the originating field only when causal tracing is enabled', async () => {
+    const op = new NumberOp('/number-1')
+    await op.pull()
+
+    const log = vi.fn()
+    const originalLog = debugDirtyTrace.log
+    const originalEnabled = debugDirtyTrace.enabled
+
+    try {
+      debugDirtyTrace.log = log
+      debugDirtyTrace.enabled = false
+      op.inputs.val.setValue(1)
+      expect(log).not.toHaveBeenCalled()
+
+      await op.pull()
+      debugDirtyTrace.enabled = true
+      op.inputs.val.setValue(2)
+
+      expect(log).toHaveBeenCalledTimes(1)
+      const trace = log.mock.calls[0].map(String).join(' ')
+      expect(trace).toContain('/number-1')
+      expect(trace).toContain(PullExecutionStatus.CLEAN)
+      expect(trace).toContain('/number-1.par.val')
+    } finally {
+      debugDirtyTrace.log = originalLog
+      debugDirtyTrace.enabled = originalEnabled
+    }
   })
 })
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -88,7 +88,7 @@ import { subscribeToPosition } from '../timeline/timeline-store'
 import * as utils from '../utils'
 import { getArc } from '../utils/arc-geometry'
 import { colorToHex, hexToColor } from '../utils/color'
-import { debugDirty, debugExecute, debugParams, debugPull } from '../utils/debug'
+import { debugDirty, debugDirtyTrace, debugExecute, debugParams, debugPull } from '../utils/debug'
 import { getDirections } from '../utils/directions'
 import { geocodeWithMapbox } from '../utils/geocoding'
 import {
@@ -695,7 +695,27 @@ export abstract class Operator<OP extends IOperator> {
   // leaving DIRTY anywhere disables pruning until the next wave re-stamps);
   // correctness first — the hot path (repeated marks between two frame pulls,
   // e.g. timeline scrubbing keyframed ops) stays O(1) per repeated mark.
-  markDirty(): void {
+  markDirty(cause?: Field | string): void {
+    // Stack capture is intentionally gated behind a separate namespace so
+    // ordinary `noodles:*` logging cannot add work to this hot path.
+    if (debugDirtyTrace.enabled) {
+      const source =
+        typeof cause === 'string'
+          ? cause
+          : cause?.pathToProps.length
+            ? cause.pathToProps.join('.')
+            : 'direct call'
+      const stack = new Error().stack?.split('\n').slice(2).join('\n') ?? 'stack unavailable'
+      debugDirtyTrace(
+        '%s: %s -> dirty; source=%s; downstream=%d\n%s',
+        this.id,
+        this._pullExecutionStatus,
+        source,
+        this._downstreamDependents.size,
+        stack
+      )
+    }
+
     const epoch = Operator._dirtyEpoch
     const visited = new Set<Operator<IOperator>>()
     const stack: Operator<IOperator>[] = [this as Operator<IOperator>]

--- a/noodles-editor/src/noodles/utils/field-expressions.ts
+++ b/noodles-editor/src/noodles/utils/field-expressions.ts
@@ -91,7 +91,7 @@ function applyResult(field: Field, result: unknown): void {
   // (e.g. `par.radius + 1` driving another sibling) converge instead of looping
   if (deepEqual(field.value, parsed.data)) return
   field.next(parsed.data)
-  field.op?.markDirty()
+  field.op?.markDirty(field)
 }
 
 export function evaluateFieldExpression(field: Field): void {

--- a/noodles-editor/src/noodles/utils/timeline-dependencies.ts
+++ b/noodles-editor/src/noodles/utils/timeline-dependencies.ts
@@ -25,7 +25,7 @@ export const useTimelineDependencyStore = create<TimelineDependencyState>((set, 
       state => ({ position: state.position, fps: state.sequence.fps }),
       () => {
         debugDirty('%s marked dirty by timeline position/fps change', op.id)
-        op.markDirty()
+        op.markDirty('timeline position/fps change')
       },
       { equalityFn: (a, b) => a.position === b.position && a.fps === b.fps }
     )
@@ -36,7 +36,7 @@ export const useTimelineDependencyStore = create<TimelineDependencyState>((set, 
       state => state.sequence,
       () => {
         debugDirty('%s marked dirty by timeline sequence change', op.id)
-        op.markDirty()
+        op.markDirty('timeline sequence change')
       },
       { equalityFn: (a, b) => a.length === b.length && a.fps === b.fps }
     )

--- a/noodles-editor/src/utils/debug.ts
+++ b/noodles-editor/src/utils/debug.ts
@@ -15,6 +15,8 @@ export const debugExecute = createDebug('noodles:executor:execute') // operator 
 // Field update pipeline namespaces
 export const debugSetValue = createDebug('noodles:field:setValue') // field value updates
 export const debugDirty = createDebug('noodles:field:dirty') // field dirty tracking
+// Intentionally outside `noodles:*`: this captures stacks and should only be enabled explicitly.
+export const debugDirtyTrace = createDebug('noodles-trace:dirty') // origin of each dirty wave
 
 // Render namespaces for video/image capture
 export const debugRender = createDebug('noodles:render') // video/image rendering setup


### PR DESCRIPTION
## Summary

Adds opt-in causal tracing for operator dirty waves so repeated graph execution can be traced back to the field or subsystem that initiated it.

## Changes

- Add the explicit `noodles-trace:dirty` debug namespace.
- Include the operator's prior state, originating field or subsystem, downstream count, and caller stack.
- Pass field identity through normal value, reference, and expression updates; label timeline-driven updates.
- Keep stack capture outside `noodles:*` and fully gated behind the explicit namespace.
- Document how to enable and disable causal tracing.

## Testing

### Unit Tests

- 323 graph-executor, field, expression, and timeline tests pass.
- 16 pull and dirty-wave benchmark tests pass.
- Added coverage that tracing is silent while disabled and reports the originating field while enabled.
- Lint, format check, and production build pass.

### Manual Testing

1. Open a project and run `localStorage.debug = 'noodles:executor:pull,noodles-trace:dirty'` in the browser console.
2. Reload, then change an operator input.
3. Confirm the console trace identifies the operator, previous state, originating field path, downstream count, and caller stack.
4. Set `localStorage.debug = ''` and reload to disable tracing.

## Documentation

- Added causal dirty-trace instructions to `dev-docs/developing.md`.

## Related Issues

Related to the execution loop diagnosed in #555.
