### PR TITLE
Fix PostHog error noise: validation, schema guards, ResizeObserver filter

### DIFF
--- a/noodles-editor/src/index.tsx
+++ b/noodles-editor/src/index.tsx
@@ -13,8 +13,10 @@ analytics.initialize()
 
 // Log uncaught errors and unhandled promise rejections to the console
 window.addEventListener('error', e => {
-  // Ignore benign ResizeObserver errors - these are harmless browser warnings
-  // that occur when ResizeObserver callbacks trigger layout changes
+  // Filter benign ResizeObserver errors - these are harmless browser optimization warnings
+  // that occur when ResizeObserver callbacks trigger layout changes. They don't indicate
+  // actual problems. We filter them here at the window level and also in analytics.captureException()
+  // to ensure they don't reach PostHog or clutter console output.
   const message = e.error?.message || e.message || ''
   if (message.includes('ResizeObserver loop')) {
     e.preventDefault()

--- a/noodles-editor/src/noodles/operators-error-handling.test.ts
+++ b/noodles-editor/src/noodles/operators-error-handling.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { analytics } from '../utils/analytics'
+import { ChartOp } from './operators'
+
+// Mock analytics
+vi.mock('../utils/analytics', () => ({
+  analytics: {
+    captureException: vi.fn(),
+    initialize: vi.fn(),
+    track: vi.fn(),
+  },
+}))
+
+describe('ChartOp error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return null chart when data is empty', () => {
+    const op = new ChartOp('/test')
+    const result = op.execute({
+      data: [],
+      chartType: 'bar',
+      xField: 'x',
+      yField: 'y',
+      width: 640,
+      height: 400,
+      color: '#4269d0',
+      title: '',
+      xLabel: '',
+      yLabel: '',
+    })
+
+    expect(result.chart).toBeNull()
+    expect(analytics.captureException).not.toHaveBeenCalled()
+  })
+
+  it('should return null chart when xField is empty', () => {
+    const op = new ChartOp('/test')
+    const result = op.execute({
+      data: [{ x: 1, y: 2 }],
+      chartType: 'bar',
+      xField: '',
+      yField: 'y',
+      width: 640,
+      height: 400,
+      color: '#4269d0',
+      title: '',
+      xLabel: '',
+      yLabel: '',
+    })
+
+    expect(result.chart).toBeNull()
+    expect(analytics.captureException).not.toHaveBeenCalled()
+  })
+
+  it('should return null chart when yField is empty for bar chart', () => {
+    const op = new ChartOp('/test')
+    const result = op.execute({
+      data: [{ x: 1, y: 2 }],
+      chartType: 'bar',
+      xField: 'x',
+      yField: '',
+      width: 640,
+      height: 400,
+      color: '#4269d0',
+      title: '',
+      xLabel: '',
+      yLabel: '',
+    })
+
+    expect(result.chart).toBeNull()
+    expect(analytics.captureException).not.toHaveBeenCalled()
+  })
+
+  it('should allow empty yField for histogram', () => {
+    const op = new ChartOp('/test')
+    const result = op.execute({
+      data: [{ x: 1 }, { x: 2 }, { x: 3 }],
+      chartType: 'histogram',
+      xField: 'x',
+      yField: '',
+      width: 640,
+      height: 400,
+      color: '#4269d0',
+      title: '',
+      xLabel: '',
+      yLabel: '',
+    })
+
+    // Histogram should work with just xField
+    expect(result.chart).not.toBeNull()
+  })
+
+  it('should generate chart with valid inputs', () => {
+    const op = new ChartOp('/test')
+    const result = op.execute({
+      data: [
+        { x: 'A', y: 10 },
+        { x: 'B', y: 20 },
+      ],
+      chartType: 'bar',
+      xField: 'x',
+      yField: 'y',
+      width: 640,
+      height: 400,
+      color: '#4269d0',
+      title: 'Test Chart',
+      xLabel: 'X Axis',
+      yLabel: 'Y Axis',
+    })
+
+    expect(result.chart).not.toBeNull()
+    expect(result.chart).toBeInstanceOf(HTMLElement)
+    expect(analytics.captureException).not.toHaveBeenCalled()
+  })
+
+  it('should capture exception if Observable Plot throws', () => {
+    const op = new ChartOp('/test')
+
+    // Create data that will cause Plot to fail
+    // (malformed data structure that Plot can't handle)
+    const result = op.execute({
+      data: [
+        { x: null, y: undefined },
+        { x: NaN, y: Infinity },
+      ],
+      chartType: 'scatter',
+      xField: 'x',
+      yField: 'y',
+      width: 640,
+      height: 400,
+      color: '#4269d0',
+      title: '',
+      xLabel: '',
+      yLabel: '',
+    })
+
+    // Should return null on error
+    expect(result.chart).toBeNull()
+
+    // Should capture the exception with context
+    expect(analytics.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        source: 'chart_op',
+        chartType: 'scatter',
+        hasData: true,
+        hasXField: true,
+        hasYField: true,
+        dataLength: 2,
+      })
+    )
+  })
+
+  it('should handle scatter plot with valid data', () => {
+    const op = new ChartOp('/test')
+    const result = op.execute({
+      data: [
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ],
+      chartType: 'scatter',
+      xField: 'x',
+      yField: 'y',
+      width: 640,
+      height: 400,
+      color: '#4269d0',
+      title: '',
+      xLabel: '',
+      yLabel: '',
+    })
+
+    expect(result.chart).not.toBeNull()
+    expect(analytics.captureException).not.toHaveBeenCalled()
+  })
+})

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -78,6 +78,7 @@ import { subscribeToPosition } from '../timeline/timeline-store'
 import * as utils from '../utils'
 import { getArc } from '../utils/arc-geometry'
 import { colorToHex, hexToColor } from '../utils/color'
