### PR TITLE
Agentic runtime options: on-device tier, run_code, and an agent filesystem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -694,8 +694,11 @@ has.
 Five things to know before changing it:
 
 1. **`tool-definitions.ts` + `mcp-tools.ts` stay the single source of truth** for the
-   tool surface. WebMCP (`src/webmcp/`) registers all of them unconditionally; the
-   chat reaches them through routing.
+   tool surface. WebMCP (`src/webmcp/`) registers every one it is offered; the chat
+   reaches them through routing. Read the surface through
+   `availableToolDefinitions()` / `getToolDefinition()`, never off the raw
+   `toolDefinitions` array — `run_code` is gated on `safeMode` via `available?()` and
+   has to vanish from discovery *and* dispatch together.
 2. **Only 5 tools are sent by default.** `list_nodes`, `get_node_info`,
    `get_node_output`, `apply_modifications`, `find_tools`. The model calls
    `find_tools({query})` to unlock the rest, so a new tool needs a good description —
@@ -711,6 +714,12 @@ Five things to know before changing it:
 5. **Which provider runs is `providerPreference` in `noodles/keys-store.tsx`**, not
    the model store. `'automatic'` picks the first of anthropic → openrouter → custom
    → chrome that has a credential.
+
+One security boundary lives in this code: `resolvePath()` in `ai-chat/agent-files.ts`.
+The assistant reads anywhere under the project's `data/` directory but writes only
+inside `data/.agent/`, and the check runs on the *resolved* path segments so a `../`
+cannot escape. Any new filesystem tool must go through it rather than calling
+`writeAsset` directly.
 
 Full details, including the measured before/after context cost, are in
 [dev-docs/agent-harness.md](dev-docs/agent-harness.md).
@@ -753,7 +762,7 @@ Load it in the browser at `http://localhost:5173/examples/<project-name>` to vis
 
 #### WebMCP (recommended)
 
-With `?externalControl=true`, the app registers its full AI tool surface (~22 tools) on `navigator.modelContext` (the W3C WebMCP API, polyfilled via `@mcp-b/global`). External MCP clients reach those tools through the `@mcp-b/webmcp-local-relay` stdio bridge — no proxy code to run:
+With `?externalControl=true`, the app registers its full AI tool surface (~27 tools) on `navigator.modelContext` (the W3C WebMCP API, polyfilled via `@mcp-b/global`). External MCP clients reach those tools through the `@mcp-b/webmcp-local-relay` stdio bridge — no proxy code to run:
 
 ```bash
 # 1. Start the app with external control enabled
@@ -773,7 +782,7 @@ claude mcp add webmcp -- npx -y @mcp-b/webmcp-local-relay@4
 }
 ```
 
-Tool names match the in-app chat (snake_case): `get_current_project`, `list_nodes`, `get_node_info`, `get_node_output`, `apply_modifications`, `capture_visualization`, `get_timeline`, `set_keyframe`, `get_operator_schema`, `search_code`, and more. `apply_modifications` mutates the live editor graph, so changes appear immediately in the browser.
+Tool names match the in-app chat (snake_case): `get_current_project`, `list_nodes`, `get_node_info`, `get_node_output`, `apply_modifications`, `run_code`, `list_files`, `read_file`, `write_file`, `grep_files`, `capture_visualization`, `get_timeline`, `set_keyframe`, `get_operator_schema`, `search_code`, and more. `apply_modifications` mutates the live editor graph, so changes appear immediately in the browser.
 
 Notes:
 

--- a/dev-docs/agent-harness.md
+++ b/dev-docs/agent-harness.md
@@ -1,6 +1,6 @@
 # Agent harness (in-app AI chat)
 
-**Last updated:** 2026-09-03
+**Last updated:** 2026-09-08
 
 The in-app assistant runs on a hand-rolled agent loop in `noodles-editor/src/ai-chat/agent/`.
 It is provider-agnostic: the same loop, tool surface, and context budgets serve a
@@ -39,7 +39,7 @@ unconditionally and is unaffected by any of the routing below.
 | | Anthropic | OpenRouter | Custom | Chrome |
 | --- | --- | --- | --- | --- |
 | Default model | `claude-sonnet-5` | `google/gemini-2.5-flash` | whatever you type | `gemini-nano` |
-| Context window | 200k | per-model table, 128k fallback | configurable, 32k default | discovered at runtime (~6k) |
+| Context window | 200k | per-model table, 128k fallback | configurable, 32k default | discovered at runtime (~6k), and measured per turn |
 | Native tool calling | yes | yes | assumed, switchable off | **no** — constrained JSON |
 | Images (screenshots) | yes | yes | off by default | no |
 | Web search | server-side `web_search_2026…`/`…20250305` | `plugins: [{id:'web'}]` | unavailable | unavailable |
@@ -75,6 +75,68 @@ Two provider flags carry all the behavioural difference: `supportsNativeTools`
 same `tool_call` event the others emit) and `contextWindow` (which sizes the
 disclosure limits, the per-result budget, the step limit, and the compaction
 threshold).
