### PR TITLE
Persist edits to connected TableEditor data

### DIFF
--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -1776,7 +1776,7 @@ export function TableEditorOpComponent({
   type,
   selected,
 }: ReactFlowNodeProps<NodeDataJSON<TableEditorOp>> & { type: 'TableEditorOp' }) {
-  const op = getOp(id as string)
+  const op = getOp(id as string) as TableEditorOp | undefined
 
   const isDimmed = useNodeDimmed(id)
   const locked = useLocked(op)

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -1782,7 +1782,7 @@ export function TableEditorOpComponent({
   const locked = useLocked(op)
   useFieldVisibility(op)
 
-  const [data, setData] = useState((op?.inputs.data.value ?? []) as unknown[])
+  const [data, setData] = useState(() => op?.getEditableData() ?? [])
   const [schema, setSchema] = useState<TableSchema>(() => {
     // Get schema from output or infer from data
     const outputSchema = op?.outputs.schema.value
@@ -1795,9 +1795,9 @@ export function TableEditorOpComponent({
   // Subscribe to data and schema changes
   useEffect(() => {
     if (!op) return
-    const dataSub = op.inputs.data.subscribe(newData => {
-      setData(newData as unknown[])
-    })
+    const syncEditableData = () => setData(op.getEditableData())
+    const dataSub = op.inputs.data.subscribe(syncEditableData)
+    const dataOverrideSub = op.inputs.dataOverride.subscribe(syncEditableData)
     const schemaSub = op.outputs.schema.subscribe(newSchema => {
       if (newSchema && typeof newSchema === 'object' && 'columns' in newSchema) {
         setSchema(newSchema as TableSchema)
@@ -1805,6 +1805,7 @@ export function TableEditorOpComponent({
     })
     return () => {
       dataSub.unsubscribe()
+      dataOverrideSub.unsubscribe()
       schemaSub.unsubscribe()
     }
   }, [op])
@@ -1813,8 +1814,8 @@ export function TableEditorOpComponent({
 
   const handleDataChange = (newData: unknown[], description = 'Edit table data') => {
     const before = captureOperatorInputs()
-    op.inputs.data.setValue(newData)
-    op.outputs.data.setValue(newData)
+    op.setEditableData(newData)
+    op.outputs.data.next(newData)
     firePropertyMutation(description, before)
   }
 
@@ -1824,8 +1825,8 @@ export function TableEditorOpComponent({
     op.outputs.schema.setValue(newSchema)
     setSchema(newSchema)
     if (newData) {
-      op.inputs.data.setValue(newData)
-      op.outputs.data.setValue(newData)
+      op.setEditableData(newData)
+      op.outputs.data.next(newData)
     }
     firePropertyMutation('Edit table schema', before)
   }
@@ -1836,7 +1837,9 @@ export function TableEditorOpComponent({
       <NodeResizer isVisible={selected} minWidth={500} minHeight={300} />
       <div className={s.content}>
         {Object.entries(op.inputs)
-          .filter(([key]) => op.isFieldVisible(key) && key !== 'data')
+          .filter(
+            ([key]) => op.isFieldVisible(key) && key !== 'data' && key !== 'dataOverride'
+          )
           .map(([key, field]) => (
             <FieldComponent
               key={key}

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -95,7 +95,7 @@ describe('TableEditorOp', () => {
       ],
     }
 
-    const result = operator.execute({ data: [{}], schema })
+    const result = operator.execute({ data: [{}], dataOverride: null, schema })
 
     expect(result.data).toEqual([{ anchor: 'start', offset2d: [64, 0], offset3d: [64, 0, 10] }])
   })
@@ -111,8 +111,8 @@ describe('TableEditorOp', () => {
       timezone: 'America/Los_Angeles',
     }
 
-    const firstResult = first.execute({ data: [{ time: storedValue }], schema })
-    const secondResult = second.execute({ data: firstResult.data, schema })
+    const firstResult = first.execute({ data: [{ time: storedValue }], dataOverride: null, schema })
+    const secondResult = second.execute({ data: firstResult.data, dataOverride: null, schema })
     const chainedValue = secondResult.data[0].time as Temporal.ZonedDateTime
 
     expect(chainedValue).toBeInstanceOf(Temporal.ZonedDateTime)

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -121,6 +121,32 @@ describe('TableEditorOp', () => {
     )
     expect(chainedValue.timeZoneId).toBe(storedValue.timezone)
   })
+
+  it('uses a persisted edit override instead of connected source data', () => {
+    const sourceData = [{ name: 'Original' }]
+    const editedData = [{ name: 'Edited' }]
+    const operator = new TableEditorOp('/table', { dataOverride: editedData })
+
+    expect(operator.getEditableData()).toEqual(editedData)
+    expect(
+      operator.execute({ data: sourceData, dataOverride: editedData, schema: null }).data
+    ).toEqual(editedData)
+  })
+
+  it('stores edits as an override when data is connected', () => {
+    const source = new TableEditorOp('/source')
+    const operator = new TableEditorOp('/table')
+    const edgeId = '/source.out.data->/table.par.data'
+    source.outputs.data.next([{ name: 'Original' }])
+    operator.inputs.data.addConnection(edgeId, source.outputs.data)
+
+    const editedData = [{ name: 'Edited' }]
+    operator.setEditableData(editedData)
+
+    expect(operator.inputs.data.value).toEqual([{ name: 'Original' }])
+    expect(operator.inputs.dataOverride.value).toEqual(editedData)
+    expect(operator.getEditableData()).toEqual(editedData)
+  })
 })
 
 describe('Operator par and out', () => {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -2331,7 +2331,8 @@ export class TableEditorOp extends Operator<TableEditorOp> {
 
   getEditableData(): unknown[] {
     const override = this.inputs.dataOverride.value
-    return Array.isArray(override) ? override : this.inputs.data.value
+    const source = this.inputs.data.value
+    return Array.isArray(override) ? override : Array.isArray(source) ? source : []
   }
 
   setEditableData(data: unknown[]): void {

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -2314,6 +2314,10 @@ export class TableEditorOp extends Operator<TableEditorOp> {
   createInputs() {
     return {
       data: new DataField(),
+      // A connected data input remains the live source until the user edits the table.
+      // Edits then become a local snapshot so they can be serialized without changing
+      // the general rule that connected input values are owned by their upstream op.
+      dataOverride: new UnknownField(null, { showByDefault: false }),
       schema: new UnknownField(null), // TableSchema | null - optional schema override
     }
   }
@@ -2325,8 +2329,31 @@ export class TableEditorOp extends Operator<TableEditorOp> {
     }
   }
 
-  execute({ data, schema }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    const validatedData = schema ? validateTableData(data, schema as TableSchema) : data
+  getEditableData(): unknown[] {
+    const override = this.inputs.dataOverride.value
+    return Array.isArray(override) ? override : this.inputs.data.value
+  }
+
+  setEditableData(data: unknown[]): void {
+    const hasConnectedSource = Array.from(this.inputs.data.subscriptions.keys()).some(
+      id => !id.startsWith('__')
+    )
+    if (hasConnectedSource || Array.isArray(this.inputs.dataOverride.value)) {
+      this.inputs.dataOverride.setValue(data)
+    } else {
+      this.inputs.data.setValue(data)
+    }
+  }
+
+  execute({
+    data,
+    dataOverride,
+    schema,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+    const editableData = Array.isArray(dataOverride) ? dataOverride : data
+    const validatedData = schema
+      ? validateTableData(editableData, schema as TableSchema)
+      : editableData
     // Convert dateTime strings to Temporal.ZonedDateTime for output
     // This happens at the operator boundary: internal storage = strings, output = Temporal
     const outputData = schema

--- a/noodles-editor/src/noodles/utils/serialization.test.ts
+++ b/noodles-editor/src/noodles/utils/serialization.test.ts
@@ -345,6 +345,33 @@ describe('serializeNodes', () => {
     expect(project.nodes[1].data.inputs.schema).toEqual(schema)
   })
 
+  it('serializes TableEditor edits made over a connected data source', () => {
+    const source = new TableEditorOp('/source')
+    const target = new TableEditorOp('/target')
+    const dataEdge = {
+      id: '/source.out.data->/target.par.data',
+      source: '/source',
+      sourceHandle: 'out.data',
+      target: '/target',
+      targetHandle: 'par.data',
+    }
+    source.outputs.data.next([{ name: 'Original' }])
+    target.inputs.data.addConnection(dataEdge.id, source.outputs.data)
+    target.setEditableData([{ name: 'Edited' }])
+    setOp('/source', source)
+    setOp('/target', target)
+
+    const nodes = [
+      { id: '/source', type: 'TableEditorOp', data: {}, position: { x: 0, y: 0 } },
+      { id: '/target', type: 'TableEditorOp', data: {}, position: { x: 100, y: 0 } },
+    ]
+    const serializedNodes = serializeNodes(getOpStore(), nodes, [dataEdge])
+    const serializedTarget = serializedNodes.find(node => node.id === '/target')
+
+    expect(serializedTarget?.data.inputs.data).toBeUndefined()
+    expect(serializedTarget?.data.inputs.dataOverride).toEqual([{ name: 'Edited' }])
+  })
+
   it('excludes ReferenceEdge connections when determining connected inputs', () => {
     setOp('node1', makeOp({ x: 123 }, false))
     setOp('node0', makeOp({ foo: 42 }, false))


### PR DESCRIPTION
## Summary

- keep converted TableEditors live to their connected source until the first edit
- persist connected-table edits as a local data override without weakening generic connected-input serialization
- restore the override on reload and retain empty-table edits
- keep unconnected TableEditor serialization unchanged

## Regression

Viewer-to-TableEditor conversion preserves the incoming data edge. Generic project serialization and property-history snapshots correctly omit connected input values, so edits made in converted tables appeared locally but were discarded when saving.

## Test plan

- `npm test -- --run src/noodles/operators.test.ts src/noodles/utils/serialization.test.ts src/noodles/components/table-editor.test.tsx` (377 passed)
- `npm run lint -- --diagnostic-level=error`
- `npm run build`

Manually: convert or open a TableEditor connected to a FileOp, edit a cell, save/reload, and confirm the edit remains while the source edge is preserved.