### PR TITLE
Show TableEditor data connections

### DIFF
--- a/noodles-editor/src/noodles/components/__tests__/table-editor-op-component.test.tsx
+++ b/noodles-editor/src/noodles/components/__tests__/table-editor-op-component.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProjectModificationActionsProvider } from '../../contexts/project-modification-actions-context'
+import type { TableEditorOp } from '../../operators'
+import { clearOps, getOp } from '../../store'
+import { transformGraph } from '../../transform-graph'
+import { nodeComponents } from '../op-components'
+
+describe('TableEditorOpComponent', () => {
+  beforeEach(() => {
+    clearOps()
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearOps()
+  })
+
+  it('renders its data input handle without hiding the table editor', () => {
+    const schema = {
+      columns: [{ name: 'Location', type: 'string' as const, defaultValue: '' }],
+    }
+    const rows = [{ Location: 'New York' }]
+    const edge = {
+      id: '/source.out.data->/table.par.data',
+      source: '/source',
+      sourceHandle: 'out.data',
+      target: '/table',
+      targetHandle: 'par.data',
+    }
+    transformGraph({
+      nodes: [
+        {
+          id: '/source',
+          type: 'TableEditorOp',
+          position: { x: -500, y: 0 },
+          data: { inputs: { data: rows, schema } },
+        },
+        {
+          id: '/table',
+          type: 'TableEditorOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: { schema } },
+        },
+      ],
+      edges: [edge],
+    })
+    const source = getOp('/source') as TableEditorOp
+    source.outputs.data.setValue(rows)
+
+    const TableEditorNode = nodeComponents.TableEditorOp
+    const { container } = render(
+      <ProjectModificationActionsProvider updateOperatorId={vi.fn()}>
+        <ReactFlowProvider>
+          <TableEditorNode
+            id="/table"
+            type="TableEditorOp"
+            selected={false}
+            data={{ inputs: { schema } }}
+            isConnectable
+            zIndex={0}
+            dragging={false}
+          />
+        </ReactFlowProvider>
+      </ProjectModificationActionsProvider>
+    )
+
+    expect(container.querySelector('[data-handleid="par.data"]')).toBeInTheDocument()
+    expect(screen.getByText('New York')).toBeInTheDocument()
+  })
+})

--- a/noodles-editor/src/noodles/components/op-components.tsx
+++ b/noodles-editor/src/noodles/components/op-components.tsx
@@ -1836,7 +1836,7 @@ export function TableEditorOpComponent({
       <NodeResizer isVisible={selected} minWidth={500} minHeight={300} />
       <div className={s.content}>
         {Object.entries(op.inputs)
-          .filter(([key]) => op.isFieldVisible(key) && key !== 'data')
+          .filter(([key]) => op.isFieldVisible(key))
           .map(([key, field]) => (
             <FieldComponent
               key={key}


### PR DESCRIPTION
## Summary

Restore the TableEditor `par.data` input row and React Flow handle so preserved Viewer connections remain visible and removable after conversion. The editable table remains rendered while the input is connected.

## Historical intent

PR #423 intentionally made the table itself the typed editor and hid the redundant generic `data` row, but did not describe hiding live connections. PR #480 later explicitly preserved Viewer connections during conversion. The invisible edge was an accidental interaction between those choices; #605's duplicate-edge repair is valid but unrelated.

## Changes

- Render all visible TableEditor inputs, including `data`.
- Add a connected-component regression test that verifies both the `par.data` handle and upstream rows are rendered.

## Testing

### Unit Tests

- `npm test -- --run src/noodles/components/__tests__/table-editor-op-component.test.tsx`
- `npx biome check src/noodles/components/__tests__/table-editor-op-component.test.tsx`

The repository-wide TypeScript check currently reports existing baseline errors unrelated to this two-line behavior change.

### Manual Testing

1. Connect a tabular data output to a Viewer.
2. Convert the Viewer to a Table Editor.
3. Confirm the incoming data edge and `data` field row remain visible.
4. Confirm the editable table remains visible and contains the upstream rows.
5. Select and delete the incoming edge; confirm the Table Editor remains usable as a standalone table.

## Documentation

No documentation changes needed.

## Related Issues

This fixes the invisible-connection interaction discovered while testing #605, but is independent of its duplicate-edge behavior.