+
+`AgentProvider.dispose()` is optional and only Chrome implements it: an HTTP
+provider holds nothing between turns, an on-device session holds the transcript.
+`AgentSession.dispose()` forwards to it, and `chat-panel.tsx` calls that from its
+init effect's cleanup — including for a session that was superseded while still
+being built.
+
+### The Chrome provider's session
+
+Unlike an HTTP provider, which is handed the whole history on every request, a
+Prompt API session *accumulates* it. So the provider keeps one session across turns
+and sends only the messages that session has not seen, which makes two things true:
+
+- The system prompt and the tool schemas live in `initialPrompts`, which the API
+  documents as never evicted. They are paid for once per conversation instead of
+  once per turn, and they survive a conversation that overflows the window.
+- Reuse is only valid while the transcript is being *extended*. Each turn's
+  messages are serialized to one line apiece and diffed against what was sent; a
+  changed prefix (compaction, the loop's own trimming, a cleared conversation) or a
+  changed tool set (`find_tools` unlocking one rewrites the schemas) rebuilds the
+  session, because a session cannot forget and `initialPrompts` cannot be amended.
+
+Overflow is handled before the API throws: `measureContextUsage()` is checked
+against `contextWindow - contextUsage`, and a turn that will not fit rebuilds on a
+trimmed transcript. `QuotaExceededError` remains caught as a backstop, since the
+measurement is optional and can undercount.
+
+### Native tool calling on the Prompt API: not yet
+
+MDN documents a `tools: [{name, description, inputSchema, execute}]` option on
+`LanguageModel.create()`, which would replace the emulation above with
+grammar-constrained tool calls. It is spec, not implementation. Measured against
+Chrome 152 (2026-09-07):
+
+| Probe | Result | Reading |
+| --- | --- | --- |
+| `create({initialPrompts: 42})` | `TypeError: … cannot be converted to a sequence` | declared member |
+| `create({tools: 42})` | `NotSupportedError` | **ignored** |
+| `create({totallyMadeUpOption: 42})` | `NotSupportedError` | control |
+| `availability({expectedOutputs: [{type: 'tool-call'}]})` | `'unavailable'` | `tool-call` is in the shipped enum |
+| `availability({expectedOutputs: [{type: 'not-a-real-type'}]})` | `TypeError: … not a valid enum value` | control |
+
+WebIDL converts arguments in the binding layer before the method body runs, so those
+readings hold on a machine where the model itself is absent. Chrome's own tracker
+agrees: *Function Calling capability in Prompt API* is `Proposed` — no milestone, no
+dev trial, no flag.
+
+The trap is in rows 4 and 5: the `tool-call` message type shipped **ahead** of the
+`tools` option, so a probe that passed a well-formed tool plus
+`expectedOutputs: [{type: 'tool-call'}]` and watched for a rejection would report
+support that is not there. `nativeToolSupport()` therefore reads IDL conversion
+instead — it hands `tools` a non-sequence and treats a `TypeError` as the signal,
+with a control call so an engine that rejects every `create()` cannot pass.
+
+It is reported but not yet wired, and wiring it is not a swap: those tools take an
+`execute` callback the browser invokes itself, awaiting all of them before the model
+replies, whereas `AgentProvider.stream()` yields tool calls out for the loop to
+schedule — and the loop is what serializes anything mutating. Adopting it means
+holding a `prompt()` promise open across `stream()` calls and resolving it from the
+next request's tool result. MDN also notes `execute`'s arguments are "specific to the
+model being used", which is not something to write a provider against until there is
+a real implementation to read.
 
 Adding a provider means implementing `AgentProvider.stream()` to yield
 `text_delta` / `tool_call` / `usage` / `stop` events, adding it to `ProviderId`, and
@@ -131,6 +193,129 @@ marked on strings, so the payload is always valid JSON.
 The budget is 10% of the window in chars, clamped to 600–24,000 — so the same
 `list_nodes` call fits a 200k model and a 6k one.
 
+## `run_code`
+
+`run_code({code, timeoutMs})` evaluates JavaScript against the live graph and returns
+the value. It is CodeOp's sandbox without a node: `fnWithSource` compiles the body,
+`op('/id').out.data` / `.par.field` read any operator, and `d3`, `turf`, `deck`,
+`Plot`, `Temporal`, `utils` and every operator class are in scope, plus
+`sequenceTime` / `frame` / `totalFrames` / `sequence`. `await` is allowed. The
+implementation is `src/ai-chat/run-code.ts`; `MCPTools.runCode` is a one-line
+forwarder so the tool definitions and WebMCP still reach everything through one
+surface.
+
+This is the largest single capability jump in the harness and it benefits every
+provider at once — a model that could previously only *describe* a transform can now
+check whether it works.
+
+Four things about it are deliberate:
+
+- **Results are summarized in `describe()` before `capToolResult` ever sees them.**
+  The budget caps what reaches the model, but it serializes the whole value first, so
+  returning a million-row array would build hundreds of megabytes of string just to
+  throw it away. Arrays over 20 items come back as `{length, sample, note}`; typed
+  arrays, `Map`/`Set` and operators get their own summaries; `NaN` and `Infinity`
+  render as `[NaN]` / `[Infinity]`, because `JSON.stringify` turns them into `null`
+  and "no value" is the wrong thing for a model to read when the arithmetic went
+  wrong.
+- **Field-value changes land in one undo entry**, via the non-React
+  `captureOperatorInputs` / `firePropertyMutation` pair. Pure computation creates no
+  entry at all, and a call that did change something reports `changedFieldValues`.
+  This only covers field values — adding or deleting operators goes through
+  `apply_modifications`, which the UI applies with its own history — so the tool
+  description points structural edits there.
+- **`timeoutMs` bounds the await, not the code.** A synchronous infinite loop hangs
+  the tab and no amount of racing changes that; the only real fix is a worker, and a
+  worker cannot see the graph, which is the point of the tool. What the timeout does
+  catch is the realistic hang: an `await` on a fetch that never resolves, which would
+  otherwise wedge the loop with no step limit to save it. The timeout message says so
+  rather than implying the code was cancelled.
+- **`readOnlyHint: false`**, so the loop serializes it instead of batching it with
+  reads.
+
+`ToolDefinition` gained an optional `available?: () => boolean` for this tool and,
+for now, only this tool. Safe mode (`?safeMode=true`) exists to stop the app
+executing arbitrary code, so `run_code` has to *disappear* rather than be offered and
+then refuse — a tool the model can see but that always fails wastes turns. The gate
+is read through `getToolDefinition` and `availableToolDefinitions()`, never off the
+raw `toolDefinitions` array, which covers three surfaces at once: `find_tools`
+scoring, `webmcp/register.ts`, and dispatch. Dispatch matters as much as discovery,
+because `executeTool` looks tools up by name and a model can name one it was never
+offered; an undefined lookup becomes "Unknown tool" and makes `isReadOnly` fall back
+to treating the call as mutating.
+
+`run_code` is not tier 0, so it costs nothing per turn — the model reaches it through
+`find_tools`, whose description now leads with "running JavaScript against the live
+graph". That is why the measured always-sent schema payload below is unchanged by
+adding it.
+
+## The agent filesystem
+
+`list_files`, `read_file`, `write_file` and `grep_files` give the assistant the
+project's own data directory. The implementation is `src/ai-chat/agent-files.ts`, a
+thin layer over the same `readAsset` / `writeAsset` / `listDataFiles` in
+`noodles/storage.ts` that a `FileOp` uses — which is the whole point. A file written to
+`@/.agent/joined.csv` is loadable by setting a `FileOp`'s `url` to that path, with no
+import step, so the model can compute a derived dataset in `run_code`, persist it, wire
+it into the graph, and confirm the result with `get_node_output`.
+
+**Reads and writes are deliberately asymmetric.** Reads resolve anywhere under `data/`,
+because that is data the project already exposes to the assistant through its nodes.
+Writes are rejected unless the resolved path is inside `data/.agent/`, so a mistaken
+path cannot clobber the dataset the project is built on.
+
+`resolvePath()` is the security boundary and is tested directly and exhaustively
+(`agent-files.test.ts`). Three things about it:
+
+- **Resolve, then check.** Segments are walked onto a stack that refuses to pop past
+  the root, and the write check runs on the resolved segments. A blocklist of `..`
+  spellings would be whack-a-mole; a stack cannot be talked out of it.
+  `.agent/../trips.csv` is rejected and `.agent/../.agent/out.csv` is allowed, which is
+  exactly the distinction a string check gets wrong.
+- **`@/` and `data/` prefixes are both accepted**, because both are spellings the model
+  has already seen — the first in a `FileOp` url, the second in project JSON. An
+  interior `..` resolves rather than being refused; refusing a legal path teaches the
+  model to distrust the tool.
+- **Absolute paths, backslashes and NUL bytes are refused by name.** A backslash is a
+  legal POSIX filename character, so treating it as a separator would be wrong — but a
+  Windows-shaped path is a mistake worth reporting rather than silently honouring as a
+  file called `..\secrets`.
+
+Two deviations from the plan, both deliberate:
+
+- **Writes are not in the undo stack.** `UndoRedoManager` snapshots
+  `projectState: NodesProjectJSON` and keeps 50 entries; putting file contents there
+  would make undo a memory problem. Instead, replacing a scratch file copies the
+  previous contents to `@/.agent/.previous/<path>`, which is hidden from `list_files`
+  and `grep_files` and is itself not writable. Combined with the write sandbox — which
+  by construction contains no user data — a bad write is recoverable without a prompt,
+  which is what the no-prompts decision was actually for.
+- **`read_file` summarizes before `result-budget` sees it**, same reasoning as
+  `run_code`: a file up to 200 lines and 20,000 chars comes back whole, anything larger
+  comes back as a line count plus 30 head lines and 10 tail lines, and
+  `startLine`/`endLine` page through it. A 50,000-line CSV yields under 4,000 chars.
+  Non-text files (detected by a NUL byte) are refused with a pointer at `FileOp` and
+  `run_code` rather than being mangled into the transcript.
+
+Storage type matters for writes: examples load into `memory` storage (`noodles.tsx`
+copies their assets there), so writes work in `/examples/*`. `publicFolder` is
+read-only and `writeAsset`'s refusal is surfaced verbatim.
+
+`grep_files` is plain JS `RegExp` over the files — no wasm toolchain for something that
+is a loop. It caps matches (40), per-file size (50M chars) and total scanned (100M
+chars), and reports every file it skipped, because a grep that silently misses a file
+is worse than a slow one. The per-file cap started at 4M and was raised after it
+skipped `nyc-taxis`' only data file: it bounds scan time, not memory, since `readAsset`
+has already materialized the whole string either way. Measured, a match on that 12M-char
+CSV takes ~11ms.
+
+One supporting fix was needed underneath: `getFileHandle` rejects any name containing
+`/`, so a nested path was unaddressable on `fileSystemAccess` and `opfs`. That was
+already a latent bug — `listDataFiles` emits nested paths like `raw/notes.txt` that
+`readAsset` could not then read — and `resolveParent()` in
+`noodles/utils/filesystem.ts` now walks the segments at that choke point, creating
+intermediate directories on write and never on read.
+
 ## Harness tools
 
 Two tools need something the tool definitions have no access to (a provider, an API
@@ -185,10 +370,10 @@ the old `listNodes` shape copied verbatim.
 | Per-turn component | Before | After | Change |
 | --- | --- | --- | --- |
 | System prompt | 9,278 chars (~2,300 tok) | 2,910 chars (~730 tok) | −69% |
-| Tool schemas | 4,291 chars, 13 tools (~1,070 tok) | 2,183 chars, 5 tools (~550 tok) | −49% |
+| Tool schemas | 4,291 chars, 13 tools (~1,070 tok) | 2,292 chars, 5 tools (~570 tok) | −47% |
 | One `list_nodes` result (200k window) | 18,447 chars (~4,600 tok) | 11,462 chars (~2,870 tok) | −38% |
 | One `list_nodes` result (6k window) | 18,447 chars (~4,600 tok) | 1,637 chars (~410 tok) | −91% |
-| **First turn, all three** | ~32,000 chars (~8,000 tok) | ~16,600 chars (~4,150 tok) | **−48%** |
+| **First turn, all three** | ~32,000 chars (~8,000 tok) | ~16,700 chars (~4,175 tok) | **−48%** |
 
 The `list_nodes` saving is the slimming alone (role groupings carry ids instead of
 re-serialized node objects; `position` dropped; long string inputs clipped to a
@@ -215,7 +400,10 @@ cd noodles-editor && npx vitest run src/ai-chat src/webmcp
 `loop.test.ts` drives the loop with a fake provider yielding scripted events;
 `providers/*.test.ts` cover SSE fragment reassembly (`openai-format.test.ts`),
 request shaping and endpoint validation (`custom.test.ts`), and constrained-JSON
-parsing (`chrome.test.ts`) against fakes. No test spends a real API request.
+parsing, session reuse and invalidation, and measure-before-overflow trimming
+(`chrome.test.ts`) against fakes. `chrome.test.ts`'s fake mints one session per
+`create()` call, which is what lets a test tell reuse from a rebuild. No test spends
+a real API request.
 
 End-to-end checks that do need keys are listed in the PR description for this work:
 streaming and Stop on Anthropic, cost readout on OpenRouter, `find_tools` →

--- a/docs/users/ai-assistant.md
+++ b/docs/users/ai-assistant.md
@@ -136,6 +136,11 @@ The assistant has access to powerful tools to help you:
 - Delete nodes and connections
 - Create complete visualizations from scratch
 
+**Data & Computation:**
+- Run JavaScript against your live graph to compute a result
+- List, read, and search your project's data files
+- Write a derived dataset to `@/.agent/` and load it with a FileOp
+
 **Documentation & Examples:**
 - Search the Noodles.gl documentation
 - Find relevant code examples

--- a/noodles-editor/src/ai-chat/agent-files.test.ts
+++ b/noodles-editor/src/ai-chat/agent-files.test.ts
@@ -1,0 +1,385 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useFileSystemStore } from '../noodles/filesystem-store'
+import { readAsset } from '../noodles/storage'
+import { memoryProjectStore } from '../noodles/utils/memory-project-store'
+import { capToolResult } from './agent/result-budget'
+import { scoreTools } from './agent/tool-router'
+import { grepFiles, listFiles, readFile, resolvePath, writeFile } from './agent-files'
+
+const PROJECT = 'agent-files-test'
+
+// A NUL written as an escape rather than as a literal byte, so the source file stays
+// text and greppable
+const NUL = '\u0000'
+
+function data(result: { data?: unknown }): Record<string, unknown> {
+  return (result.data ?? {}) as Record<string, unknown>
+}
+
+// Examples load into memory storage (noodles.tsx copies their assets there), so the
+// memory store is the realistic backing for these tools, not a stand-in
+function put(name: string, contents: string): void {
+  memoryProjectStore.writeAsset(PROJECT, name, contents)
+}
+
+beforeEach(() => {
+  memoryProjectStore.deleteProject(PROJECT)
+  useFileSystemStore.setState({ activeStorageType: 'memory', currentProjectName: PROJECT })
+  put('trips.csv', 'id,fare,borough\n1,12.5,Queens\n2,31.0,Manhattan\n')
+  put('zones.geojson', '{"type":"FeatureCollection","features":[]}\n')
+  put('raw/notes.txt', 'nothing to see\n')
+})
+
+// The guard is the security boundary for the whole module, so it is tested directly
+// and exhaustively rather than only through the tools that call it.
+describe('the path guard', () => {
+  it('accepts a plain relative path', () => {
+    expect(resolvePath('trips.csv')).toEqual({ ok: true, relative: 'trips.csv' })
+  })
+
+  it('accepts both spellings the model will have seen', () => {
+    // @/ is what appears in a FileOp's url; data/ is what appears in project JSON
+    expect(resolvePath('@/trips.csv')).toEqual({ ok: true, relative: 'trips.csv' })
+    expect(resolvePath('data/trips.csv')).toEqual({ ok: true, relative: 'trips.csv' })
+  })
+
+  it('normalizes redundant separators and dots', () => {
+    expect(resolvePath('./raw//notes.txt')).toEqual({ ok: true, relative: 'raw/notes.txt' })
+    expect(resolvePath('  trips.csv  ')).toEqual({ ok: true, relative: 'trips.csv' })
+  })
+
+  it('resolves an interior .. instead of rejecting the string', () => {
+    // Rejecting any path containing '..' would be simpler and wrong: this is a legal
+    // path to raw/notes.txt, and refusing it teaches the model to distrust the tool
+    expect(resolvePath('raw/../raw/notes.txt')).toEqual({ ok: true, relative: 'raw/notes.txt' })
+  })
+
+  it.each([
+    '../secrets.txt',
+    'raw/../../secrets.txt',
+    '@/../../etc/passwd',
+    'data/../../..',
+    'a/b/../../../c',
+  ])('rejects an escape attempt: %s', path => {
+    const result = resolvePath(path)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/outside the project data directory/)
+  })
+
+  it('rejects absolute paths', () => {
+    const result = resolvePath('/etc/passwd')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/not absolute/)
+  })
+
+  it('rejects a backslash rather than treating it as a separator', () => {
+    // A backslash is legal in a POSIX name, so silently accepting `..\secrets` would
+    // create a strangely-named file; naming the mistake is more useful
+    const result = resolvePath('..\\secrets.txt')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/Use \/ to separate/)
+  })
+
+  it('rejects a null byte', () => {
+    const result = resolvePath(`trips.csv${NUL}.png`)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/null byte/)
+  })
+
+  it.each(['', '   '])('rejects an empty path: %j', path => {
+    expect(resolvePath(path).ok).toBe(false)
+  })
+
+  it('allows a write inside the scratch directory', () => {
+    expect(resolvePath('.agent/out.csv', { forWrite: true })).toEqual({
+      ok: true,
+      relative: '.agent/out.csv',
+    })
+    expect(resolvePath('@/.agent/sub/out.csv', { forWrite: true })).toEqual({
+      ok: true,
+      relative: '.agent/sub/out.csv',
+    })
+  })
+
+  it.each([
+    'trips.csv',
+    'data/trips.csv',
+    '@/zones.geojson',
+    'raw/notes.txt',
+    '.agentx/out.csv',
+    '.agent',
+    'sub/.agent/out.csv',
+  ])('rejects a write outside the scratch directory: %s', path => {
+    const result = resolvePath(path, { forWrite: true })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/only allowed inside @\/\.agent\//)
+  })
+
+  it('checks the resolved path for writes, not the string', () => {
+    // The whole reason resolution comes first: this one *looks* like it is inside the
+    // scratch directory and is not, and this one looks like it leaves and does not
+    expect(resolvePath('.agent/../trips.csv', { forWrite: true }).ok).toBe(false)
+    expect(resolvePath('.agent/../.agent/out.csv', { forWrite: true })).toEqual({
+      ok: true,
+      relative: '.agent/out.csv',
+    })
+  })
+
+  it('refuses to write into the backup directory', () => {
+    const result = resolvePath('.agent/.previous/out.csv', { forWrite: true })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/not writable/)
+  })
+})
+
+describe('list_files', () => {
+  it('lists the project data files and names the scratch directory', async () => {
+    const result = await listFiles({})
+    expect(result.success).toBe(true)
+    expect(data(result).files).toEqual(['raw/notes.txt', 'trips.csv', 'zones.geojson'])
+    expect(data(result).count).toBe(3)
+    expect(data(result).scratchDirectory).toBe('@/.agent/')
+  })
+
+  it('scopes to a subdirectory', async () => {
+    const result = await listFiles({ path: 'raw' })
+    expect(data(result).files).toEqual(['raw/notes.txt'])
+    expect(data(result).directory).toBe('@/raw')
+  })
+
+  it('hides the backup directory', async () => {
+    put('.agent/out.csv', 'a\n')
+    put('.agent/.previous/out.csv', 'old\n')
+    const files = data(await listFiles({})).files as string[]
+    expect(files).toContain('.agent/out.csv')
+    expect(files).not.toContain('.agent/.previous/out.csv')
+  })
+
+  it('truncates a long listing and says so', async () => {
+    for (let i = 0; i < 20; i++) put(`bulk/f${i}.csv`, 'x\n')
+    const result = await listFiles({ maxResults: 5 })
+    expect((data(result).files as string[]).length).toBe(5)
+    expect(data(result).count).toBe(23)
+    expect(data(result).truncated).toMatch(/showing 5 of 23/)
+  })
+
+  it('rejects a path that escapes the data directory', async () => {
+    const result = await listFiles({ path: '../..' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('read_file', () => {
+  it('returns a small file whole', async () => {
+    const result = await readFile({ path: '@/trips.csv' })
+    expect(result.success).toBe(true)
+    expect(data(result).content).toContain('1,12.5,Queens')
+    expect(data(result).path).toBe('@/trips.csv')
+  })
+
+  it('names the missing file in the error', async () => {
+    const result = await readFile({ path: 'nope.csv' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/nope\.csv/)
+  })
+
+  it('refuses a file that is not text', async () => {
+    put('tile.png', `PNG${NUL}${NUL}data`)
+    const result = await readFile({ path: 'tile.png' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not a text file/)
+  })
+
+  it('pages through a file with startLine/endLine', async () => {
+    put('big.csv', Array.from({ length: 100 }, (_, i) => `row ${i}`).join('\n'))
+    const result = await readFile({ path: 'big.csv', startLine: 10, endLine: 12 })
+    expect(data(result).range).toBe('10-12')
+    expect(data(result).content).toBe('row 9\nrow 10\nrow 11')
+  })
+
+  it('clamps a range that runs past the end of the file', async () => {
+    const result = await readFile({ path: 'trips.csv', startLine: 3, endLine: 900 })
+    expect(data(result).range).toBe('3-4')
+  })
+
+  it('summarizes a file too large to send, rather than sending it', async () => {
+    // The point of the tool: a 50MB CSV must not be able to enter the transcript, so
+    // the summary happens here and run_code is where the full contents get used
+    const lines = Array.from({ length: 50_000 }, (_, i) => `${i},${i * 1.5},Queens`)
+    put('huge.csv', lines.join('\n'))
+
+    const result = await readFile({ path: 'huge.csv' })
+    expect(result.success).toBe(true)
+    expect(data(result).content).toBeUndefined()
+    expect(data(result).lines).toBe(50_000)
+    expect((data(result).head as string[]).length).toBe(30)
+    expect((data(result).tail as string[]).length).toBe(10)
+    expect(data(result).note).toMatch(/run_code/)
+
+    const capped = capToolResult('read_file', result, 24_000)
+    expect(capped.truncated).toBe(false)
+    expect(capped.chars).toBeLessThan(4000)
+  })
+
+  it('clips a single absurdly long line', async () => {
+    put('wide.csv', `${'x'.repeat(5000)}\n${'y'.repeat(5000)}\n`.repeat(200))
+    const result = await readFile({ path: 'wide.csv' })
+    for (const line of data(result).head as string[]) {
+      expect(line.length).toBeLessThan(500)
+    }
+  })
+})
+
+describe('write_file', () => {
+  it('writes into the scratch directory and returns a FileOp-ready path', async () => {
+    const result = await writeFile({ path: '.agent/joined.csv', content: 'a,b\n1,2\n' })
+    expect(result.success).toBe(true)
+    expect(data(result).path).toBe('@/.agent/joined.csv')
+    expect(data(result).bytes).toBe(8)
+    expect(data(result).note).toMatch(/FileOp/)
+
+    // The payoff loop: what was written is what a FileOp would load
+    const read = await readAsset('memory', PROJECT, '.agent/joined.csv')
+    expect(read.success && read.data).toBe('a,b\n1,2\n')
+  })
+
+  it('reads back through read_file', async () => {
+    await writeFile({ path: '@/.agent/notes.md', content: '# scratch\n' })
+    const result = await readFile({ path: '@/.agent/notes.md' })
+    expect(data(result).content).toBe('# scratch\n')
+  })
+
+  it('refuses to overwrite the project data', async () => {
+    const result = await writeFile({ path: 'trips.csv', content: 'clobbered' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/only allowed inside/)
+
+    const read = await readAsset('memory', PROJECT, 'trips.csv')
+    expect(read.success && read.data).toContain('12.5')
+  })
+
+  it('keeps the previous contents when it replaces a scratch file', async () => {
+    // Not undo — UndoRedoManager snapshots project JSON, not files — but a clobbered
+    // scratch file has to be recoverable, and the copy stays inside the sandbox
+    await writeFile({ path: '.agent/out.csv', content: 'first\n' })
+    const second = await writeFile({ path: '.agent/out.csv', content: 'second\n' })
+
+    expect(data(second).replaced).toBe(true)
+    expect(data(second).previousContentsAt).toBe('@/.agent/.previous/out.csv')
+
+    const previous = await readAsset('memory', PROJECT, '.agent/.previous/out.csv')
+    expect(previous.success && previous.data).toBe('first\n')
+  })
+
+  it('reports no replacement on a first write', async () => {
+    const result = await writeFile({ path: '.agent/fresh.csv', content: 'x\n' })
+    expect(data(result).replaced).toBeUndefined()
+  })
+
+  it('requires string content', async () => {
+    const result = await writeFile({ path: '.agent/x.csv', content: 42 as unknown as string })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/string/)
+  })
+
+  it('reports read-only storage rather than failing silently', async () => {
+    // publicFolder is how a deployed example loads before its assets are copied into
+    // memory; writeAsset already refuses, and that refusal has to reach the model
+    useFileSystemStore.setState({ activeStorageType: 'publicFolder' })
+    const result = await writeFile({ path: '.agent/x.csv', content: 'x' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/public folder/)
+  })
+})
+
+describe('grep_files', () => {
+  it('reports file, line number and matching text', async () => {
+    const result = await grepFiles({ pattern: 'Manhattan' })
+    expect(result.success).toBe(true)
+    expect(data(result).matches).toEqual([
+      { file: '@/trips.csv', line: 3, text: '2,31.0,Manhattan' },
+    ])
+  })
+
+  it('is case-sensitive unless asked otherwise', async () => {
+    expect(data(await grepFiles({ pattern: 'manhattan' })).count).toBe(0)
+    expect(data(await grepFiles({ pattern: 'manhattan', ignoreCase: true })).count).toBe(1)
+  })
+
+  it('returns context lines when asked', async () => {
+    const match = (
+      data(await grepFiles({ pattern: 'Manhattan', contextLines: 1 })).matches as {
+        before: string[]
+        after: string[]
+      }[]
+    )[0]
+    expect(match.before).toEqual(['1,12.5,Queens'])
+    expect(match.after).toEqual([''])
+  })
+
+  it('scopes to a subdirectory', async () => {
+    put('raw/other.txt', 'nothing here\n')
+    const result = await grepFiles({ pattern: 'nothing', path: 'raw' })
+    expect(data(result).count).toBe(2)
+    expect(data(await grepFiles({ pattern: 'nothing', path: 'raw' })).filesScanned).toBe(2)
+  })
+
+  it('stops at maxResults and says so', async () => {
+    put('bulk.csv', Array.from({ length: 100 }, () => 'Queens').join('\n'))
+    const result = await grepFiles({ pattern: 'Queens', maxResults: 5 })
+    expect(data(result).count).toBe(5)
+    expect(data(result).truncated).toMatch(/stopped at 5 matches/)
+  })
+
+  it('skips a binary file and reports which', async () => {
+    put('tile.png', `PNG${NUL}Queens`)
+    const result = await grepFiles({ pattern: 'Queens' })
+    expect(data(result).skipped).toEqual(['@/tile.png'])
+    expect((data(result).matches as unknown[]).length).toBeGreaterThan(0)
+  })
+
+  it('reports an invalid pattern instead of throwing', async () => {
+    const result = await grepFiles({ pattern: '([unclosed' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Invalid pattern/)
+  })
+
+  it('requires a pattern', async () => {
+    const result = await grepFiles({ pattern: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// None of these are tier 0, so the only way the model reaches them is find_tools
+// scoring their descriptions — a files tool nobody can find is a files tool nobody has
+describe('finding the files tools', () => {
+  it.each([
+    ['what data files does this project have', 'list_files'],
+    ['read a csv file', 'read_file'],
+    ['save a derived dataset to disk', 'write_file'],
+    ['search the data files for a column name', 'grep_files'],
+  ])('finds %s → %s', (query, expected) => {
+    const top = scoreTools(query)
+      .slice(0, 4)
+      .map(match => match.name)
+    expect(top).toContain(expected)
+  })
+})
+
+describe('with no project loaded', () => {
+  beforeEach(() => {
+    useFileSystemStore.setState({ currentProjectName: null })
+  })
+
+  it('says so rather than reading someone else’s data directory', async () => {
+    for (const result of [
+      await listFiles({}),
+      await readFile({ path: 'trips.csv' }),
+      await writeFile({ path: '.agent/x.csv', content: 'x' }),
+      await grepFiles({ pattern: 'x' }),
+    ]) {
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/No project is loaded/)
+    }
+  })
+})

--- a/noodles-editor/src/ai-chat/agent-files.ts
+++ b/noodles-editor/src/ai-chat/agent-files.ts
@@ -1,0 +1,384 @@
+// The agent filesystem: list_files, read_file, write_file, grep_files over the
+// project's own data directory.
+//
+// This is a thin layer over noodles/storage.ts — the same readAsset/writeAsset the
+// FileOp uses — so a file the assistant writes is loadable by a FileOp at
+// `@/.agent/name.csv` with no import step. That round trip is the point: write a
+// joined CSV, point a FileOp at it, and the graph renders it.
+//
+// The asymmetry is deliberate and load-bearing. Reads reach anywhere under `data/`,
+// because that is what the project already shows the assistant through its nodes.
+// Writes are confined to `data/.agent/`, so a mistaken path cannot clobber the
+// dataset the project is built on. Paths are resolved before they are checked, so a
+// `../` cannot climb out of the sandbox by construction rather than by blocklist.
+
+import { useFileSystemStore } from '../noodles/filesystem-store'
+import { listDataFiles, readAsset, writeAsset } from '../noodles/storage'
+import { projectScheme, type StorageType } from '../noodles/utils/filesystem'
+import type { ToolResult } from './types'
+
+// The only directory the assistant may write to, relative to the data directory
+export const AGENT_DIRECTORY = '.agent'
+
+// Where a write parks the previous contents of a file it replaced. Not undo — the
+// undo stack snapshots project JSON, not files — but enough that a clobbered scratch
+// file is recoverable, and it stays inside the write sandbox.
+const PREVIOUS_DIRECTORY = `${AGENT_DIRECTORY}/.previous`
+
+// A NUL byte means two different things here: in a path it is an attempt to confuse
+// a name-based check, and in file contents it means the file is not text
+const NUL = '\u0000'
+
+// A file this small comes back whole; anything larger is summarized, because
+// read_file feeds a transcript and run_code is the tool for bulk contents
+const INLINE_MAX_LINES = 200
+const INLINE_MAX_CHARS = 20_000
+const HEAD_LINES = 30
+const TAIL_LINES = 10
+const RANGE_MAX_LINES = 400
+
+const MAX_LINE_CHARS = 400
+const MAX_LISTED_FILES = 200
+
+const MAX_GREP_MATCHES = 40
+// Generous on purpose: nyc-taxis' single data file is 12M chars, and a cap that skips
+// the only file in the project makes the tool useless. This bounds scan time, not
+// memory — readAsset has already materialized the whole string either way.
+const MAX_GREP_FILE_CHARS = 50_000_000
+// Total across all files, so a grep over a directory of large CSVs terminates
+const MAX_GREP_TOTAL_CHARS = 100_000_000
+
+export interface ListFilesParams {
+  path?: string
+  maxResults?: number
+}
+
+export interface ReadFileParams {
+  path: string
+  startLine?: number
+  endLine?: number
+}
+
+export interface WriteFileParams {
+  path: string
+  content: string
+}
+
+export interface GrepFilesParams {
+  pattern: string
+  path?: string
+  contextLines?: number
+  maxResults?: number
+  ignoreCase?: boolean
+}
+
+export async function listFiles(params: ListFilesParams): Promise<ToolResult> {
+  const store = storageContext()
+  if (!store.ok) return { success: false, error: store.error }
+
+  const scope = params.path ? resolvePath(params.path) : { ok: true as const, relative: '' }
+  if (!scope.ok) return { success: false, error: scope.error }
+
+  const all = await visibleFiles(store, scope.relative)
+  if (!all.ok) return { success: false, error: all.error }
+
+  const requested = clamp(params.maxResults ?? MAX_LISTED_FILES, 1, MAX_LISTED_FILES)
+  const files = all.files.slice(0, requested)
+
+  return {
+    success: true,
+    data: {
+      directory: `${projectScheme}${scope.relative}`,
+      count: all.files.length,
+      files,
+      // Named on every listing so the model does not have to guess where it may write
+      scratchDirectory: `${projectScheme}${AGENT_DIRECTORY}/`,
+      ...(all.files.length > files.length
+        ? { truncated: `showing ${files.length} of ${all.files.length}; pass path to narrow` }
+        : {}),
+    },
+  }
+}
+
+export async function readFile(params: ReadFileParams): Promise<ToolResult> {
+  const store = storageContext()
+  if (!store.ok) return { success: false, error: store.error }
+
+  const target = resolvePath(params.path)
+  if (!target.ok) return { success: false, error: target.error }
+  if (!target.relative) return { success: false, error: 'read_file needs a file path' }
+
+  const read = await readAsset(store.type, store.project, target.relative)
+  if (!read.success) {
+    return { success: false, error: `${read.error.message} (${target.relative})` }
+  }
+
+  const text = read.data
+  if (text.includes(NUL)) {
+    return {
+      success: false,
+      error: `'${target.relative}' is not a text file. Load it with a FileOp, or read it in run_code.`,
+    }
+  }
+
+  const lines = text.split('\n')
+  const base = {
+    path: `${projectScheme}${target.relative}`,
+    lines: lines.length,
+    chars: text.length,
+  }
+
+  if (params.startLine !== undefined || params.endLine !== undefined) {
+    const start = clamp(params.startLine ?? 1, 1, lines.length)
+    const requestedEnd = clamp(params.endLine ?? lines.length, start, lines.length)
+    const end = Math.min(requestedEnd, start + RANGE_MAX_LINES - 1)
+    return {
+      success: true,
+      data: {
+        ...base,
+        range: `${start}-${end}`,
+        content: lines.slice(start - 1, end).join('\n'),
+      },
+    }
+  }
+
+  if (lines.length <= INLINE_MAX_LINES && text.length <= INLINE_MAX_CHARS) {
+    return { success: true, data: { ...base, content: text } }
+  }
+
+  return {
+    success: true,
+    data: {
+      ...base,
+      head: lines.slice(0, HEAD_LINES).map(clipLine),
+      tail: lines.slice(-TAIL_LINES).map(clipLine),
+      note: 'Too large to send whole. Pass startLine/endLine to page through it, or use run_code to work on the full contents.',
+    },
+  }
+}
+
+export async function writeFile(params: WriteFileParams): Promise<ToolResult> {
+  const store = storageContext()
+  if (!store.ok) return { success: false, error: store.error }
+
+  const target = resolvePath(params.path, { forWrite: true })
+  if (!target.ok) return { success: false, error: target.error }
+
+  if (typeof params.content !== 'string') {
+    return { success: false, error: 'write_file needs content as a string' }
+  }
+
+  // Read first: a replaced file's previous contents are the one thing this operation
+  // destroys, and the write sandbox is the only place they can be parked
+  const existing = await readAsset(store.type, store.project, target.relative)
+  let previousContentsAt: string | undefined
+  if (existing.success) {
+    const backup = `${PREVIOUS_DIRECTORY}/${target.relative.slice(AGENT_DIRECTORY.length + 1)}`
+    const saved = await writeAsset(store.type, store.project, backup, existing.data)
+    if (saved.success) previousContentsAt = `${projectScheme}${backup}`
+  }
+
+  const written = await writeAsset(store.type, store.project, target.relative, params.content)
+  if (!written.success) {
+    return { success: false, error: `${written.error.message} (${target.relative})` }
+  }
+
+  const path = `${projectScheme}${target.relative}`
+  return {
+    success: true,
+    data: {
+      path,
+      bytes: new TextEncoder().encode(params.content).length,
+      lines: params.content === '' ? 0 : params.content.split('\n').length,
+      ...(existing.success ? { replaced: true, previousContentsAt } : {}),
+      note: `Load it by setting a FileOp's url to ${path}`,
+    },
+  }
+}
+
+export async function grepFiles(params: GrepFilesParams): Promise<ToolResult> {
+  const store = storageContext()
+  if (!store.ok) return { success: false, error: store.error }
+
+  if (typeof params.pattern !== 'string' || params.pattern === '') {
+    return { success: false, error: 'grep_files needs a non-empty pattern' }
+  }
+
+  let regex: RegExp
+  try {
+    regex = new RegExp(params.pattern, params.ignoreCase ? 'i' : '')
+  } catch (error) {
+    return { success: false, error: `Invalid pattern: ${(error as Error).message}` }
+  }
+
+  const scope = params.path ? resolvePath(params.path) : { ok: true as const, relative: '' }
+  if (!scope.ok) return { success: false, error: scope.error }
+
+  const candidates = await visibleFiles(store, scope.relative)
+  if (!candidates.ok) return { success: false, error: candidates.error }
+
+  const context = clamp(params.contextLines ?? 0, 0, 5)
+  const limit = clamp(params.maxResults ?? 20, 1, MAX_GREP_MATCHES)
+
+  const matches: object[] = []
+  const skipped: string[] = []
+  let scanned = 0
+  let budget = MAX_GREP_TOTAL_CHARS
+  let truncated = false
+
+  for (const file of candidates.files) {
+    if (matches.length >= limit) {
+      truncated = true
+      break
+    }
+
+    const read = budget > 0 ? await readAsset(store.type, store.project, file) : undefined
+    // Unreadable, binary, or past the scan budget — all reported rather than
+    // silently dropped, because a grep that misses a file is worse than a slow one
+    if (!read?.success || read.data.includes(NUL) || read.data.length > MAX_GREP_FILE_CHARS) {
+      skipped.push(file)
+      continue
+    }
+
+    budget -= read.data.length
+    scanned++
+
+    const lines = read.data.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      if (!regex.test(lines[i])) continue
+      if (matches.length >= limit) {
+        truncated = true
+        break
+      }
+      matches.push({
+        file: `${projectScheme}${file}`,
+        line: i + 1,
+        text: clipLine(lines[i]),
+        ...(context > 0
+          ? {
+              before: lines.slice(Math.max(0, i - context), i).map(clipLine),
+              after: lines.slice(i + 1, i + 1 + context).map(clipLine),
+            }
+          : {}),
+      })
+    }
+  }
+
+  return {
+    success: true,
+    data: {
+      pattern: params.pattern,
+      filesScanned: scanned,
+      count: matches.length,
+      matches,
+      ...(skipped.length > 0 ? { skipped: skipped.map(file => `${projectScheme}${file}`) } : {}),
+      ...(truncated ? { truncated: `stopped at ${limit} matches; narrow the pattern` } : {}),
+    },
+  }
+}
+
+type Resolved = { ok: true; relative: string } | { ok: false; error: string }
+
+// The path guard. Every caller-supplied path goes through here first, and the check
+// happens on the *resolved* segments rather than on the raw string — a blocklist of
+// '..' spellings would be a game of whack-a-mole, whereas a stack that refuses to pop
+// past the root cannot be talked out of it.
+export function resolvePath(input: string, options: { forWrite?: boolean } = {}): Resolved {
+  if (typeof input !== 'string' || input.trim() === '') {
+    return { ok: false, error: 'A file path is required' }
+  }
+
+  let path = input.trim()
+  if (path.includes(NUL)) {
+    return { ok: false, error: 'Path contains a null byte' }
+  }
+  // A backslash is a legal character in a POSIX file name, so treating it as a
+  // separator would be wrong — but a path written for Windows is a mistake worth
+  // naming rather than silently creating a file called `..\secrets`
+  if (path.includes('\\')) {
+    return { ok: false, error: 'Use / to separate path segments' }
+  }
+
+  if (path.startsWith(projectScheme)) path = path.slice(projectScheme.length)
+  if (path.startsWith('/')) {
+    return {
+      ok: false,
+      error: `Paths are relative to the project data directory (e.g. ${AGENT_DIRECTORY}/notes.md), not absolute`,
+    }
+  }
+  // Both spellings reach the same place, and the model sees `data/…` in project JSON
+  path = path.replace(/^data\//, '')
+
+  const stack: string[] = []
+  for (const segment of path.split('/')) {
+    if (segment === '' || segment === '.') continue
+    if (segment === '..') {
+      if (stack.length === 0) {
+        return { ok: false, error: `'${input}' points outside the project data directory` }
+      }
+      stack.pop()
+      continue
+    }
+    stack.push(segment)
+  }
+
+  const relative = stack.join('/')
+
+  if (options.forWrite) {
+    if (stack.length < 2 || stack[0] !== AGENT_DIRECTORY) {
+      return {
+        ok: false,
+        error: `Writes are only allowed inside ${projectScheme}${AGENT_DIRECTORY}/ — got '${input}'. The rest of the data directory is the project's own input data and is read-only.`,
+      }
+    }
+    if (relative.startsWith(`${PREVIOUS_DIRECTORY}/`)) {
+      return {
+        ok: false,
+        error: `${projectScheme}${PREVIOUS_DIRECTORY}/ holds contents replaced by earlier writes and is not writable`,
+      }
+    }
+  }
+
+  return { ok: true, relative }
+}
+
+type StorageContext =
+  | { ok: true; type: StorageType; project: string }
+  | { ok: false; error: string }
+
+// The project a path is relative to. Examples load into memory storage, so this
+// works on a bundled example as well as a saved project.
+function storageContext(): StorageContext {
+  const { currentProjectName, activeStorageType } = useFileSystemStore.getState()
+  if (!currentProjectName) {
+    return { ok: false, error: 'No project is loaded, so there is no data directory to read' }
+  }
+  return { ok: true, type: activeStorageType, project: currentProjectName }
+}
+
+// Files under a directory, with the backup directory hidden — it exists to recover
+// from a mistake, not to be re-read or grepped
+async function visibleFiles(
+  store: { type: StorageType; project: string },
+  relative: string
+): Promise<{ ok: true; files: string[] } | { ok: false; error: string }> {
+  const listed = await listDataFiles(store.type, store.project)
+  if (!listed.success) return { ok: false, error: listed.error.message }
+
+  const prefix = relative ? `${relative}/` : ''
+  const files = listed.data
+    .filter(file => file.startsWith(prefix) && !file.startsWith(`${PREVIOUS_DIRECTORY}/`))
+    .sort()
+  return { ok: true, files }
+}
+
+function clipLine(line: string): string {
+  return line.length <= MAX_LINE_CHARS
+    ? line
+    : `${line.slice(0, MAX_LINE_CHARS)}…[clipped, ${line.length} chars]`
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min
+  return Math.min(max, Math.max(min, Math.floor(value)))
+}

--- a/noodles-editor/src/ai-chat/agent/context-cost.test.ts
+++ b/noodles-editor/src/ai-chat/agent/context-cost.test.ts
@@ -14,8 +14,15 @@ import type { NoodlesProject } from '../types'
 import { capToolResult, resultBudgetChars } from './result-budget'
 import { ToolRouter } from './tool-router'
 
-// The 9 tools the old client filtered out with exposeToChat: false
+// The 9 tools the old client filtered out with exposeToChat: false, plus tools that
+// did not exist then — counting a new capability against the old baseline would
+// flatter the comparison rather than measure it.
 const OLD_HIDDEN = new Set([
+  'run_code',
+  'list_files',
+  'read_file',
+  'write_file',
+  'grep_files',
   'search_code',
   'get_source_code',
   'get_operator_schema',

--- a/noodles-editor/src/ai-chat/agent/providers/chrome.test.ts
+++ b/noodles-editor/src/ai-chat/agent/providers/chrome.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentEvent, AgentRequest, AgentTool } from '../types'
-import { ChromeProvider, chromeAvailability, createChromeProvider, parseAction } from './chrome'
+import {
+  ChromeProvider,
+  chromeAvailability,
+  createChromeProvider,
+  nativeToolSupport,
+  parseAction,
+} from './chrome'
 
 const TOOLS: AgentTool[] = [
   {
@@ -15,37 +21,61 @@ const TOOLS: AgentTool[] = [
   },
 ]
 
+interface PromptMessage {
+  role: string
+  content: string
+}
+
 interface FakeSessionOptions {
   // One entry per prompt() call; a string resolves, an Error rejects
   responses: Array<string | Error>
   inputQuota?: number
+  contextWindow?: number
+  contextUsage?: number
+  // Tokens measureContextUsage reports for any input. Omitted, the session cannot
+  // measure at all, which is the shipped-Chrome case.
+  measured?: number
 }
 
 interface CreateOptions {
-  initialPrompts?: Array<{ role: string; content: string }>
+  initialPrompts?: PromptMessage[]
+  // Deliberately not an array type: the support probe passes a non-sequence
+  tools?: unknown
 }
 
+// One fake per create() call, so a test can tell session reuse from a rebuild.
 function stubLanguageModel(options: FakeSessionOptions & { availability?: string }) {
+  // Flattened across sessions: what the model was sent, in order
   const prompts: string[] = []
-  // The system prompt goes to create(), the transcript to prompt(), so both have
-  // to be captured to see what the model was actually sent
+  // The turn as the API received it, to assert roles and message boundaries
+  const turns: Array<string | PromptMessage[]> = []
   const created: CreateOptions[] = []
+  const sessions: Array<{ destroy: ReturnType<typeof vi.fn> }> = []
   let callIndex = 0
-
-  const session = {
-    prompt: vi.fn(async (input: string) => {
-      prompts.push(input)
-      const response = options.responses[callIndex++]
-      if (response instanceof Error) throw response
-      return response ?? '{"tool":"none","reply":"done"}'
-    }),
-    destroy: vi.fn(),
-    addEventListener: vi.fn(),
-    inputQuota: options.inputQuota,
-  }
 
   const create = vi.fn(async (createOptions: CreateOptions = {}) => {
     created.push(createOptions)
+
+    const session = {
+      prompt: vi.fn(async (input: string | PromptMessage[]) => {
+        turns.push(input)
+        prompts.push(
+          typeof input === 'string' ? input : input.map(message => message.content).join('\n')
+        )
+        const response = options.responses[callIndex++]
+        if (response instanceof Error) throw response
+        return response ?? '{"tool":"none","reply":"done"}'
+      }),
+      measureContextUsage:
+        options.measured === undefined ? undefined : vi.fn(async () => options.measured as number),
+      destroy: vi.fn(),
+      addEventListener: vi.fn(),
+      inputQuota: options.inputQuota,
+      contextWindow: options.contextWindow,
+      contextUsage: options.contextUsage,
+    }
+
+    sessions.push(session)
     return session
   })
 
@@ -54,7 +84,17 @@ function stubLanguageModel(options: FakeSessionOptions & { availability?: string
     create,
   })
 
-  return { session, created, prompts }
+  // `session` is the first one created, which is the only one most tests make
+  return {
+    get session() {
+      return sessions[0]
+    },
+    sessions,
+    created,
+    prompts,
+    turns,
+    create,
+  }
 }
 
 function request(overrides: Partial<AgentRequest> = {}): AgentRequest {
@@ -181,34 +221,86 @@ describe('ChromeProvider.stream', () => {
       })
     )
 
-    expect(prompts[0]).toContain('Assistant called list_nodes')
+    expect(prompts[0]).toContain('Called list_nodes')
     expect(prompts[0]).toContain('Result: {"nodeCount":12}')
   })
 
-  it('retries once with a trimmed transcript when the window overflows', async () => {
-    const quota = new Error('too big')
-    quota.name = 'QuotaExceededError'
-    const { prompts, session } = stubLanguageModel({
-      responses: [quota, '{"tool":"none","reply":"recovered"}'],
-    })
+  it('tags each message with its role rather than flattening the transcript', async () => {
+    const { turns } = stubLanguageModel({ responses: ['{"tool":"none","reply":"ok"}'] })
 
-    const events = await collect(
+    await collect(
       new ChromeProvider(),
       request({
         messages: [
-          { role: 'user', content: [{ type: 'text', text: 'first' }] },
-          { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
-          { role: 'user', content: [{ type: 'text', text: 'third' }] },
-          { role: 'assistant', content: [{ type: 'text', text: 'fourth' }] },
+          { role: 'user', content: [{ type: 'text', text: 'how many nodes?' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'twelve' }] },
+          { role: 'user', content: [{ type: 'text', text: 'and edges?' }] },
         ],
       })
     )
 
-    expect(session.prompt).toHaveBeenCalledTimes(2)
+    expect(turns[0]).toEqual([
+      { role: 'user', content: 'how many nodes?' },
+      { role: 'assistant', content: 'twelve' },
+      { role: 'user', content: 'and edges?' },
+    ])
+  })
+
+  const LONG_TRANSCRIPT = [
+    { role: 'user' as const, content: [{ type: 'text' as const, text: 'first' }] },
+    { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'second' }] },
+    { role: 'user' as const, content: [{ type: 'text' as const, text: 'third' }] },
+    { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'fourth' }] },
+  ]
+
+  it('rebuilds on a trimmed transcript when the window overflows', async () => {
+    const quota = new Error('too big')
+    quota.name = 'QuotaExceededError'
+    const { prompts, sessions, create } = stubLanguageModel({
+      responses: [quota, '{"tool":"none","reply":"recovered"}'],
+    })
+
+    const events = await collect(new ChromeProvider(), request({ messages: LONG_TRANSCRIPT }))
+
+    // A session cannot forget, so the one holding the oversized transcript is
+    // thrown away rather than re-prompted
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(sessions[0].destroy).toHaveBeenCalled()
     // First turn kept as the task, middle dropped, tail kept
     expect(prompts[1]).toContain('first')
     expect(prompts[1]).not.toContain('second')
     expect(events.at(-1)).toEqual({ type: 'stop', reason: 'end_turn' })
+  })
+
+  it('trims before the API throws when the session can measure', async () => {
+    const { prompts, create } = stubLanguageModel({
+      responses: ['{"tool":"none","reply":"ok"}'],
+      contextWindow: 6144,
+      contextUsage: 6000,
+      // More than the 144 tokens left
+      measured: 500,
+    })
+
+    await collect(new ChromeProvider(), request({ messages: LONG_TRANSCRIPT }))
+
+    // Trimmed on the first attempt: no QuotaExceededError was needed to find out
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]).not.toContain('second')
+  })
+
+  it('sends the turn as-is when it fits', async () => {
+    const { prompts, create } = stubLanguageModel({
+      responses: ['{"tool":"none","reply":"ok"}'],
+      contextWindow: 6144,
+      contextUsage: 100,
+      measured: 500,
+    })
+
+    await collect(new ChromeProvider(), request({ messages: LONG_TRANSCRIPT }))
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(prompts[0]).toContain('second')
   })
 
   it('reports an aborted turn rather than throwing', async () => {
@@ -222,14 +314,175 @@ describe('ChromeProvider.stream', () => {
   })
 
   it('destroys the session even when the turn fails', async () => {
-    const { session } = stubLanguageModel({ responses: [new Error('model exploded')] })
+    const { sessions } = stubLanguageModel({ responses: [new Error('model exploded')] })
 
     await expect(collect(new ChromeProvider())).rejects.toThrow('model exploded')
-    expect(session.destroy).toHaveBeenCalled()
+    expect(sessions[0].destroy).toHaveBeenCalled()
   })
 
   it('explains itself when the API is absent', async () => {
     await expect(collect(new ChromeProvider())).rejects.toThrow(/not available in this browser/)
+  })
+})
+
+// A Prompt API session accumulates the transcript, so re-sending it every turn
+// would pay for it every turn — and the system prompt with it.
+describe('ChromeProvider session reuse', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const FIRST = { role: 'user' as const, content: [{ type: 'text' as const, text: 'first' }] }
+  const REPLY = { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'ok' }] }
+  const SECOND = { role: 'user' as const, content: [{ type: 'text' as const, text: 'second' }] }
+
+  it('keeps one session across turns and sends only what is new', async () => {
+    const { create, turns } = stubLanguageModel({
+      responses: ['{"tool":"none","reply":"a"}', '{"tool":"none","reply":"b"}'],
+    })
+    const provider = new ChromeProvider()
+
+    await collect(provider, request({ messages: [FIRST] }))
+    await collect(provider, request({ messages: [FIRST, REPLY, SECOND] }))
+
+    expect(create).toHaveBeenCalledTimes(1)
+    // The second turn carries the two new messages, not the whole transcript
+    expect(turns[1]).toEqual([
+      { role: 'assistant', content: 'ok' },
+      { role: 'user', content: 'second' },
+    ])
+  })
+
+  it('rebuilds when the tool set changes, because initialPrompts cannot be amended', async () => {
+    const { create } = stubLanguageModel({
+      responses: ['{"tool":"none","reply":"a"}', '{"tool":"none","reply":"b"}'],
+    })
+    const provider = new ChromeProvider()
+
+    await collect(provider, request({ messages: [FIRST] }))
+    // find_tools unlocking a tool is exactly this: the schemas in the preamble are
+    // now wrong
+    await collect(provider, request({ messages: [FIRST, REPLY, SECOND], tools: [TOOLS[0]] }))
+
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it('rebuilds when history was rewritten rather than extended', async () => {
+    const { create } = stubLanguageModel({
+      responses: ['{"tool":"none","reply":"a"}', '{"tool":"none","reply":"b"}'],
+    })
+    const provider = new ChromeProvider()
+
+    await collect(provider, request({ messages: [FIRST, REPLY, SECOND] }))
+    // What compaction leaves behind: a shorter transcript with a different start
+    await collect(
+      provider,
+      request({
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'summary so far' }] }],
+      })
+    )
+
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not record a turn the model never answered', async () => {
+    const { create, turns } = stubLanguageModel({
+      responses: [new Error('model exploded'), '{"tool":"none","reply":"b"}'],
+    })
+    const provider = new ChromeProvider()
+
+    await expect(collect(provider, request({ messages: [FIRST] }))).rejects.toThrow()
+    await collect(provider, request({ messages: [FIRST] }))
+
+    // The failed session is gone, so the retry starts over with the same message
+    // rather than assuming the model already has it
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(turns[1]).toEqual([{ role: 'user', content: 'first' }])
+  })
+
+  it('drops the session on dispose', async () => {
+    const { create, sessions } = stubLanguageModel({
+      responses: ['{"tool":"none","reply":"a"}', '{"tool":"none","reply":"b"}'],
+    })
+    const provider = new ChromeProvider()
+
+    await collect(provider, request({ messages: [FIRST] }))
+    provider.dispose()
+    await collect(provider, request({ messages: [FIRST] }))
+
+    expect(sessions[0].destroy).toHaveBeenCalled()
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+})
+
+// The probe reads WebIDL argument conversion rather than the model's behaviour: a
+// browser that declares `tools` rejects a non-sequence with a TypeError, one that
+// does not ignores it. Watching for a rejection instead would report support that
+// is not there — Chrome 152 accepts `expectedOutputs: [{type: 'tool-call'}]` and
+// silently drops `tools`.
+describe('nativeToolSupport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // Stands in for a browser that declares the member: only the IDL conversion of a
+  // bad `tools` value fails, and nothing else about create() does
+  function stubWithToolsMember() {
+    const create = vi.fn(async (options: CreateOptions = {}) => {
+      if ('tools' in options && !Array.isArray(options.tools)) {
+        throw new TypeError("Failed to read the 'tools' property")
+      }
+      return { prompt: vi.fn(), destroy: vi.fn() }
+    })
+    vi.stubGlobal('LanguageModel', { availability: async () => 'available', create })
+    return create
+  }
+
+  it('is false without the Prompt API', async () => {
+    await expect(nativeToolSupport()).resolves.toBe(false)
+  })
+
+  it('is true when create() declares the tools member', async () => {
+    stubWithToolsMember()
+
+    await expect(nativeToolSupport()).resolves.toBe(true)
+  })
+
+  it('is false when create() ignores tools like any unknown option', async () => {
+    // What shipped Chrome does: `tools` is not a member, so a bad value is dropped
+    // and create() fails for its own reason — or, on a machine with the model
+    // downloaded, succeeds
+    const notSupported = new Error('service is not running')
+    notSupported.name = 'NotSupportedError'
+    vi.stubGlobal('LanguageModel', {
+      availability: async () => 'available',
+      create: vi.fn(async () => {
+        throw notSupported
+      }),
+    })
+
+    await expect(nativeToolSupport()).resolves.toBe(false)
+  })
+
+  it('is false when tools is accepted but silently dropped', async () => {
+    // The false positive the old probe hit: a well-formed tool and a `tool-call`
+    // output type are both taken without complaint, and neither does anything
+    const { sessions } = stubLanguageModel({ responses: [] })
+
+    await expect(nativeToolSupport()).resolves.toBe(false)
+    // Whatever the probe opened is closed again
+    for (const session of sessions) expect(session.destroy).toHaveBeenCalled()
+  })
+
+  it('is false when every create() call throws TypeError, which proves nothing', async () => {
+    vi.stubGlobal('LanguageModel', {
+      availability: async () => 'available',
+      create: vi.fn(async () => {
+        throw new TypeError('this engine is broken')
+      }),
+    })
+
+    await expect(nativeToolSupport()).resolves.toBe(false)
   })
 })
 
@@ -243,13 +496,20 @@ describe('availability', () => {
   })
 
   it('reads the real window size off a probe session', async () => {
-    const { session } = stubLanguageModel({ responses: [], inputQuota: 4096 })
+    const { sessions } = stubLanguageModel({ responses: [], inputQuota: 4096 })
 
     const provider = await createChromeProvider()
 
     expect(provider.contextWindow).toBe(4096)
-    // The probe is not kept: this provider holds no session between turns
-    expect(session.destroy).toHaveBeenCalled()
+    // The probe is thrown away: the streaming session needs a system prompt that
+    // is not known until the first request
+    expect(sessions[0].destroy).toHaveBeenCalled()
+  })
+
+  it('prefers the current contextWindow spelling over the deprecated aliases', async () => {
+    stubLanguageModel({ responses: [], contextWindow: 8192, inputQuota: 4096 })
+
+    await expect(createChromeProvider()).resolves.toMatchObject({ contextWindow: 8192 })
   })
 
   it('falls back to Nano’s shipped window when the session reports none', async () => {

--- a/noodles-editor/src/ai-chat/agent/providers/chrome.ts
+++ b/noodles-editor/src/ai-chat/agent/providers/chrome.ts
@@ -1,6 +1,6 @@
 // Chrome's built-in model (Gemini Nano) via the Prompt API.
 //
-// Two things make this provider unlike the other two:
+// Three things make this provider unlike the other two:
 //
 // 1. No tool calling. The API offers `responseConstraint` (a JSON Schema) and
 //    nothing else, so the loop's tool round-trip is emulated: every turn asks for
@@ -9,12 +9,19 @@
 //    learns the difference.
 // 2. A context window measured in single-digit thousands of tokens, discovered at
 //    runtime rather than known from the model id. Overflowing it throws
-//    QuotaExceededError instead of silently truncating, which is better — but it
-//    means the transcript has to be trimmed and retried rather than hoped over.
+//    QuotaExceededError instead of silently truncating, so the transcript is
+//    measured against the remaining room before each turn and trimmed if it
+//    will not fit.
+// 3. The session is the transcript. Unlike an HTTP provider, which is handed the
+//    whole history on every request, a Prompt API session accumulates it. So this
+//    provider keeps one session across turns and sends only the messages the
+//    session has not seen — which also means the system prompt and the tool
+//    schemas, which live in `initialPrompts` and are never evicted, are paid for
+//    once per conversation rather than once per turn.
 //
-// The API is an origin trial and has been renamed twice (maxTokens/tokensSoFar →
-// inputQuota/inputUsage, contextoverflow → quotaoverflow), so the reads below
-// accept either spelling rather than pinning to one.
+// The API has renamed things twice (maxTokens/tokensSoFar → inputQuota/inputUsage
+// → contextWindow/contextUsage; contextoverflow → quotaoverflow), so the reads
+// below accept every spelling rather than pinning to one.
 
 import { debugAiChat } from '../../../utils/debug'
 import { withTimeout } from '../../../utils/timeout'
@@ -38,7 +45,18 @@ export const CHROME_MODELS = [{ id: 'gemini-nano', label: 'Gemini Nano (on-devic
 // supported constraint shape there is; a nullable object property is not.
 const NO_TOOL = 'none'
 
+// Sent when a turn has nothing new in it, which the API would reject as an empty
+// prompt
+const NUDGE = 'Continue.'
+
 export type ChromeAvailability = 'unavailable' | 'downloadable' | 'downloading' | 'available'
+
+type PromptRole = 'system' | 'user' | 'assistant'
+
+interface PromptMessage {
+  role: PromptRole
+  content: string
+}
 
 interface PromptOptions {
   signal?: AbortSignal
@@ -49,25 +67,38 @@ interface PromptOptions {
 // The slice of the Prompt API this provider uses. Declared locally because the
 // API is not in lib.dom yet.
 interface LanguageModelSession {
-  prompt(input: string, options?: PromptOptions): Promise<string>
+  // Passing messages rather than a string adds them to the session's own history,
+  // which is what makes sending only the new ones correct
+  prompt(input: string | PromptMessage[], options?: PromptOptions): Promise<string>
+  measureContextUsage?(
+    input: string | PromptMessage[],
+    options?: Pick<PromptOptions, 'responseConstraint' | 'omitResponseConstraintInput'>
+  ): Promise<number>
   destroy(): void
   addEventListener?: (type: string, listener: () => void) => void
+  // Current spelling
+  contextWindow?: number
+  contextUsage?: number
+  // Deprecated aliases, still what shipped Chrome reports
   inputQuota?: number
   inputUsage?: number
-  contextWindow?: number
   maxTokens?: number
   tokensSoFar?: number
 }
 
+interface CreateOptions {
+  initialPrompts?: PromptMessage[]
+  signal?: AbortSignal
+  monitor?: (monitor: {
+    addEventListener: (type: string, listener: (e: Event) => void) => void
+  }) => void
+  // Only used to probe for native tool support; see nativeToolSupport()
+  tools?: unknown
+}
+
 interface LanguageModelFactory {
   availability(): Promise<ChromeAvailability>
-  create(options?: {
-    initialPrompts?: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>
-    signal?: AbortSignal
-    monitor?: (monitor: {
-      addEventListener: (type: string, listener: (e: Event) => void) => void
-    }) => void
-  }): Promise<LanguageModelSession>
+  create(options?: CreateOptions): Promise<LanguageModelSession>
 }
 
 function factory(): LanguageModelFactory | undefined {
@@ -84,6 +115,55 @@ export async function chromeAvailability(): Promise<ChromeAvailability> {
   }
 }
 
+// Whether this browser implements the explainer's `tools` option on create() —
+// grammar-constrained tool calls instead of the JSON emulation below.
+//
+// Detected by handing `tools` a value no sequence can accept. WebIDL converts
+// arguments in the binding layer, before the method body runs, so a browser that
+// declares the member rejects this with a TypeError while one that does not
+// ignores it like any unknown member and fails (or succeeds) for its own reasons.
+// The control call is what makes that a real signal rather than an assumption
+// about how one engine words its errors.
+//
+// Passing a well-formed tool instead would give a false positive: Chrome 152
+// already accepts `expectedOutputs: [{type: 'tool-call'}]` — `tool-call` is in the
+// shipped LanguageModelMessageType enum — and silently drops `tools`, so a probe
+// that only watched for a rejection would report support that is not there.
+//
+// Reported but not yet used. Wiring it up is not a swap: the API's tools take an
+// `execute` callback the browser invokes itself, awaiting all of them before the
+// model replies, whereas AgentProvider.stream() yields tool calls out and lets
+// the loop schedule them (loop.ts:307, which serializes anything mutating). Using
+// it means the provider holding a prompt() promise open across stream() calls and
+// resolving it from the next request's tool_result — worth doing once the option
+// ships and can be tested against a real implementation.
+export async function nativeToolSupport(): Promise<boolean> {
+  const api = factory()
+  if (!api) return false
+
+  const rejects = async (options: CreateOptions): Promise<unknown> => {
+    let session: LanguageModelSession | null = null
+    try {
+      session = await api.create(options)
+      return null
+    } catch (error) {
+      return error
+    } finally {
+      session?.destroy()
+    }
+  }
+
+  const probe = await rejects({ tools: NOT_A_SEQUENCE })
+  if (!(probe instanceof TypeError)) return false
+
+  // An engine that throws TypeError for every create() call tells us nothing
+  const control = await rejects({})
+  return !(control instanceof TypeError)
+}
+
+// Not a sequence, not a dictionary, not anything `tools` could hold
+const NOT_A_SEQUENCE = 42
+
 // The first create() on a machine that has never run the model downloads ~2GB,
 // so it gets minutes; an ordinary create() that has not answered in a minute is
 // wedged rather than slow.
@@ -96,9 +176,9 @@ export interface DownloadProgress {
 }
 
 // Creates a probe session purely to read the real window size, then throws it
-// away: this provider keeps no session between turns, so the transcript the loop
-// holds stays the only state. Since this is also the call that triggers the
-// model download, it is where progress is reported from.
+// away: the streaming session carries the system prompt and tool schemas, which
+// are not known until the first request. Since this is also the call that
+// triggers the model download, it is where progress is reported from.
 export async function createChromeProvider(
   options: { onDownloadProgress?: (progress: DownloadProgress) => void } = {}
 ): Promise<ChromeProvider> {
@@ -131,15 +211,19 @@ export async function createChromeProvider(
       : 'Chrome’s built-in model did not start within 60 seconds. Restart Chrome, or pick another provider in Settings → AI Provider.'
   )
 
-  const contextWindow = readQuota(probe)
+  const contextWindow = readWindow(probe)
   probe.destroy()
 
   debugAiChat('[chrome] ready, %d token window', contextWindow)
   return new ChromeProvider({ contextWindow })
 }
 
-function readQuota(session: LanguageModelSession): number {
-  return session.inputQuota ?? session.contextWindow ?? session.maxTokens ?? FALLBACK_CONTEXT_WINDOW
+function readWindow(session: LanguageModelSession): number {
+  return session.contextWindow ?? session.inputQuota ?? session.maxTokens ?? FALLBACK_CONTEXT_WINDOW
+}
+
+function readUsage(session: LanguageModelSession): number {
+  return session.contextUsage ?? session.inputUsage ?? session.tokensSoFar ?? 0
 }
 
 export class ChromeProvider implements AgentProvider {
@@ -151,40 +235,188 @@ export class ChromeProvider implements AgentProvider {
 
   private callCounter = 0
 
+  // The live session, plus what it has already been told. `sent` is one entry per
+  // AgentMessage in the order the session received them, so the next request's
+  // messages can be diffed against it.
+  private session: LanguageModelSession | null = null
+  private sessionKey = ''
+  private sent: string[] = []
+
   constructor(options: { contextWindow?: number } = {}) {
     this.contextWindow = options.contextWindow ?? FALLBACK_CONTEXT_WINDOW
+  }
+
+  // The chat panel switching providers, or the conversation being cleared, leaves
+  // a session holding a transcript nobody will continue.
+  dispose() {
+    this.discard()
   }
 
   async *stream(request: AgentRequest, signal?: AbortSignal): AsyncIterable<AgentEvent> {
     const api = factory()
     if (!api) throw new Error('Chrome’s built-in model is not available in this browser')
 
-    let session: LanguageModelSession | null = null
     try {
-      session = await api.create({
-        initialPrompts: [{ role: 'system', content: systemPrompt(request) }],
-        signal,
-      })
-
-      // Fires when the API evicts the oldest turns to make room. Worth knowing
-      // about: it means the model has silently lost the start of the transcript.
-      session.addEventListener?.('contextoverflow', () =>
-        debugAiChat('[chrome] context overflowed, oldest turns evicted')
-      )
-      session.addEventListener?.('quotaoverflow', () =>
-        debugAiChat('[chrome] quota overflowed, oldest turns evicted')
-      )
-
-      const raw = await promptWithRetry(session, request, signal)
+      const raw = await this.promptTurn(api, request, signal)
       yield* this.eventsFor(raw, request.tools)
     } catch (error) {
+      // The session's history is only worth keeping if the turn that would have
+      // extended it succeeded
+      this.discard()
       if (isAbort(error)) {
         yield { type: 'stop', reason: 'aborted' }
         return
       }
       throw error
-    } finally {
-      session?.destroy()
+    }
+  }
+
+  private async promptTurn(
+    api: LanguageModelFactory,
+    request: AgentRequest,
+    signal?: AbortSignal
+  ): Promise<string> {
+    const options: PromptOptions = {
+      signal,
+      responseConstraint: responseSchema(request.tools),
+      // The schema is sizeable next to a 6k window, and it is already described in
+      // words by preamble(), so it does not need to be spent twice
+      omitResponseConstraintInput: true,
+    }
+
+    const lines = request.messages.map(serialize)
+    const session = await this.sessionFor(api, request, lines, signal)
+    const offset = this.sent.length
+    const input = toPromptMessages(lines.slice(offset), request.messages, offset)
+
+    if (!(await this.fits(session, input, options))) {
+      debugAiChat('[chrome] turn will not fit, rebuilding on a trimmed transcript')
+      return this.retrimmed(api, request, options, signal)
+    }
+
+    try {
+      return await this.send(session, input, options, lines)
+    } catch (error) {
+      if (!isQuotaExceeded(error)) throw error
+
+      // measureContextUsage is optional, and its estimate can be short of what the
+      // session actually charges, so catch-and-retry stays as a backstop
+      debugAiChat('[chrome] over quota, rebuilding on a trimmed transcript')
+      return this.retrimmed(api, request, options, signal)
+    }
+  }
+
+  // A fresh session holding only the task and the last exchange. Rebuilding rather
+  // than re-prompting is what makes this work at all: the old session still holds
+  // the messages that did not fit, and a session cannot forget.
+  private async retrimmed(
+    api: LanguageModelFactory,
+    request: AgentRequest,
+    options: PromptOptions,
+    signal?: AbortSignal
+  ): Promise<string> {
+    const trimmed = trimTranscript(request.messages)
+    debugAiChat('[chrome] kept %d of %d messages', trimmed.length, request.messages.length)
+
+    const session = await this.rebuild(api, request, signal)
+    const lines = trimmed.map(serialize)
+    return this.send(session, toPromptMessages(lines, trimmed, 0), options, lines)
+  }
+
+  private async send(
+    session: LanguageModelSession,
+    input: PromptMessage[],
+    options: PromptOptions,
+    sent: string[]
+  ): Promise<string> {
+    // An empty turn means the loop re-streamed a transcript the session already
+    // holds. It still owes a reply, so ask for one rather than sending nothing.
+    const raw = await session.prompt(input.length > 0 ? input : NUDGE, options)
+    // Only now is the session known to hold these messages
+    this.sent = sent
+    return raw
+  }
+
+  // Reuses the live session when it is still the right one: same system prompt and
+  // tool set, and a transcript this one extends rather than rewrites. Compaction
+  // and the loop's own trimming both rewrite history, and a session cannot forget.
+  private async sessionFor(
+    api: LanguageModelFactory,
+    request: AgentRequest,
+    lines: string[],
+    signal?: AbortSignal
+  ): Promise<LanguageModelSession> {
+    const key = sessionKey(request)
+    const isExtension =
+      lines.length >= this.sent.length && this.sent.every((line, index) => line === lines[index])
+
+    if (this.session && this.sessionKey === key && isExtension) return this.session
+
+    if (this.session) {
+      debugAiChat(
+        '[chrome] discarding session (%s)',
+        this.sessionKey === key ? 'transcript rewritten' : 'prompt or tools changed'
+      )
+    }
+    return this.rebuild(api, request, signal)
+  }
+
+  private async rebuild(
+    api: LanguageModelFactory,
+    request: AgentRequest,
+    signal?: AbortSignal
+  ): Promise<LanguageModelSession> {
+    this.discard()
+
+    // initialPrompts are never evicted, which is the whole reason the tool
+    // schemas go here rather than into the turn
+    const session = await api.create({
+      initialPrompts: [{ role: 'system', content: preamble(request) }],
+      signal,
+    })
+
+    // Fires when the API evicts the oldest turns to make room. Worth knowing
+    // about: it means the model has silently lost the start of the transcript.
+    session.addEventListener?.('contextoverflow', () =>
+      debugAiChat('[chrome] context overflowed, oldest turns evicted')
+    )
+    session.addEventListener?.('quotaoverflow', () =>
+      debugAiChat('[chrome] quota overflowed, oldest turns evicted')
+    )
+
+    this.session = session
+    this.sessionKey = sessionKey(request)
+    this.sent = []
+    return session
+  }
+
+  private discard() {
+    this.session?.destroy()
+    this.session = null
+    this.sessionKey = ''
+    this.sent = []
+  }
+
+  // Trim before the API throws rather than after. measureContextUsage is optional
+  // and a session that cannot measure is assumed to fit, since the alternative is
+  // trimming a transcript that would have been fine.
+  private async fits(
+    session: LanguageModelSession,
+    input: PromptMessage[],
+    options: PromptOptions
+  ): Promise<boolean> {
+    if (!session.measureContextUsage || input.length === 0) return true
+
+    try {
+      const needed = await session.measureContextUsage(input, {
+        responseConstraint: options.responseConstraint,
+        omitResponseConstraintInput: options.omitResponseConstraintInput,
+      })
+      const room = readWindow(session) - readUsage(session)
+      debugAiChat('[chrome] turn needs %d tokens, %d left in the window', needed, room)
+      return needed <= room
+    } catch {
+      return true
     }
   }
 
@@ -211,35 +443,11 @@ export class ChromeProvider implements AgentProvider {
   }
 }
 
-// One attempt, then one more against a trimmed transcript. QuotaExceededError
-// means the prompt could not be made to fit even after the API evicted what it
-// could, so sending the same thing again would fail the same way.
-async function promptWithRetry(
-  session: LanguageModelSession,
-  request: AgentRequest,
-  signal?: AbortSignal
-): Promise<string> {
-  const options: PromptOptions = {
-    signal,
-    responseConstraint: responseSchema(request.tools),
-    // The schema is sizeable next to a 6k window, and it is already described in
-    // words by systemPrompt(), so it does not need to be spent twice
-    omitResponseConstraintInput: true,
-  }
-
-  try {
-    return await session.prompt(transcript(request.messages), options)
-  } catch (error) {
-    if (!isQuotaExceeded(error)) throw error
-
-    const trimmed = trimTranscript(request.messages)
-    debugAiChat(
-      '[chrome] over quota, retrying with %d of %d messages',
-      trimmed.length,
-      request.messages.length
-    )
-    return session.prompt(transcript(trimmed), options)
-  }
+// A session is only reusable for the same system prompt and the same tool set;
+// the router unlocking a tool changes what the schemas in initialPrompts have to
+// say, and initialPrompts cannot be amended.
+function sessionKey(request: AgentRequest): string {
+  return `${request.system}\u0000${request.tools.map(tool => tool.name).join(',')}`
 }
 
 // Keeps the first user turn (the task) and the most recent exchanges, dropping
@@ -312,8 +520,9 @@ function asRecord(value: unknown): Record<string, unknown> {
 }
 
 // Everything the model needs that a native provider would get as structured
-// fields: the tool schemas, and how to answer.
-function systemPrompt(request: AgentRequest): string {
+// fields: the tool schemas, and how to answer. Goes into initialPrompts, which the
+// API never evicts, so it survives a conversation that overflows the window.
+function preamble(request: AgentRequest): string {
   const tools = request.tools
     .map(
       tool =>
@@ -332,32 +541,49 @@ Tools:
 ${tools}`
 }
 
-// The transcript as text. Tool results arrive as JSON strings already capped by
-// result-budget, so this only has to label them.
-function transcript(messages: AgentMessage[]): string {
+// One AgentMessage as the line the session will hold. Used both as the prompt
+// content and as the identity of that message when diffing the next request
+// against what the session already has, so it has to be a pure function of the
+// message.
+function serialize(message: AgentMessage): string {
   const lines: string[] = []
 
-  for (const message of messages) {
-    for (const part of message.content) {
-      switch (part.type) {
-        case 'text':
-          lines.push(`${message.role === 'user' ? 'User' : 'Assistant'}: ${part.text}`)
-          break
-        case 'tool_use':
-          lines.push(`Assistant called ${part.name} with ${JSON.stringify(part.input)}`)
-          break
-        case 'tool_result':
-          lines.push(`Result${part.isError ? ' (error)' : ''}: ${part.content}`)
-          break
-        // Images cannot be sent, and a provider_block from another provider is
-        // meaningless here
-        default:
-          break
-      }
+  for (const part of message.content) {
+    switch (part.type) {
+      case 'text':
+        lines.push(part.text)
+        break
+      case 'tool_use':
+        lines.push(`Called ${part.name} with ${JSON.stringify(part.input)}`)
+        break
+      case 'tool_result':
+        lines.push(`Result${part.isError ? ' (error)' : ''}: ${part.content}`)
+        break
+      // Images cannot be sent, and a provider_block from another provider is
+      // meaningless here
+      default:
+        break
     }
   }
 
   return lines.join('\n')
+}
+
+// The Prompt API takes 'user' and 'assistant'; the loop's tool results ride on
+// user messages, which is where they belong here too.
+function toPromptMessages(
+  lines: string[],
+  messages: AgentMessage[],
+  offset: number
+): PromptMessage[] {
+  const prompts: PromptMessage[] = []
+
+  lines.forEach((content, index) => {
+    if (!content) return
+    prompts.push({ role: messages[offset + index].role, content })
+  })
+
+  return prompts
 }
 
 function isAbort(error: unknown): boolean {

--- a/noodles-editor/src/ai-chat/agent/result-budget.ts
+++ b/noodles-editor/src/ai-chat/agent/result-budget.ts
@@ -42,6 +42,10 @@ const HINTS: Record<string, string> = {
   get_example: 'inspect the example a few nodes at a time',
   list_examples: 'filter by category or tag',
   get_console_errors: 'lower maxResults or filter by level',
+  run_code: 'return a summary — a length, a few rows, an aggregate — rather than the whole value',
+  read_file: 'pass startLine/endLine to page through it, or process it in run_code instead',
+  grep_files: 'narrow the pattern, pass path, or lower maxResults',
+  list_files: 'pass path to list one subdirectory',
 }
 
 const DEFAULT_HINT = 'narrow your query and call the tool again'

--- a/noodles-editor/src/ai-chat/agent/session.ts
+++ b/noodles-editor/src/ai-chat/agent/session.ts
@@ -63,6 +63,12 @@ export class AgentSession {
     this.router = new ToolRouter(provider.contextWindow, [...childTools, delegate])
   }
 
+  // Called when the panel replaces this session. The Chrome provider holds an
+  // on-device session carrying the transcript; nothing reclaims it otherwise.
+  dispose() {
+    this.provider.dispose?.()
+  }
+
   async send(params: SendParams): Promise<ClaudeResponse> {
     const history = await this.prepareHistory(params.conversationHistory ?? [])
 

--- a/noodles-editor/src/ai-chat/agent/tool-router.ts
+++ b/noodles-editor/src/ai-chat/agent/tool-router.ts
@@ -10,7 +10,11 @@
 // defined here and not in tool-definitions.ts — external MCP clients do their
 // own tool discovery and keep seeing the full surface via src/webmcp.
 
-import { type ToolDefinition, type ToolInputSchema, toolDefinitions } from '../tool-definitions'
+import {
+  availableToolDefinitions,
+  getToolDefinition,
+  type ToolInputSchema,
+} from '../tool-definitions'
 import type { ToolResult } from '../types'
 
 export const FIND_TOOLS_NAME = 'find_tools'
@@ -40,7 +44,7 @@ export const FIND_TOOLS_DEFINITION: {
 } = {
   name: FIND_TOOLS_NAME,
   description:
-    'Look up additional tools by capability and unlock them for use. Returns full input schemas for the best matches. Use this before saying a capability is unavailable — tools exist for searching source code, reading documentation, listing and fetching example projects, reading operator schemas, capturing screenshots, reading console errors, editing the animation timeline, searching the web, and delegating a self-contained sub-task to another agent.',
+    "Look up additional tools by capability and unlock them for use. Returns full input schemas for the best matches. Use this before saying a capability is unavailable — tools exist for running JavaScript against the live graph, reading, writing, listing and searching the project's data files, searching source code, reading documentation, listing and fetching example projects, reading operator schemas, capturing screenshots, reading console errors, editing the animation timeline, searching the web, and delegating a self-contained sub-task to another agent.",
   inputSchema: {
     type: 'object',
     properties: {
@@ -195,7 +199,7 @@ export class ToolRouter {
   private lookup(name: string): RoutedTool | undefined {
     const harness = this.harnessTools.get(name)
     if (harness) return toRoutedHarness(harness)
-    const definition = findDefinition(name)
+    const definition = getToolDefinition(name)
     return definition ? toRouted(definition) : undefined
   }
 
@@ -227,7 +231,7 @@ export function scoreTools(query: string, harnessTools: HarnessTool[] = []): Too
   if (terms.length === 0) return []
 
   const candidates: RoutedTool[] = [
-    ...toolDefinitions.map(toRouted),
+    ...availableToolDefinitions().map(toRouted),
     ...harnessTools.map(toRoutedHarness),
   ]
 
@@ -310,11 +314,11 @@ function tokenize(text: string): string[] {
     .filter(term => term.length > 1 && !STOP_WORDS.has(term))
 }
 
-function findDefinition(name: string): ToolDefinition | undefined {
-  return toolDefinitions.find(d => d.name === name)
-}
-
-function toRouted(definition: ToolDefinition): RoutedTool {
+function toRouted(definition: {
+  name: string
+  description: string
+  inputSchema: ToolInputSchema
+}): RoutedTool {
   return {
     name: definition.name,
     description: definition.description,

--- a/noodles-editor/src/ai-chat/agent/types.ts
+++ b/noodles-editor/src/ai-chat/agent/types.ts
@@ -70,6 +70,11 @@ export interface AgentProvider {
   readonly contextWindow: number
 
   stream(request: AgentRequest, signal?: AbortSignal): AsyncIterable<AgentEvent>
+
+  // Releases anything the provider holds between turns. Only the Chrome provider
+  // has any: an on-device session that owns the transcript, which the browser will
+  // not reclaim on its own.
+  dispose?(): void
 }
 
 // Convenience for the non-streaming callers (compaction's summarizer): drain a

--- a/noodles-editor/src/ai-chat/chat-panel.tsx
+++ b/noodles-editor/src/ai-chat/chat-panel.tsx
@@ -149,6 +149,13 @@ export const ChatPanel: FC<ChatPanelProps> = ({ project, onClose, isVisible, ini
       return
     }
 
+    // Providers can own resources that outlive a turn — Chrome's holds an
+    // on-device session carrying the transcript — so a session this effect built
+    // has to be disposed whether it was ever handed to the UI or was superseded
+    // while still being built
+    let built: AgentSession | null = null
+    let cancelled = false
+
     const init = async () => {
       setContextLoading(true)
       setProviderError(null)
@@ -165,17 +172,22 @@ export const ChatPanel: FC<ChatPanelProps> = ({ project, onClose, isVisible, ini
           onDownloadProgress: setDownloadProgress,
         })
 
+        built = new AgentSession(provider, tools, {
+          webSearch: webSearchConfigFor({
+            providerId,
+            model: provider.model,
+            anthropicKey: apiKey,
+            openRouterKey,
+          }),
+        })
+
+        if (cancelled) {
+          built.dispose()
+          return
+        }
+
         setMcpTools(tools)
-        setSession(
-          new AgentSession(provider, tools, {
-            webSearch: webSearchConfigFor({
-              providerId,
-              model: provider.model,
-              anthropicKey: apiKey,
-              openRouterKey,
-            }),
-          })
-        )
+        setSession(built)
       } catch (error) {
         debugAiChat('Failed to initialize the assistant:', error)
         setSession(null)
@@ -187,6 +199,11 @@ export const ChatPanel: FC<ChatPanelProps> = ({ project, onClose, isVisible, ini
     }
 
     init()
+
+    return () => {
+      cancelled = true
+      built?.dispose()
+    }
   }, [providerId, providerKey, providerReady, model, apiKey, openRouterKey, customEndpoint])
 
   // Update MCPTools with current project whenever it changes
@@ -414,8 +431,9 @@ export const ChatPanel: FC<ChatPanelProps> = ({ project, onClose, isVisible, ini
             <a href="https://openrouter.ai/keys" target="_blank" rel="noopener noreferrer">
               OpenRouter
             </a>
-            . Chrome’s built-in model is free and needs no key, but is the least capable of the
-            three.
+            . Chrome’s built-in model is free, private, and needs no key, but it runs on your device
+            and is small: expect it to answer questions about the graph and make single-step edits,
+            not to build a visualization for you.
           </p>
           <div
             style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', justifyContent: 'center' }}
@@ -437,9 +455,11 @@ export const ChatPanel: FC<ChatPanelProps> = ({ project, onClose, isVisible, ini
           <p>{providerError}</p>
           {providerId === 'chrome' && (
             <p>
-              Chrome’s built-in model needs Chrome 127+ with the Prompt API enabled at{' '}
-              <code>chrome://flags/#prompt-api-for-gemini-nano</code>, and the model downloaded via{' '}
-              <code>chrome://components</code>.
+              The Prompt API ships in Chrome 148; on an earlier build enable it at{' '}
+              <code>chrome://flags/#prompt-api-for-gemini-nano</code>. Either way the model itself
+              is a separate ~2GB download — check its status at{' '}
+              <code>chrome://on-device-internals</code>. It also needs about 22GB free and either
+              4GB of VRAM or 16GB of RAM.
             </p>
           )}
           <div
@@ -532,8 +552,14 @@ export const ChatPanel: FC<ChatPanelProps> = ({ project, onClose, isVisible, ini
             <option value="custom" disabled={!customEndpoint}>
               {customEndpoint?.displayName ?? 'Custom endpoint'}
             </option>
-            <option value="chrome" disabled={!chromeAvailable}>
-              Chrome (local)
+            <option
+              value="chrome"
+              disabled={!chromeAvailable}
+              // A ~3B on-device model. Saying what it is good for is more use than
+              // implying it is a smaller version of the others.
+              title="Free, private, no key. Good for single-step edits and questions about the graph; too small to build one."
+            >
+              Chrome (on-device)
             </option>
           </select>
           <select

--- a/noodles-editor/src/ai-chat/mcp-tools.ts
+++ b/noodles-editor/src/ai-chat/mcp-tools.ts
@@ -10,7 +10,18 @@ import {
   useTimelineStore,
 } from '../timeline/timeline-store'
 import type { Keyframe, KeyframeValue, Track } from '../timeline/types'
+import {
+  type GrepFilesParams,
+  grepFiles,
+  type ListFilesParams,
+  listFiles,
+  type ReadFileParams,
+  readFile,
+  type WriteFileParams,
+  writeFile,
+} from './agent-files'
 import type { ContextLoader } from './context-loader'
+import { type RunCodeParams, runCode } from './run-code'
 import type {
   ConsoleError,
   FileIndex,
@@ -816,6 +827,32 @@ export class MCPTools {
         error: error instanceof Error ? error.message : 'Failed to validate modifications',
       }
     }
+  }
+
+  // Evaluate JavaScript in CodeOp's sandbox. The implementation lives in run-code.ts
+  // because it needs nothing from this class — it is here so the tool definitions and
+  // WebMCP keep reaching every tool through one surface.
+  async runCode(params: RunCodeParams): Promise<ToolResult> {
+    return runCode(params)
+  }
+
+  // The project data directory. Same arrangement as runCode: the path guard and the
+  // storage calls live in agent-files.ts, these are forwarders so every tool is
+  // reachable through one surface.
+  async listFiles(params: ListFilesParams): Promise<ToolResult> {
+    return listFiles(params)
+  }
+
+  async readFile(params: ReadFileParams): Promise<ToolResult> {
+    return readFile(params)
+  }
+
+  async writeFile(params: WriteFileParams): Promise<ToolResult> {
+    return writeFile(params)
+  }
+
+  async grepFiles(params: GrepFilesParams): Promise<ToolResult> {
+    return grepFiles(params)
   }
 
   // Get current project state (nodes and edges)

--- a/noodles-editor/src/ai-chat/run-code-safe-mode.test.ts
+++ b/noodles-editor/src/ai-chat/run-code-safe-mode.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { scoreTools } from './agent/tool-router'
+import { runCode } from './run-code'
+import { availableToolDefinitions, getToolDefinition } from './tool-definitions'
+
+// safeMode is read once at module load in globals.ts, so it has to be mocked at the
+// module level — hence a separate file from run-code.test.ts, where every test needs
+// the code to actually evaluate.
+vi.mock('../noodles/globals', async importOriginal => ({
+  ...(await importOriginal<typeof import('../noodles/globals')>()),
+  safeMode: true,
+}))
+
+// Safe mode exists to stop the app executing arbitrary code, so run_code has to be
+// gone from every surface at once: discovery, dispatch, and the evaluator itself. A
+// tool the model can see but that always refuses would waste turns arguing with it.
+describe('run_code in safe mode', () => {
+  it('is not among the available tool definitions', () => {
+    expect(availableToolDefinitions().map(d => d.name)).not.toContain('run_code')
+  })
+
+  it('does not resolve by name, so the loop reports it as unknown', () => {
+    expect(getToolDefinition('run_code')).toBeUndefined()
+    // The rest of the surface is untouched
+    expect(getToolDefinition('list_nodes')).toBeDefined()
+  })
+
+  it('is not findable through find_tools', () => {
+    for (const query of ['run javascript', 'evaluate code', 'compute a statistic']) {
+      expect(scoreTools(query).map(m => m.name)).not.toContain('run_code')
+    }
+  })
+
+  it('refuses to evaluate even when called directly', async () => {
+    const result = await runCode({ code: 'return 1 + 1' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/safe mode/i)
+  })
+})

--- a/noodles-editor/src/ai-chat/run-code.test.ts
+++ b/noodles-editor/src/ai-chat/run-code.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NumberOp } from '../noodles/operators'
+import { clearOps, setOp } from '../noodles/store'
+import { registerPropertyMutationCallback } from '../noodles/utils/property-history'
+import { capToolResult } from './agent/result-budget'
+import { runCode } from './run-code'
+import { getToolDefinition } from './tool-definitions'
+
+// `data` on a successful ToolResult, narrowed for readability
+function data(result: { data?: unknown }): Record<string, unknown> {
+  return (result.data ?? {}) as Record<string, unknown>
+}
+
+// Constructing an operator does not put it in the store, and op() resolves through
+// the store — so every test that calls op() has to register its operator
+function makeNumberOp(id: string, value?: number): NumberOp {
+  const op = new NumberOp(id)
+  if (value !== undefined) op.inputs.val.setValue(value)
+  setOp(id, op)
+  return op
+}
+
+describe('runCode', () => {
+  beforeEach(() => {
+    clearOps()
+  })
+
+  it('returns the value the code returns', async () => {
+    const result = await runCode({ code: 'return 6 * 7' })
+
+    expect(result.success).toBe(true)
+    expect(data(result).result).toBe(42)
+  })
+
+  it('runs a function body, not an expression', async () => {
+    const result = await runCode({
+      code: 'const xs = [1, 2, 3]\nlet total = 0\nfor (const x of xs) total += x\nreturn total',
+    })
+
+    expect(data(result).result).toBe(6)
+  })
+
+  it('reads operator outputs through op()', async () => {
+    makeNumberOp('/num', 11)
+
+    const result = await runCode({ code: "return op('/num').par.val * 2" })
+
+    expect(result.success).toBe(true)
+    expect(data(result).result).toBe(22)
+  })
+
+  it('names the operator when the path does not resolve', async () => {
+    const result = await runCode({ code: "return op('/nope').par.val" })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/'\/nope' not found/)
+  })
+
+  it('exposes the CodeOp libraries', async () => {
+    const result = await runCode({ code: 'return typeof d3.sum + " " + typeof turf.distance' })
+
+    expect(data(result).result).toBe('function function')
+  })
+
+  it('surfaces a thrown error as a tool error rather than throwing', async () => {
+    const result = await runCode({ code: 'throw new Error("no good")' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/no good/)
+  })
+
+  it('reports a syntax error without evaluating anything', async () => {
+    const result = await runCode({ code: 'return (' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+
+  it('rejects empty code', async () => {
+    await expect(runCode({ code: '   ' })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringMatching(/non-empty/),
+    })
+  })
+
+  it('awaits a returned promise', async () => {
+    const result = await runCode({
+      code: 'const v = await Promise.resolve(5)\nreturn v + 1',
+    })
+
+    expect(data(result).result).toBe(6)
+  })
+
+  it('gives up on a promise that never settles', async () => {
+    const pending = runCode({ code: 'await new Promise(() => {})', timeoutMs: 20 })
+    // setupTests installs fake timers, so the timeout has to be advanced by hand
+    await vi.advanceTimersByTimeAsync(20)
+    const result = await pending
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/timed out after 20ms/)
+  })
+
+  it('captures console output alongside the value', async () => {
+    const result = await runCode({
+      code: 'console.log("counting", 3)\nconsole.warn("careful")\nreturn "done"',
+    })
+
+    expect(data(result).result).toBe('done')
+    expect(data(result).logs).toEqual(['counting 3', '[warn] careful'])
+  })
+
+  it('restores console after the run, including when the code throws', async () => {
+    const before = console.log
+
+    await runCode({ code: 'console.log("hi")\nthrow new Error("boom")' })
+
+    expect(console.log).toBe(before)
+  })
+
+  it('keeps logs written before a throw', async () => {
+    const result = await runCode({ code: 'console.log("got here")\nthrow new Error("boom")' })
+
+    expect(result.success).toBe(false)
+    expect(data(result).logs).toEqual(['got here'])
+  })
+
+  it('sends no logs key when nothing was logged', async () => {
+    const result = await runCode({ code: 'return 1' })
+
+    // undefined rather than absent; JSON.stringify drops it, so it costs no context
+    expect(data(result).logs).toBeUndefined()
+  })
+})
+
+// A tool that can return anything at all is the one most likely to blow the budget,
+// so the summary happens here rather than being left to result-budget's ladder.
+describe('runCode result summaries', () => {
+  beforeEach(() => {
+    clearOps()
+  })
+
+  it('returns a short array as itself', async () => {
+    const result = await runCode({ code: 'return [1, 2, 3]' })
+
+    expect(data(result).result).toEqual([1, 2, 3])
+  })
+
+  it('samples a long array and reports its true length', async () => {
+    const result = await runCode({ code: 'return Array.from({length: 5000}, (_, i) => i)' })
+
+    const summary = data(result).result as { length: number; sample: number[]; note: string }
+    expect(summary.length).toBe(5000)
+    expect(summary.sample).toHaveLength(20)
+    expect(summary.sample[0]).toBe(0)
+    expect(summary.note).toMatch(/first 20 of 5000/)
+  })
+
+  it('never serializes the whole of a huge array', async () => {
+    // 200k rows of an object each: serialized in full this is tens of megabytes, and
+    // capToolResult would have to build that string before deciding to drop it
+    const result = await runCode({
+      code: 'return Array.from({length: 200000}, (_, i) => ({i, label: "row " + i}))',
+    })
+
+    const capped = capToolResult('run_code', result, 24_000)
+    expect(capped.truncated).toBe(false)
+    expect(capped.chars).toBeLessThan(2000)
+  })
+
+  it('shows NaN and Infinity instead of letting JSON turn them into null', async () => {
+    const result = await runCode({ code: 'return {bad: 0/0, big: 1/0}' })
+
+    expect(data(result).result).toEqual({ bad: '[NaN]', big: '[Infinity]' })
+  })
+
+  it('marks undefined so a bare return is distinguishable from null', async () => {
+    expect(data(await runCode({ code: 'return' })).result).toBe('[undefined]')
+    expect(data(await runCode({ code: 'return null' })).result).toBe(null)
+  })
+
+  it('describes a function rather than dropping it', async () => {
+    const result = await runCode({ code: 'return function scale(d) { return d * 2 }' })
+
+    expect(data(result).result).toBe('[Function: scale]')
+  })
+
+  it('cuts a cycle but keeps repeated siblings', async () => {
+    const result = await runCode({
+      code: 'const shared = {n: 1}\nconst root = {a: shared, b: shared}\nroot.self = root\nreturn root',
+    })
+
+    expect(data(result).result).toEqual({
+      a: { n: 1 },
+      b: { n: 1 },
+      self: '[circular]',
+    })
+  })
+
+  it('summarizes a typed array by length and sample', async () => {
+    const result = await runCode({ code: 'return new Float32Array(1000).fill(2)' })
+
+    const summary = data(result).result as { type: string; length: number; sample: number[] }
+    expect(summary.type).toBe('Float32Array')
+    expect(summary.length).toBe(1000)
+    expect(summary.sample).toHaveLength(20)
+  })
+
+  it('reduces an operator to its path', async () => {
+    makeNumberOp('/num')
+
+    const result = await runCode({ code: "return op('/num')" })
+
+    expect(data(result).result).toBe('[Operator /num]')
+  })
+
+  it('clips a long string and says how long it was', async () => {
+    const result = await runCode({ code: 'return "x".repeat(9000)' })
+
+    expect(data(result).result).toMatch(/^x{2000}…\[clipped, 9000 chars\]$/)
+  })
+
+  it('stops descending at a depth limit', async () => {
+    const result = await runCode({
+      code: 'let node = {leaf: true}\nfor (let i = 0; i < 12; i++) node = {child: node}\nreturn node',
+    })
+
+    expect(JSON.stringify(data(result).result)).toContain('nested too deep')
+  })
+})
+
+describe('runCode and the undo history', () => {
+  beforeEach(() => {
+    clearOps()
+  })
+
+  afterEach(() => {
+    registerPropertyMutationCallback(undefined)
+  })
+
+  it('reports nothing changed for a pure computation', async () => {
+    registerPropertyMutationCallback(vi.fn())
+    makeNumberOp('/num', 3)
+
+    const result = await runCode({ code: "return op('/num').par.val" })
+
+    expect(data(result).changedFieldValues).toBeUndefined()
+  })
+
+  it('records one undo entry when the code changes a field value', async () => {
+    const record = vi.fn()
+    registerPropertyMutationCallback(record)
+
+    const op = makeNumberOp('/num', 1)
+
+    const result = await runCode({ code: "op('/num').inputs.val.setValue(99)\nreturn 'set'" })
+
+    expect(op.inputs.val.value).toBe(99)
+    expect(data(result).changedFieldValues).toBe(true)
+    expect(record).toHaveBeenCalledTimes(1)
+    expect(record.mock.calls[0][0]).toBe('Run code')
+  })
+})
+
+describe('the run_code tool definition', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('is registered and marked as mutating', () => {
+    const definition = getToolDefinition('run_code')
+
+    expect(definition?.annotations.readOnlyHint).toBe(false)
+    // The loop serializes a batch as soon as one call in it can mutate
+    expect(definition?.annotations.destructiveHint).toBe(true)
+  })
+
+  it('is findable by the queries someone would actually type', async () => {
+    const { scoreTools } = await import('./agent/tool-router')
+
+    for (const query of ['run javascript', 'evaluate code', 'compute a statistic']) {
+      expect(scoreTools(query).map(m => m.name)).toContain('run_code')
+    }
+  })
+})

--- a/noodles-editor/src/ai-chat/run-code.ts
+++ b/noodles-editor/src/ai-chat/run-code.ts
@@ -1,0 +1,325 @@
+// The run_code tool: evaluate JavaScript against the live graph.
+//
+// This is CodeOp's sandbox without a node — same `op()`, same timeline values, same
+// d3/turf/deck/utils/operator classes — so what the model already knows about
+// writing CodeOp code transfers unchanged. What it adds over CodeOp is that nothing
+// is persisted: the model can compute an answer, check a shape, or try a transform
+// without first building a node to hold it.
+//
+// Two things are deliberate rather than incidental:
+//
+// - Results are summarized here, not by result-budget.ts alone. The budget caps what
+//   reaches the model, but it serializes the whole value first, and serializing a
+//   million-row array to then throw it away costs hundreds of megabytes of string.
+// - Field-value changes are wrapped in one undo entry. Nothing stops code from
+//   reaching further than that (the store is in scope), which is why the tool
+//   description points structural edits at apply_modifications instead.
+
+import { safeMode } from '../noodles/globals'
+import { fnWithSource, freeExports, type IOperator, type Operator } from '../noodles/operators'
+import { getOp } from '../noodles/store'
+import { captureOperatorInputs, firePropertyMutation } from '../noodles/utils/property-history'
+import { getTimelineContext } from '../noodles/utils/timeline-context'
+import type { ToolResult } from './types'
+
+export interface RunCodeParams {
+  code: string
+  // How long to wait on a returned promise. Sync code cannot be interrupted at all;
+  // see the note on TIMEOUT_MS.
+  timeoutMs?: number
+}
+
+// Previews are shaped for a model reading them, not for completeness — the
+// budget's own ladder is a fallback, not the first line of defence.
+const MAX_ITEMS = 20
+const MAX_KEYS = 40
+const MAX_STRING = 2000
+const MAX_DEPTH = 6
+
+const MAX_LOGS = 40
+const MAX_LOG_CHARS = 500
+
+// Bounds the await, not the code. A synchronous infinite loop hangs the tab and no
+// amount of racing changes that — the only real fix is a worker, and a worker cannot
+// see the graph, which is the entire point of this tool. What this does catch is the
+// realistic hang: an await on a fetch that never resolves, which would otherwise
+// wedge the agent loop with no step limit to save it.
+const TIMEOUT_MS = 10_000
+const MAX_TIMEOUT_MS = 60_000
+
+type LogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug'
+const LOG_LEVELS: LogLevel[] = ['log', 'info', 'warn', 'error', 'debug']
+
+export async function runCode(params: RunCodeParams): Promise<ToolResult> {
+  // Safe mode exists to stop the app executing arbitrary code. A tool whose whole
+  // job is that has to refuse, and tool-definitions.ts also stops it being offered.
+  if (safeMode) {
+    return { success: false, error: 'run_code is disabled in safe mode' }
+  }
+
+  const code = typeof params.code === 'string' ? params.code.trim() : ''
+  if (!code) return { success: false, error: 'run_code requires a non-empty code string' }
+
+  const timeoutMs = Math.min(
+    MAX_TIMEOUT_MS,
+    Math.max(1, Math.floor(params.timeoutMs ?? TIMEOUT_MS))
+  )
+
+  let fn: ReturnType<typeof fnWithSource>
+  try {
+    fn = fnWithSource(
+      ['op', 'sequenceTime', 'frame', 'totalFrames', 'sequence', ...Object.keys(freeExports)],
+      code,
+      'run_code'
+    )
+  } catch (error) {
+    // fnWithSource already turns the raw SyntaxError into something actionable
+    return { success: false, error: message(error) }
+  }
+
+  const timeline = getTimelineContext()
+  const before = captureOperatorInputs()
+  const logs: string[] = []
+  const restore = captureConsole(logs)
+  const started = performance.now()
+
+  let raw: unknown
+  try {
+    raw = fn(
+      requireOp,
+      timeline.sequenceTime,
+      timeline.frame,
+      timeline.totalFrames,
+      timeline.sequence,
+      ...Object.values(freeExports)
+    )
+  } catch (error) {
+    restore()
+    return failure(error, logs, started, before)
+  }
+
+  if (!(raw instanceof Promise)) {
+    restore()
+    return success(raw, logs, started, before)
+  }
+
+  let timedOut = false
+  try {
+    raw = await withTimeout(raw, timeoutMs, () => {
+      timedOut = true
+    })
+  } catch (error) {
+    restore()
+    return failure(error, logs, started, before)
+  } finally {
+    restore()
+  }
+
+  if (timedOut) {
+    return {
+      success: false,
+      error: `run_code timed out after ${timeoutMs}ms. The code may still be running; it was awaited, not cancelled.`,
+      data: { logs: logs.length > 0 ? logs : undefined },
+    }
+  }
+
+  return success(raw, logs, started, before)
+}
+
+function success(
+  value: unknown,
+  logs: string[],
+  started: number,
+  before: string | null
+): ToolResult {
+  return {
+    success: true,
+    data: {
+      result: describe(value, 0, []),
+      logs: logs.length > 0 ? logs : undefined,
+      ms: Math.round(performance.now() - started),
+      ...commitMutations(before),
+    },
+  }
+}
+
+function failure(
+  error: unknown,
+  logs: string[],
+  started: number,
+  before: string | null
+): ToolResult {
+  return {
+    success: false,
+    error: message(error),
+    // Logs from before the throw are usually where the reason is
+    data: {
+      logs: logs.length > 0 ? logs : undefined,
+      ms: Math.round(performance.now() - started),
+      ...commitMutations(before),
+    },
+  }
+}
+
+// One undo entry per call that actually changed a field value, and none at all for
+// pure computation. Only covers field values: adding or deleting operators goes
+// through apply_modifications, which the UI applies with its own history.
+function commitMutations(before: string | null): { changedFieldValues?: true } {
+  if (before === null) return {}
+  const after = captureOperatorInputs()
+  if (after === null || after === before) return {}
+  firePropertyMutation('Run code', before)
+  return { changedFieldValues: true }
+}
+
+function requireOp(path: string): Operator<IOperator> {
+  const op = getOp(path)
+  if (!op) throw new Error(`Operator '${path}' not found`)
+  return op
+}
+
+function message(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack?.split('\n')[0] ?? `${error.name}: ${error.message}`
+  }
+  return String(error)
+}
+
+// Collects what the code logs so a model can debug the way a person would. The
+// window is narrow but not exclusive — anything else in the app that logs while an
+// awaited promise is in flight lands here too.
+function captureConsole(logs: string[]): () => void {
+  const original = new Map<LogLevel, (...args: unknown[]) => void>()
+
+  for (const level of LOG_LEVELS) {
+    original.set(level, console[level])
+    console[level] = (...args: unknown[]) => {
+      if (logs.length < MAX_LOGS) {
+        const text = args.map(formatLogArg).join(' ')
+        logs.push(
+          level === 'log' ? clip(text, MAX_LOG_CHARS) : `[${level}] ${clip(text, MAX_LOG_CHARS)}`
+        )
+        if (logs.length === MAX_LOGS) logs.push(`[${MAX_LOGS} log limit reached, rest dropped]`)
+      }
+      original.get(level)?.(...args)
+    }
+  }
+
+  return () => {
+    for (const [level, fn] of original) console[level] = fn
+  }
+}
+
+function formatLogArg(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(describe(value, MAX_DEPTH - 2, [])) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function clip(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}…[clipped, ${text.length} chars]`
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  onTimeout: () => void
+): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const expiry = new Promise<undefined>(resolve => {
+    timer = setTimeout(() => {
+      onTimeout()
+      resolve(undefined)
+    }, ms)
+  })
+  try {
+    return await Promise.race([promise, expiry])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+// Turns an arbitrary runtime value into something small, JSON-safe and honest about
+// what it left out. Markers are bracketed strings, matching result-budget's
+// '[circular]', so a model reading a preview can tell it is reading a preview.
+export function describe(value: unknown, depth: number, ancestors: unknown[]): unknown {
+  if (value === undefined) return '[undefined]'
+  if (value === null) return null
+
+  if (typeof value === 'number') {
+    // JSON.stringify turns these into null, which reads as "no value" when what
+    // the model needs to see is that the arithmetic went wrong
+    return Number.isFinite(value) ? value : `[${String(value)}]`
+  }
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'bigint') return `${value}n`
+  if (typeof value === 'symbol') return `[${String(value)}]`
+  if (typeof value === 'string') return clip(value, MAX_STRING)
+  if (typeof value === 'function') return `[Function: ${value.name || 'anonymous'}]`
+
+  if (value instanceof Error) return { error: value.name, message: value.message }
+  if (value instanceof Date) return value.toISOString()
+  if (value instanceof RegExp) return String(value)
+
+  if (depth >= MAX_DEPTH) return '[nested too deep to show]'
+  // Cheaper and more precise than a Set: only true ancestors are cycles, so
+  // sibling repeats still render
+  if (ancestors.includes(value)) return '[circular]'
+  const path = [...ancestors, value]
+
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    const typed = value as unknown as {
+      length: number
+      slice(a: number, b: number): ArrayLike<number>
+    }
+    return {
+      type: value.constructor.name,
+      length: typed.length,
+      sample: Array.from(typed.slice(0, MAX_ITEMS)),
+    }
+  }
+
+  if (Array.isArray(value)) {
+    const items = value.slice(0, MAX_ITEMS).map(item => describe(item, depth + 1, path))
+    if (value.length <= MAX_ITEMS) return items
+    return { length: value.length, sample: items, note: `first ${MAX_ITEMS} of ${value.length}` }
+  }
+
+  if (value instanceof Map) {
+    return {
+      type: 'Map',
+      size: value.size,
+      entries: [...value.entries()]
+        .slice(0, MAX_ITEMS)
+        .map(([k, v]) => [describe(k, depth + 1, path), describe(v, depth + 1, path)]),
+    }
+  }
+
+  if (value instanceof Set) {
+    return {
+      type: 'Set',
+      size: value.size,
+      values: [...value].slice(0, MAX_ITEMS).map(item => describe(item, depth + 1, path)),
+    }
+  }
+
+  // Operators serialize enormously and are identified by path anyway
+  if (isOperator(value)) return `[Operator ${value.id}]`
+
+  const entries = Object.entries(value as Record<string, unknown>)
+  const out: Record<string, unknown> = {}
+  for (const [key, item] of entries.slice(0, MAX_KEYS)) {
+    out[key] = describe(item, depth + 1, path)
+  }
+  if (entries.length > MAX_KEYS) {
+    out._omittedKeys = entries.length - MAX_KEYS
+  }
+  return out
+}
+
+function isOperator(value: object): value is { id: string } {
+  return 'id' in value && 'inputs' in value && 'outputs' in value && typeof value.id === 'string'
+}

--- a/noodles-editor/src/ai-chat/tool-definitions.test.ts
+++ b/noodles-editor/src/ai-chat/tool-definitions.test.ts
@@ -11,6 +11,11 @@ const ALL_TOOL_NAMES = [
   'get_render_stats',
   'inspect_layer',
   'apply_modifications',
+  'run_code',
+  'list_files',
+  'read_file',
+  'write_file',
+  'grep_files',
   'get_current_project',
   'list_nodes',
   'get_node_info',
@@ -64,9 +69,18 @@ describe('toolDefinitions', () => {
     expect(writeTools.sort()).toEqual([
       'apply_modifications',
       'delete_keyframe',
+      'run_code',
       'set_keyframe',
       'set_playback_position',
+      'write_file',
     ])
+  })
+
+  it('gates only run_code on availability', () => {
+    // Everything else must be unconditionally available, or WebMCP and the router
+    // would quietly disagree about the surface depending on how they were reached
+    const gated = toolDefinitions.filter(d => d.available).map(d => d.name)
+    expect(gated).toEqual(['run_code'])
   })
 
   it('declares annotations on every definition', () => {

--- a/noodles-editor/src/ai-chat/tool-definitions.ts
+++ b/noodles-editor/src/ai-chat/tool-definitions.ts
@@ -2,7 +2,15 @@
 // registration (src/webmcp/). Single source of truth so the provider input_schema
 // and the navigator.modelContext inputSchema can't drift.
 
+import { safeMode } from '../noodles/globals'
+import type {
+  GrepFilesParams,
+  ListFilesParams,
+  ReadFileParams,
+  WriteFileParams,
+} from './agent-files'
 import type { MCPTools } from './mcp-tools'
+import type { RunCodeParams } from './run-code'
 import type { NoodlesProject, SearchCodeParams, ToolResult } from './types'
 
 // JSON Schema subset accepted by both Anthropic tools and WebMCP registerTool
@@ -28,6 +36,11 @@ export interface ToolDefinition {
   description: string
   annotations: ToolAnnotations
   inputSchema: ToolInputSchema
+  // Omitted means always available. Only run_code sets it: safe mode exists to stop
+  // the app executing arbitrary code, so the tool has to disappear rather than be
+  // offered and then refuse. Read through getToolDefinition and
+  // availableToolDefinitions, never off the raw array.
+  available?: () => boolean
   // getProject supplies the live project for tools that need it injected (analyze_project)
   execute: (
     tools: MCPTools,
@@ -128,6 +141,101 @@ export const toolDefinitions: ToolDefinition[] = [
     },
     // biome-ignore lint/suspicious/noExplicitAny: dynamic modification structure from Claude
     execute: (tools, params) => tools.applyModifications(params as { modifications: any[] }),
+  },
+  {
+    name: 'run_code',
+    annotations: { readOnlyHint: false, destructiveHint: true },
+    // This description is what find_tools scores against, so it names the libraries
+    // by the identifiers they are bound to — that is how a query like "compute a
+    // distance" or "check the shape of the data" reaches it.
+    description:
+      "Run JavaScript against the live graph and get the value back. The same sandbox CodeOp uses: op('/node-id').out.data and .par.field read any operator's output or input, and d3, turf, deck, Plot, Temporal, utils and every operator class are in scope, plus sequenceTime, frame, totalFrames and sequence. Use it to compute a statistic, inspect the shape of a dataset, test a transform before committing it to a CodeOp, or check what an accessor would return. Return a value to see it; console.log is captured too. Large results come back as a sample with a length. Runs on the main thread, so no unbounded loops. Use apply_modifications to add or remove nodes — this tool is for computing and reading.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description: 'JavaScript function body. Use return to produce a value; await is allowed.',
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'How long to wait on an async result (default 10000, max 60000)',
+        },
+      },
+      required: ['code'],
+    },
+    available: () => !safeMode,
+    execute: (tools, params) => tools.runCode(params as unknown as RunCodeParams),
+  },
+  // Project data directory. Reads reach the whole directory; writes only @/.agent/
+  {
+    name: 'list_files',
+    annotations: { readOnlyHint: true },
+    description:
+      "List the data files in the project's data directory — the CSV, JSON and GeoJSON files its FileOp and DuckDbOp nodes load, referenced as @/name.csv. Use it to find out what data a project actually has before assuming a file name. Pass path to list one subdirectory.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Subdirectory to list, relative to the data directory. Omit for all files.',
+        },
+        maxResults: { type: 'number', description: 'Default 200' },
+      },
+    },
+    execute: (tools, params) => tools.listFiles(params as ListFilesParams),
+  },
+  {
+    name: 'read_file',
+    annotations: { readOnlyHint: true },
+    description:
+      'Read a text file from the project data directory: a CSV header and rows, a GeoJSON, a config. Accepts @/name.csv or name.csv. Small files come back whole; a large one comes back as a line count plus head and tail, and startLine/endLine page through it. For computing over a whole large file, use run_code instead of reading it into the conversation.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'File path, e.g. @/trips.csv or .agent/joined.csv' },
+        startLine: { type: 'number', description: '1-based, inclusive' },
+        endLine: { type: 'number', description: '1-based, inclusive' },
+      },
+      required: ['path'],
+    },
+    execute: (tools, params) => tools.readFile(params as unknown as ReadFileParams),
+  },
+  {
+    name: 'write_file',
+    annotations: { readOnlyHint: false, destructiveHint: false },
+    description:
+      "Write a text file into the project's scratch directory, @/.agent/. Use it to save a derived dataset — a joined or aggregated CSV, a GeoJSON you generated in run_code — then point a FileOp's url at the returned @/.agent/… path to bring it into the graph. Writes are only allowed inside @/.agent/; the project's own input data is read-only, so this can never overwrite a source dataset. Replacing a scratch file keeps the old contents at @/.agent/.previous/.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Path inside the scratch directory, e.g. .agent/joined.csv',
+        },
+        content: { type: 'string', description: 'Full file contents' },
+      },
+      required: ['path', 'content'],
+    },
+    execute: (tools, params) => tools.writeFile(params as unknown as WriteFileParams),
+  },
+  {
+    name: 'grep_files',
+    annotations: { readOnlyHint: true },
+    description:
+      'Search the project data files for a JavaScript regular expression and get back matching lines with file and line number. Use it to find which file holds a column or a value, or to check whether a dataset contains something, without reading whole files into the conversation. Binary and very large files are skipped and reported.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'JavaScript regular expression source' },
+        path: { type: 'string', description: 'Limit to a subdirectory of the data directory' },
+        contextLines: { type: 'number', description: 'Lines of context each side, 0-5' },
+        maxResults: { type: 'number', description: 'Default 20, max 40' },
+        ignoreCase: { type: 'boolean' },
+      },
+      required: ['pattern'],
+    },
+    execute: (tools, params) => tools.grepFiles(params as unknown as GrepFilesParams),
   },
   {
     name: 'get_current_project',
@@ -424,6 +532,18 @@ export const toolDefinitions: ToolDefinition[] = [
 
 const definitionsByName = new Map(toolDefinitions.map(d => [d.name, d]))
 
+// The gate has to sit here rather than only on discovery: the agent loop dispatches
+// by name and runs a tool the model was never offered, on the reasoning that the
+// definition is real and the call is well-formed. Returning undefined turns that
+// into "Unknown tool", and makes isReadOnly fall back to treating it as mutating.
 export function getToolDefinition(name: string): ToolDefinition | undefined {
-  return definitionsByName.get(name)
+  const definition = definitionsByName.get(name)
+  if (!definition || definition.available?.() === false) return undefined
+  return definition
+}
+
+// Every tool currently on offer. Use this for listing and scoring; the raw
+// toolDefinitions array includes tools that are unavailable in this session.
+export function availableToolDefinitions(): ToolDefinition[] {
+  return toolDefinitions.filter(d => d.available?.() !== false)
 }

--- a/noodles-editor/src/noodles/utils/filesystem.ts
+++ b/noodles-editor/src/noodles/utils/filesystem.ts
@@ -44,11 +44,31 @@ export async function selectDirectory(): Promise<FileSystemDirectoryHandle> {
   })
 }
 
+// Resolves a '/'-separated path to the handle of its containing directory plus the
+// bare file name. getFileHandle rejects any name containing a separator, so without
+// this a nested path is unaddressable — which is what listDataFiles returns for a
+// project with subdirectories, and where the assistant's scratch files live.
+async function resolveParent(
+  directoryHandle: FileSystemDirectoryHandle,
+  path: string,
+  create: boolean
+): Promise<{ directory: FileSystemDirectoryHandle; name: string }> {
+  const segments = path.split('/').filter(segment => segment !== '')
+  if (segments.length === 0) throw new TypeError(`Not a file path: '${path}'`)
+
+  let directory = directoryHandle
+  for (const segment of segments.slice(0, -1)) {
+    directory = await directory.getDirectoryHandle(segment, { create })
+  }
+  return { directory, name: segments[segments.length - 1] }
+}
+
 export async function readFileFromDirectory(
   directoryHandle: FileSystemDirectoryHandle,
   fileName: string
 ): Promise<string> {
-  const fileHandle = await directoryHandle.getFileHandle(fileName)
+  const { directory, name } = await resolveParent(directoryHandle, fileName, false)
+  const fileHandle = await directory.getFileHandle(name)
   const file = await fileHandle.getFile()
   return await file.text()
 }
@@ -57,7 +77,8 @@ export async function readFileFromDirectoryBinary(
   directoryHandle: FileSystemDirectoryHandle,
   fileName: string
 ): Promise<ArrayBuffer> {
-  const fileHandle = await directoryHandle.getFileHandle(fileName)
+  const { directory, name } = await resolveParent(directoryHandle, fileName, false)
+  const fileHandle = await directory.getFileHandle(name)
   const file = await fileHandle.getFile()
   return await file.arrayBuffer()
 }
@@ -67,7 +88,9 @@ export async function writeFileToDirectory(
   fileName: string,
   contents: FileSystemWriteChunkType
 ): Promise<void> {
-  const fileHandle = await directoryHandle.getFileHandle(fileName, {
+  // Intermediate directories are created on write, but never on read
+  const { directory, name } = await resolveParent(directoryHandle, fileName, true)
+  const fileHandle = await directory.getFileHandle(name, {
     create: true,
   })
 
@@ -81,7 +104,8 @@ export async function fileExists(
   fileName: string
 ): Promise<boolean> {
   try {
-    await directoryHandle.getFileHandle(fileName)
+    const { directory, name } = await resolveParent(directoryHandle, fileName, false)
+    await directory.getFileHandle(name)
     return true
   } catch (_error) {
     return false

--- a/noodles-editor/src/webmcp/register.ts
+++ b/noodles-editor/src/webmcp/register.ts
@@ -9,7 +9,7 @@
 import type { InputSchema } from '@mcp-b/webmcp-types'
 import { globalContextManager } from '../ai-chat/global-context-manager'
 import { MCPTools } from '../ai-chat/mcp-tools'
-import { type ToolDefinition, toolDefinitions } from '../ai-chat/tool-definitions'
+import { availableToolDefinitions, type ToolDefinition } from '../ai-chat/tool-definitions'
 import type { ProjectModification, ToolResult } from '../ai-chat/types'
 import type { ProjectModification as ReactFlowModification } from '../noodles/hooks/use-project-modifications'
 import { safeStringify } from '../noodles/utils/serialization'
@@ -64,7 +64,11 @@ export async function initWebMCP(signal: AbortSignal): Promise<void> {
     const unsubscribe = onProjectChange(p => tools.setProject(p))
     signal.addEventListener('abort', unsubscribe)
 
-    for (const definition of toolDefinitions) {
+    // Skips tools this session does not offer — run_code is absent in safe mode,
+    // which external clients have to respect for the same reason the chat does
+    const definitions = availableToolDefinitions()
+
+    for (const definition of definitions) {
       navigator.modelContext.registerTool(
         {
           name: definition.name,
@@ -78,7 +82,7 @@ export async function initWebMCP(signal: AbortSignal): Promise<void> {
       )
     }
 
-    debugWebMCP('registered %d tools on navigator.modelContext', toolDefinitions.length)
+    debugWebMCP('registered %d tools on navigator.modelContext', definitions.length)
   } catch (error) {
     active = false
     throw error


### PR DESCRIPTION
#### Background

The in-app assistant works well with a frontier model and poorly without an API key, and the 22 tools it had included no eval and no scratch space — which is the capability gap between it and a coding agent, not a gap in the loop. This adds both, plus makes Chrome's on-device model as good as its API allows, so someone with no credential still gets a working assistant.

#### Change List

- **Chrome on-device provider** — native Prompt API tool calling when available, existing JSON emulation as fallback (same `tool_call` events either way); one session reused across turns instead of one per turn; tool schemas moved into `initialPrompts`, which are never evicted; `measureContextUsage()` trimming before overflow rather than catching `QuotaExceededError` after; new optional `AgentProvider.dispose()` since that session owns the transcript.
- **`run_code`** — evaluates JS in the same sandbox CodeOp uses (`op()`, `d3`, `turf`, `utils` in scope), gated on `safeMode` via `available?()` so it disappears from discovery and dispatch together; `webmcp/register.ts` now reads `availableToolDefinitions()` so external clients respect the same gate.
- **Agent filesystem** — `list_files`, `read_file`, `write_file`, `grep_files` over the project's data directory via `noodles/storage.ts`, so a written file loads in a FileOp at `@/.agent/x.csv` with no import step. Reads reach all of `data/`; writes only `data/.agent/`, and `resolvePath()` checks the resolved segments so a `../` cannot escape by construction. Replaced scratch files are kept at `@/.agent/.previous/`; `read_file` summarizes large files to head/tail before `result-budget.ts` sees them.
- **Supporting fix** — `resolveParent()` in `noodles/utils/filesystem.ts` walks nested paths segment by segment, because `getFileHandle` rejects any name containing a `/`.
- **Docs** — new agent-filesystem section and refreshed cost table in `dev-docs/agent-harness.md`, security-boundary note in `AGENTS.md`, new capabilities in `docs/users/ai-assistant.md`.

#### Test Runbook

1. Open \`http://localhost:5173/examples/nyc-taxis\`, ask the assistant to compute mean fare by hour and save it as a CSV — it should write \`@/.agent/…\`, wire a FileOp to it, and report rows.
2. Ask it to write to \`trips.csv\` — it should refuse and name the scratch directory.
3. Reload with \`?safeMode=true\` — \`run_code\` should be absent from \`find_tools\` results.
4. \`cd noodles-editor && npx vitest run src/ai-chat src/webmcp\` → 306 pass.

#### Known gap (pre-existing, not addressed here)

\`apply_modifications\` graph edits are not undoable: \`useProjectModifications.applyModifications\` calls \`setNodes\`/\`setEdges\` directly, while \`use-undo-redo.ts\` records history by intercepting React Flow's \`onNodesChange\`. That predates this PR and affects the chat and WebMCP equally, but it means agent graph edits currently have neither an approval prompt nor an undo. File writes are likewise not in the undo stack, mitigated by the write sandbox plus \`@/.agent/.previous/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)