### PR TITLE
Fix pure Deck.gl fit-to-panel preview sizing

### DIFF
--- a/noodles-editor/src/render/transform-scale.test.ts
+++ b/noodles-editor/src/render/transform-scale.test.ts
@@ -63,7 +63,7 @@ describe('TransformScale', () => {
         { style: { position: 'relative', width: 1000, height: 600 } },
         createElement(
           TransformScale,
-          { scale: 0.3, scaleMode: 'fit' },
+          { scale: 0.3, scaleMode: 'fit', width: 1920, height: 1080 },
           createElement('div', { style: { width: 1920, height: 1080 } })
         )
       )
@@ -88,6 +88,28 @@ describe('TransformScale', () => {
     expect(Number(surface.style.transform.match(/scale\(([^)]+)\)/)?.[1])).toBeCloseTo(484 / 1920)
     expect(stage.dataset.scaleMode).toBe('fit')
     expect(surface.style.transformOrigin).toBe('center center')
+  })
+
+  it('sizes the surface for absolutely positioned render content', () => {
+    class ResizeObserverMock {
+      observe() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+
+    const { container } = render(
+      createElement(
+        TransformScale,
+        { scale: 0.3, scaleMode: 'fit', width: 1920, height: 1080 },
+        createElement('div', {
+          style: { position: 'absolute', width: 1920, height: 1080 },
+        })
+      )
+    )
+
+    const surface = container.querySelector<HTMLElement>('.transform-scale')!
+    expect(surface.style.width).toBe('1920px')
+    expect(surface.style.height).toBe('1080px')
   })
 
   it('uses the saved manual scale without fitting', () => {

--- a/noodles-editor/src/render/transform-scale.tsx
+++ b/noodles-editor/src/render/transform-scale.tsx
@@ -40,11 +40,15 @@ export function getTransformScaleFactor(target: Element): { x: number; y: number
 export function TransformScale({
   scale,
   scaleMode = 'manual',
+  width,
+  height,
   children,
 }: {
   scale: number
   scaleMode?: 'fit' | 'manual'
-  children: ReactNode
+  width?: number
+  height?: number
+  children?: ReactNode
 }) {
   const stageRef = useRef<HTMLDivElement>(null)
   const surfaceRef = useRef<HTMLDivElement>(null)
@@ -95,8 +99,11 @@ export function TransformScale({
         className="transform-scale"
         style={{
           flex: '0 0 auto',
-          width: 'max-content',
-          height: 'max-content',
+          // DeckGL's root is absolutely positioned, so it does not contribute to
+          // max-content sizing. Use the fixed render size when available so the
+          // surface can be measured and centered around the entire canvas.
+          width: width ?? 'max-content',
+          height: height ?? 'max-content',
           transform: `scale(${isFit ? fitScale : scale})`,
           transformOrigin: isFit ? 'center center' : 'top left',
         }}

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -625,6 +625,8 @@ export default function TimelineEditor() {
               <TransformScale
                 scale={renderSettings.scaleControl}
                 scaleMode={renderSettings.scaleMode}
+                width={lodResolution.width}
+                height={lodResolution.height}
               >
                 <ErrorBoundary title="Visualization Error">{renderContent()}</ErrorBoundary>
               </TransformScale>


### PR DESCRIPTION
#### Background

Pure Deck.gl previews were centered from a collapsed 0×0 scaling surface because DeckGL renders its root with absolute positioning, causing the canvas to be clipped on the bottom and right.

#### Change List
- Size the transform surface from the fixed render resolution so fit-to-panel scaling can measure and center the full canvas.
- Pass the LOD-adjusted resolution into the transform wrapper and add regression coverage for absolutely positioned render content.
- Verified with focused Vitest coverage, Biome checks, and a production Vite build.