+import { analytics } from '../utils/analytics'
 import { debugDirty, debugExecute, debugParams, debugPull } from '../utils/debug'
 import { getDirections } from '../utils/directions'
 import { geocodeWithMapbox } from '../utils/geocoding'
@@ -2232,13 +2233,34 @@ export class DuckDbOp extends Operator<DuckDbOp> {
       await conn.close()
       return { data }
     } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e))
+      const errorMsg = error.message || ''
+
       debugExecute('Error executing query', e)
+
+      // Log error to console for debugging
+      // Note: "Object Not Found" and syntax errors often occur during typing,
+      // so we don't capture those to PostHog to avoid noise from incomplete queries
+      if (errorMsg.includes('Object Not Found')) {
+        console.error(
+          '[DuckDbOp] Object not found - table or view may not be registered.',
+          'This often happens when typing an incomplete query.',
+          error
+        )
+      } else if (errorMsg.includes('syntax error') || errorMsg.includes('Parser Error')) {
+        console.error('[DuckDbOp] SQL syntax error (likely incomplete query):', error)
+      } else {
+        // Only capture non-typing-related errors to analytics
+        console.error('[DuckDbOp] Query execution failed:', error)
+        analytics.captureException(error, {
+          source: 'duckdb_op',
+          errorType: 'execution_error',
+        })
+      }
+
       await conn.close()
       await db.reset()
-      if (e instanceof Error) {
-        throw e
-      }
-      return null
+      throw error
     }
   }
 }
@@ -2394,31 +2416,53 @@ export class ChartOp extends Operator<ChartOp> {
       return { chart: null }
     }
 
-    // Build marks based on chart type
-    let marks: Plot.Markish[]
-    switch (chartType) {
-      case 'bar':
-        marks = [Plot.barY(data, { x: xField, y: yField, fill: color })]
-        break
-      case 'histogram':
-        marks = [Plot.rectY(data, Plot.binX({ y: 'count' }, { x: xField, fill: color }))]
-        break
-      case 'scatter':
-        marks = [Plot.dot(data, { x: xField, y: yField, fill: color })]
-        break
+    // Validate that fields are populated (not empty strings)
+    // This prevents Observable Plot from receiving undefined field names
+    if (!xField || (chartType !== 'histogram' && !yField)) {
+      console.warn(
+        `[ChartOp] Field validation failed - xField: "${xField}", yField: "${yField}", chartType: "${chartType}"`
+      )
+      return { chart: null }
     }
 
-    // Generate and return plot
-    const chart = Plot.plot({
-      width,
-      height,
-      title,
-      marks,
-      x: { label: xLabel || xField },
-      y: { label: yLabel || yField },
-    })
+    try {
+      // Build marks based on chart type
+      let marks: Plot.Markish[]
+      switch (chartType) {
+        case 'bar':
+          marks = [Plot.barY(data, { x: xField, y: yField, fill: color })]
+          break
+        case 'histogram':
+          marks = [Plot.rectY(data, Plot.binX({ y: 'count' }, { x: xField, fill: color }))]
+          break
+        case 'scatter':
+          marks = [Plot.dot(data, { x: xField, y: yField, fill: color })]
+          break
+      }
 
-    return { chart }
+      // Generate and return plot
+      const chart = Plot.plot({
+        width,
+        height,
+        title,
+        marks,
+        x: { label: xLabel || xField },
+        y: { label: yLabel || yField },
+      })
+
+      return { chart }
+    } catch (error) {
+      console.error('[ChartOp] Plot generation failed:', error)
+      analytics.captureException(error as Error, {
+        source: 'chart_op',
+        chartType,
+        hasData: data?.length > 0,
+        hasXField: !!xField,
+        hasYField: !!yField,
+        dataLength: data?.length,
+      })
+      return { chart: null }
+    }
   }
 }
 

--- a/noodles-editor/src/noodles/utils/can-connect-error.test.ts
+++ b/noodles-editor/src/noodles/utils/can-connect-error.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+import { DataField, NumberField, StringField, UnknownField } from '../fields'
+import { schemasAreCompatible, validateConnection } from './can-connect'
+
+describe('can-connect error handling', () => {
+  describe('schemasAreCompatible with invalid schemas', () => {
+    it('should handle null schemas gracefully', () => {
+      const validSchema = z.number()
+      // @ts-expect-error - testing null schema handling
+      const result = schemasAreCompatible(null, validSchema)
+      expect(result).toBe(false)
+    })
+
+    it('should handle undefined schemas gracefully', () => {
+      const validSchema = z.string()
+      // @ts-expect-error - testing undefined schema handling
+      const result = schemasAreCompatible(undefined, validSchema)
+      expect(result).toBe(false)
+    })
+
+    it('should handle non-Zod objects gracefully', () => {
+      const validSchema = z.boolean()
+      const invalidSchema = { notAZodSchema: true } as any
+      const result = schemasAreCompatible(invalidSchema, validSchema)
+      expect(result).toBe(false)
+    })
+
+    it('should handle valid schemas normally', () => {
+      const schema1 = z.number()
+      const schema2 = z.number()
+      const result = schemasAreCompatible(schema1, schema2)
+      expect(result).toBe(true)
+    })
+
+    it('should handle incompatible schemas', () => {
+      const schema1 = z.number()
+      const schema2 = z.string()
+      const result = schemasAreCompatible(schema1, schema2)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('validateConnection with edge cases', () => {
+    it('should allow UnknownField to connect to any field', () => {
+      const unknownField = new UnknownField()
+      const numberField = new NumberField(42)
+
+      const result = validateConnection(unknownField, numberField)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate compatible field types', () => {
+      const numberField1 = new NumberField(10)
+      const numberField2 = new NumberField(20)
+
+      const result = validateConnection(numberField1, numberField2)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should reject incompatible field types', () => {
+      const numberField = new NumberField(42)
+      const stringField = new StringField('hello')
+
+      const result = validateConnection(numberField, stringField)
+      expect(result.valid).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('should handle DataField connections', () => {
+      const dataField1 = new DataField()
+      const dataField2 = new DataField()
+
+      const result = validateConnection(dataField1, dataField2)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate field values when available', () => {
+      const numberField1 = new NumberField(10, { min: 0, max: 100 })
+      const numberField2 = new NumberField(20, { min: 0, max: 50 })
+
+      // Set value that's valid for field1 but not field2
+      numberField1.setValue(75)
+
+      const result = validateConnection(numberField1, numberField2)
+      // Should fail because 75 > 50 (max of field2)
+      expect(result.valid).toBe(false)
+    })
+
+    it('should allow connections without value constraints', () => {
+      const stringField1 = new StringField('test')
+      const stringField2 = new StringField('other')
+
+      const result = validateConnection(stringField1, stringField2)
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  describe('schema unwrapping edge cases', () => {
+    it('should handle optional schemas', () => {
+      const optionalNumber = z.number().optional()
+      const number = z.number()
+
+      // Optional number should be compatible with number
+      const result = schemasAreCompatible(optionalNumber, number)
+      // This will fail because optional adds undefined as possibility
+      // but we're testing that it doesn't crash
+      expect(typeof result).toBe('boolean')
+    })
+
+    it('should handle nullable schemas', () => {
+      const nullableString = z.string().nullable()
+      const string = z.string()
+
+      const result = schemasAreCompatible(nullableString, string)
+      expect(typeof result).toBe('boolean')
+    })
+
+    it('should handle deeply nested wrapper types', () => {
+      const deeplyWrapped = z.number().optional().nullable().default(42)
+      const simple = z.number()
+
+      const result = schemasAreCompatible(deeplyWrapped, simple)
+      expect(typeof result).toBe('boolean')
+    })
+
+    it('should handle array schemas', () => {
+      const arraySchema = z.array(z.number())
+      const anotherArray = z.array(z.number())
+
+      const result = schemasAreCompatible(arraySchema, anotherArray)
+      expect(result).toBe(true)
+    })
+
+    it('should handle union types', () => {
+      const union = z.union([z.number(), z.string()])
+      const number = z.number()
+
+      const result = schemasAreCompatible(number, union)
+      expect(typeof result).toBe('boolean')
+    })
+  })
+})

--- a/noodles-editor/src/noodles/utils/can-connect.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.ts
@@ -77,26 +77,70 @@ const WRAPPER_TYPES = new Set([
 ])
 
 // Unwrap wrapper types to get the underlying schema
-function unwrapSchema(schema: z.ZodType): z.ZodType {
+function unwrapSchema(schema: z.ZodType): z.ZodType | null {
+  // Guard against undefined or non-object schemas
+  if (!schema || typeof schema !== 'object') {
+    if (debugConnect.enabled) {
+      debugConnect('⚠️ unwrapSchema received invalid schema:', schema)
+    }
+    return null
+  }
+
   let current = schema
   // biome-ignore lint/suspicious/noExplicitAny: Zod internal API access
-  let def = (current as any)._zod.def as ZodDef
+  const zodInternal = (current as any)._zod
+  if (!zodInternal || !zodInternal.def) {
+    if (debugConnect.enabled) {
+      debugConnect('⚠️ Schema missing _zod internal structure')
+    }
+    return null
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: Zod internal API access
+  let def = zodInternal.def as ZodDef
   while (WRAPPER_TYPES.has(def.type)) {
     const inner = def.innerType ?? def.schema ?? def.in
     if (!inner) break
     current = inner
     // biome-ignore lint/suspicious/noExplicitAny: Zod internal API access
-    def = (current as any)._zod.def as ZodDef
+    const innerZod = (current as any)?._zod
+    if (!innerZod || !innerZod.def) break
+    def = innerZod.def as ZodDef
   }
   return current
 }
 
 // Check if source schema is structurally compatible with target schema
 export function schemasAreCompatible(from: z.ZodType, to: z.ZodType, depth = 0): boolean {
+  const unwrappedFrom = unwrapSchema(from)
+  const unwrappedTo = unwrapSchema(to)
+
+  // If either schema is invalid, fail safely
+  if (!unwrappedFrom || !unwrappedTo) {
+    if (debugConnect.enabled) {
+      const indent = '  '.repeat(depth)
+      debugConnect(
+        `${indent}✗ Schema unwrapping failed - from: ${!!unwrappedFrom}, to: ${!!unwrappedTo}`
+      )
+    }
+    return false
+  }
+
   // biome-ignore lint/suspicious/noExplicitAny: Zod internal API access
-  const fromDef = (unwrapSchema(from) as any)._zod.def as ZodDef
+  const fromZod = (unwrappedFrom as any)._zod
   // biome-ignore lint/suspicious/noExplicitAny: Zod internal API access
-  const toDef = (unwrapSchema(to) as any)._zod.def as ZodDef
+  const toZod = (unwrappedTo as any)._zod
+
+  if (!fromZod?.def || !toZod?.def) {
+    if (debugConnect.enabled) {
+      const indent = '  '.repeat(depth)
+      debugConnect(`${indent}✗ Missing _zod.def - from: ${!!fromZod?.def}, to: ${!!toZod?.def}`)
+    }
+    return false
+  }
+
+  const fromDef = fromZod.def as ZodDef
+  const toDef = toZod.def as ZodDef
 
   if (debugConnect.enabled) {
     const indent = '  '.repeat(depth)
@@ -328,12 +372,10 @@ export function validateConnection(from: Field, to: Field): ConnectionValidation
   const fromSchema = from.schema
   const toSchema = to instanceof ListField ? to.schema.unwrap() : to.schema
 
-  // biome-ignore lint/suspicious/noExplicitAny: Zod internal API access
-  const fromType = (unwrapSchema(fromSchema) as any)._zod.def.type
-
   if (debugConnect.enabled) {
     debugConnect(`Schema comparison starting...`)
   }
+
   // Structural type check
   if (!schemasAreCompatible(fromSchema, toSchema)) {
     if (debugConnect.enabled) {
@@ -348,6 +390,28 @@ export function validateConnection(from: Field, to: Field): ConnectionValidation
   if (debugConnect.enabled) {
     debugConnect(`✓ Schema compatible`)
   }
+
+  // Get fromType for constraint validation check
+  const unwrappedFrom = unwrapSchema(fromSchema)
+  if (!unwrappedFrom) {
+    // Schema is invalid but passed schemasAreCompatible (shouldn't happen)
+    // Allow connection but skip value validation
+    if (debugConnect.enabled) {
+      debugConnect('⚠️ fromSchema unwrap failed, skipping value validation')
+    }
+    return { valid: true }
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: Zod internal API access
+  const fromZod = (unwrappedFrom as any)._zod
+  if (!fromZod?.def) {
+    if (debugConnect.enabled) {
+      debugConnect('⚠️ fromSchema missing _zod.def, skipping value validation')
+    }
+    return { valid: true }
+  }
+
+  const fromType = fromZod.def.type
 
   // Skip constraint validation for unknown schemas — they're optimistically compatible
   // with anything, so value-level checking doesn't make sense

--- a/noodles-editor/src/utils/analytics-filtering.test.ts
+++ b/noodles-editor/src/utils/analytics-filtering.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type posthog from 'posthog-js'
+
+// Mock posthog before importing analytics
+vi.mock('posthog-js', () => ({
+  default: {
+    init: vi.fn(),
+    capture: vi.fn(),
+    captureException: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+    has_opted_out_capturing: vi.fn(() => false),
+  },
+}))
+
+describe('Analytics error filtering', () => {
+  let analytics: any
+  let mockPosthog: typeof posthog
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    // Clear localStorage
+    localStorage.clear()
+
+    // Re-import analytics to get fresh instance
+    const analyticsModule = await import('./analytics')
+    analytics = analyticsModule.analytics
+    const posthogModule = await import('posthog-js')
+    mockPosthog = posthogModule.default
+
+    // Initialize analytics
+    analytics.initialize()
+  })
+
+  describe('ResizeObserver error filtering', () => {
+    it('should filter ResizeObserver loop errors', () => {
+      const resizeError = new Error('ResizeObserver loop completed with undelivered notifications')
+
+      analytics.captureException(resizeError, { source: 'test' })
+
+      // PostHog should not be called for ResizeObserver errors
+      expect(mockPosthog.captureException).not.toHaveBeenCalled()
+    })
+
+    it('should filter ResizeObserver errors with partial message match', () => {
+      const resizeError = new Error('Something went wrong: ResizeObserver loop limit exceeded')
+
+      analytics.captureException(resizeError, { source: 'test' })
+
+      expect(mockPosthog.captureException).not.toHaveBeenCalled()
+    })
+
+    it('should capture non-ResizeObserver errors normally', () => {
+      const normalError = new Error('Actual error that should be tracked')
+
+      analytics.captureException(normalError, { source: 'test' })
+
+      // Should capture non-filtered errors
+      expect(mockPosthog.captureException).toHaveBeenCalledWith(
+        normalError,
+        expect.objectContaining({ source: 'test' })
+      )
+    })
+
+    it('should capture TypeError exceptions', () => {
+      const typeError = new TypeError('Cannot read property of undefined')
+
+      analytics.captureException(typeError, { source: 'test' })
+
+      expect(mockPosthog.captureException).toHaveBeenCalledWith(
+        typeError,
+        expect.objectContaining({ source: 'test' })
+      )
+    })
+
+    it('should capture ReferenceError exceptions', () => {
+      const refError = new ReferenceError('Variable is not defined')
+
+      analytics.captureException(refError, { source: 'test' })
+
+      expect(mockPosthog.captureException).toHaveBeenCalledWith(
+        refError,
+        expect.objectContaining({ source: 'test' })
+      )
+    })
+  })
+
+  describe('Error capture consent', () => {
+    it('should respect error capture disabled setting', () => {
+      analytics.setErrorCaptureConsent(false)
+
+      const error = new Error('Test error')
+      analytics.captureException(error)
+
+      expect(mockPosthog.captureException).not.toHaveBeenCalled()
+    })
+
+    it('should capture errors when consent is enabled', () => {
+      analytics.setErrorCaptureConsent(true)
+
+      const error = new Error('Test error')
+      analytics.captureException(error, { source: 'test' })
+
+      expect(mockPosthog.captureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ source: 'test' })
+      )
+    })
+
+    it('should default to enabled when no consent stored', () => {
+      // Clear any stored consent
+      localStorage.removeItem('noodles-error-capture-consent')
+
+      const error = new Error('Test error')
+      analytics.captureException(error, { source: 'test' })
+
+      // Should capture by default
+      expect(mockPosthog.captureException).toHaveBeenCalled()
+    })
+  })
+
+  describe('Error properties filtering', () => {
+    it('should include non-sensitive properties', () => {
+      const error = new Error('Test error')
+      analytics.captureException(error, {
+        source: 'chart_op',
+        chartType: 'bar',
+        hasData: true,
+      })
+
+      expect(mockPosthog.captureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          source: 'chart_op',
+          chartType: 'bar',
+          hasData: true,
+        })
+      )
+    })
+
+    it('should include component stack when provided', () => {
+      const error = new Error('React error')
+      analytics.captureException(error, {
+        source: 'react_error_boundary',
+        componentStack: 'at Component (bundle.js:123)',
+      })
+
+      expect(mockPosthog.captureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          source: 'react_error_boundary',
+          componentStack: 'at Component (bundle.js:123)',
+        })
+      )
+    })
+  })
+
+  describe('Multiple error types', () => {
+    it('should filter all ResizeObserver variants', () => {
+      const errors = [
+        new Error('ResizeObserver loop completed with undelivered notifications'),
+        new Error('ResizeObserver loop limit exceeded'),
+        new Error('Something ResizeObserver loop something'),
+      ]
+
+      errors.forEach(error => {
+        analytics.captureException(error)
+      })
+
+      // None should be captured
+      expect(mockPosthog.captureException).not.toHaveBeenCalled()
+    })
+
+    it('should capture all non-ResizeObserver errors', () => {
+      const errors = [
+        new Error('Normal error'),
+        new TypeError('Type error'),
+        new ReferenceError('Reference error'),
+        new Error('Another error'),
+      ]
+
+      errors.forEach(error => {
+        analytics.captureException(error, { source: 'test' })
+      })
+
+      // All should be captured
+      expect(mockPosthog.captureException).toHaveBeenCalledTimes(4)
+    })
+  })
+})

--- a/noodles-editor/src/utils/analytics.ts
+++ b/noodles-editor/src/utils/analytics.ts
@@ -301,6 +301,16 @@ export class AnalyticsManager {
       return
     }
 
+    // Filter benign ResizeObserver errors
+    // These are harmless browser optimization warnings that occur when ResizeObserver
+    // callbacks trigger layout changes. They don't indicate actual problems and
+    // would create noise in error tracking.
+    const message = error.message || ''
+    if (message.includes('ResizeObserver loop')) {
+      debugAnalytics('Filtered benign ResizeObserver error from analytics')
+      return
+    }
+
     // PostHog exception capture
     if (this.posthogInitialized) {
       try {


### PR DESCRIPTION
#### Background
PostHog showed 4 error categories affecting 7+ users across 20+ occurrences. This PR fixes them holistically with defensive programming, proper error handling, and targeted filtering.

#### Change List
- **ChartOp yField TypeError** (2 users/incident): Add field validation before Observable Plot calls, wrap in try-catch with analytics capture
- **Zod _zod access TypeError** (Safari): Add null guards before all `._zod` accesses (5 locations), schema validation before property access
- **ResizeObserver loop errors** (4 users, 7 occurrences): Filter benign browser warnings at both window handler and analytics layer
- **DuckDB errors** (1 user, 9 occurrences): Console logging for debugging, skip PostHog for typing-related errors (incomplete queries)
- **35 new tests** covering all error edge cases, comprehensive error filtering validation