### PR TITLE
fix: sync bounding box fit with render size

### DIFF
--- a/noodles-editor/scripts/parse-operators.ts
+++ b/noodles-editor/scripts/parse-operators.ts
@@ -155,6 +155,10 @@ function parseFieldsFromReturnExpression(
       }
     }
 
+    // Host-injected runtime inputs are implementation details, not user-facing
+    // operator parameters, so leave them out of the generated AI/tool registry.
+    if (options.runtimeOnly === true) continue
+
     fields.push({
       name: fieldName,
       fieldType,

--- a/noodles-editor/src/noodles/components/copy-controls.tsx
+++ b/noodles-editor/src/noodles/components/copy-controls.tsx
@@ -12,7 +12,12 @@ import {
   identifyContainerChildren,
   remapPastedIds,
 } from '../utils/copy-paste-utils'
-import { type CopiedNodesJSON, safeStringify, serializeNodes } from '../utils/serialization'
+import {
+  type CopiedNodesJSON,
+  isRuntimeOnlyInputEdge,
+  safeStringify,
+  serializeNodes,
+} from '../utils/serialization'
 
 export interface CopyControlsProps {
   graphRef: GraphRef
@@ -89,7 +94,8 @@ export const CopyControls = forwardRef<CopyControlsRef, CopyControlsProps>(
       const serializedNodes = serializeNodes(store, nodesToCopy, edgesToCopy, {
         forClipboard: true,
       })
-      const data = safeStringify({ nodes: serializedNodes, edges: edgesToCopy })
+      const serializedEdges = edgesToCopy.filter(edge => !isRuntimeOnlyInputEdge(store, edge))
+      const data = safeStringify({ nodes: serializedNodes, edges: serializedEdges })
 
       clipboardDataRef.current = data
       copy(data)

--- a/noodles-editor/src/noodles/components/node-properties.tsx
+++ b/noodles-editor/src/noodles/components/node-properties.tsx
@@ -69,7 +69,7 @@ import { SuggestedNodesSection } from './SuggestedNodes'
 function getDefaultVisibleFields(op: Operator<IOperator>): Set<string> {
   return new Set(
     Object.entries(op.inputs)
-      .filter(([_, field]) => field.showByDefault)
+      .filter(([_, field]) => field.showByDefault && !field.runtimeOnly)
       .map(([name]) => name)
   )
 }
@@ -572,17 +572,19 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
   // Early return after all hooks
   if (!op) return null
 
-  const inputs = Object.entries(op.inputs).map(([name, input]) => {
-    const { type } = input.constructor as typeof Field
-    return {
-      name,
-      type,
-      codeRef: `op('${op.id}').${IN_NS}.${name}`,
-      mustacheRef: `{{${op.id}.${IN_NS}.${name}}}`,
-      handleClass: handleClass(input),
-      field: input,
-    }
-  })
+  const inputs = Object.entries(op.inputs)
+    .filter(([_, input]) => !input.runtimeOnly)
+    .map(([name, input]) => {
+      const { type } = input.constructor as typeof Field
+      return {
+        name,
+        type,
+        codeRef: `op('${op.id}').${IN_NS}.${name}`,
+        mustacheRef: `{{${op.id}.${IN_NS}.${name}}}`,
+        handleClass: handleClass(input),
+        field: input,
+      }
+    })
 
   const outputs = Object.entries(op.outputs).map(([name, output]) => {
     const { type } = output.constructor as typeof Field
@@ -792,7 +794,7 @@ export function NodeProperties({ nodeId }: { nodeId: string }) {
       <div className={s.section}>
         <div className={s.sectionHeader}>
           <div className={s.sectionTitle}>Inputs</div>
-          {Object.keys(op.inputs).length > 0 &&
+          {inputs.length > 0 &&
             op.visibleFields.value !== null &&
             (() => {
               const { toHide, toShow } = getVisibilityChanges(op, edges)

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -28,6 +28,7 @@ export interface IField<
   addConnection<F extends Field>(id: string, field: F): void
   removeConnection(id: string, connectionType: 'reference' | 'value'): void
   serialize(): z.infer<S>
+  runtimeOnly?: boolean
 }
 
 type BaseFieldOptions = {
@@ -37,6 +38,7 @@ type BaseFieldOptions = {
   showByDefault?: boolean // Defaults to true. Set to false to hide field by default in UI.
   useDeepEquality?: boolean // Use deep equality when comparing values to prevent unnecessary updates
   maxDepth?: number // Maximum depth for deep equality checks (Infinity = unlimited)
+  runtimeOnly?: boolean // Runtime-injected input; excluded from project serialization and history
 }
 
 type PointFieldOptions = BaseFieldOptions & {
@@ -136,6 +138,10 @@ export abstract class Field<
   // Infinity = unlimited depth, 0 = reference equality only, 1 = shallow, 2+ = limited depth
   maxDepth = Infinity
 
+  // Runtime-only fields participate in operator execution like normal inputs, but
+  // their environment-derived values are never persisted with the project.
+  runtimeOnly = false
+
   // Hold a reference to the operator that owns this field. Only used for debugging at the moment.
   op!: Operator<IOperator>
 
@@ -199,6 +205,7 @@ export abstract class Field<
     showByDefault,
     useDeepEquality,
     maxDepth,
+    runtimeOnly,
   }: Partial<O>) {
     let schema = this.schema
 
@@ -215,6 +222,10 @@ export abstract class Field<
     // Set maxDepth if specified
     if (maxDepth !== undefined) {
       this.maxDepth = maxDepth
+    }
+
+    if (runtimeOnly !== undefined) {
+      this.runtimeOnly = runtimeOnly
     }
 
     if (accessor) {
@@ -305,6 +316,7 @@ export abstract class Field<
     field: F,
     connectionType: 'reference' | 'value' = 'value'
   ) {
+    if (this.runtimeOnly) return
     if (this.subscriptions.has(id)) {
       return
     }
@@ -1408,6 +1420,7 @@ export class CompoundPropsField extends Field<
     field: F,
     connectionType: 'reference' | 'value' = 'value'
   ): Subscription | undefined {
+    if (this.runtimeOnly) return
     if (this.subscriptions.has(id)) {
       return
     }
@@ -1449,6 +1462,7 @@ export class ListField<F extends Field> extends Field<
   // Overrides the default setValue to handle a list of fields
   // TODO: Do we need to handle reference connections?
   addConnection(id: string, field: F, _connectionType: 'reference' | 'value' = 'value') {
+    if (this.runtimeOnly) return
     if (this.subscriptions.has(id)) {
       return
     }

--- a/noodles-editor/src/noodles/hooks/__tests__/use-project-modifications.test.tsx
+++ b/noodles-editor/src/noodles/hooks/__tests__/use-project-modifications.test.tsx
@@ -4,7 +4,7 @@
 import { act, renderHook } from '@testing-library/react'
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { ConcatOp, ContainerOp, DeckRendererOp, NumberOp } from '../../operators'
+import { BoundingBoxOp, ConcatOp, ContainerOp, DeckRendererOp, NumberOp } from '../../operators'
 import { clearOps, getOp, hasOp, setOp, setPendingInsertionIndex } from '../../store'
 import { MULTI_INPUT_EDGE_TYPE } from '../../utils/multi-input-utils'
 import { type ProjectModification, useProjectModifications } from '../use-project-modifications'
@@ -189,6 +189,31 @@ describe('useProjectModifications', () => {
       expect(op.isFieldVisible('effects')).toBe(true)
       expect(op.visibleFields.value).toBeInstanceOf(Set)
       expect(op.visibleFields.value?.has('effects')).toBe(true)
+    })
+
+    it('does not capture programmatic updates to runtime-only inputs', () => {
+      const op = new BoundingBoxOp('/bbox')
+      setOp('/bbox', op as never)
+      nodes = [
+        {
+          id: '/bbox',
+          type: 'BoundingBoxOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: {} },
+        },
+      ]
+      const { result } = renderHook(() =>
+        useProjectModifications({ getNodes, getEdges, setNodes, setEdges })
+      )
+
+      act(() => {
+        result.current.updateNode('/bbox', {
+          data: { inputs: { viewportSize: { x: 1, y: 1 } } },
+        })
+      })
+
+      expect(op.inputs.viewportSize.value).toEqual({ x: 3840, y: 2160 })
+      expect((nodes[0].data.inputs as Record<string, unknown>).viewportSize).toBeUndefined()
     })
   })
 

--- a/noodles-editor/src/noodles/hooks/use-project-modifications.ts
+++ b/noodles-editor/src/noodles/hooks/use-project-modifications.ts
@@ -54,6 +54,16 @@ interface UseProjectModificationsOptions {
   setEdges: (edges: ReactFlowEdge[] | ((edges: ReactFlowEdge[]) => ReactFlowEdge[])) => void
 }
 
+function omitRuntimeOnlyInputs(
+  operator: Operator<IOperator> | undefined,
+  inputs: Record<string, unknown>
+): Record<string, unknown> {
+  if (!operator) return inputs
+  return Object.fromEntries(
+    Object.entries(inputs).filter(([name]) => !operator.inputs[name]?.runtimeOnly)
+  )
+}
+
 export function useProjectModifications(options: UseProjectModificationsOptions) {
   const { getNodes, getEdges, setNodes, setEdges } = options
 
@@ -356,16 +366,19 @@ export function useProjectModifications(options: UseProjectModificationsOptions)
 
       // Get the operator instance from store
       const operator = getOp(nodeId)
+      const requestedInputs = updates.data?.inputs
+      const editableInputs = requestedInputs
+        ? omitRuntimeOnlyInputs(operator, requestedInputs)
+        : undefined
 
-      if (operator && updates.data?.inputs) {
+      if (operator && editableInputs) {
         // Update operator inputs using setValue
-        const inputs = updates.data.inputs
-        Object.entries(inputs).forEach(([key, value]: [string, unknown]) => {
+        Object.entries(editableInputs).forEach(([key, value]: [string, unknown]) => {
           const operatorInputs = (operator as unknown as Record<string, unknown>).inputs as
-            | Record<string, { setValue?: (value: unknown) => void }>
+            | Record<string, { runtimeOnly?: boolean; setValue?: (value: unknown) => void }>
             | undefined
           const input = operatorInputs?.[key]
-          if (input && typeof input.setValue === 'function') {
+          if (input && !input.runtimeOnly && typeof input.setValue === 'function') {
             input.setValue(value)
             // Auto-show field when value is set programmatically (AI tools)
             operator.showField(key)
@@ -382,17 +395,14 @@ export function useProjectModifications(options: UseProjectModificationsOptions)
             const nodeData = (n.data || {}) as Record<string, unknown>
             const updatesData = (updates.data || {}) as Record<string, unknown>
             const nodeInputs = (nodeData.inputs || {}) as Record<string, unknown>
-            const updateInputs = (updatesData.inputs || {}) as Record<string, unknown>
+            const updateInputs = editableInputs ?? {}
             return {
               ...n,
               ...updates,
               data: {
                 ...nodeData,
                 ...updatesData,
-                inputs: {
-                  ...nodeInputs,
-                  ...updateInputs,
-                },
+                inputs: omitRuntimeOnlyInputs(operator, { ...nodeInputs, ...updateInputs }),
               },
             }
           }
@@ -503,17 +513,17 @@ export function useProjectModifications(options: UseProjectModificationsOptions)
             const nodeData = (n.data || {}) as Record<string, unknown>
             const updatesData = (update.updates.data || {}) as Record<string, unknown>
             const nodeInputs = (nodeData.inputs || {}) as Record<string, unknown>
-            const updateInputs = (updatesData.inputs || {}) as Record<string, unknown>
+            const updateInputs = omitRuntimeOnlyInputs(
+              getOp(n.id),
+              (updatesData.inputs || {}) as Record<string, unknown>
+            )
             return {
               ...n,
               ...update.updates,
               data: {
                 ...nodeData,
                 ...updatesData,
-                inputs: {
-                  ...nodeInputs,
-                  ...updateInputs,
-                },
+                inputs: omitRuntimeOnlyInputs(getOp(n.id), { ...nodeInputs, ...updateInputs }),
               },
             }
           }
@@ -538,17 +548,17 @@ export function useProjectModifications(options: UseProjectModificationsOptions)
               const nodeData = (n.data || {}) as Record<string, unknown>
               const updatesData = (update.updates.data || {}) as Record<string, unknown>
               const nodeInputs = (nodeData.inputs || {}) as Record<string, unknown>
-              const updateInputs = (updatesData.inputs || {}) as Record<string, unknown>
+              const updateInputs = omitRuntimeOnlyInputs(
+                getOp(n.id),
+                (updatesData.inputs || {}) as Record<string, unknown>
+              )
               return {
                 ...n,
                 ...update.updates,
                 data: {
                   ...nodeData,
                   ...updatesData,
-                  inputs: {
-                    ...nodeInputs,
-                    ...updateInputs,
-                  },
+                  inputs: omitRuntimeOnlyInputs(getOp(n.id), { ...nodeInputs, ...updateInputs }),
                 },
               }
             }
@@ -566,10 +576,10 @@ export function useProjectModifications(options: UseProjectModificationsOptions)
           const inputs = updates.data.inputs as Record<string, unknown>
           for (const [key, value] of Object.entries(inputs)) {
             const operatorInputs = (operator as unknown as Record<string, unknown>).inputs as
-              | Record<string, { setValue?: (value: unknown) => void }>
+              | Record<string, { runtimeOnly?: boolean; setValue?: (value: unknown) => void }>
               | undefined
             const input = operatorInputs?.[key]
-            if (input && typeof input.setValue === 'function') {
+            if (input && !input.runtimeOnly && typeof input.setValue === 'function') {
               input.setValue(value)
               // Auto-show field when value is set programmatically (AI tools)
               operator.showField(key)

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -784,11 +784,12 @@ describe('BoundingBoxOp', () => {
         { lng: 3, lat: 4 },
       ],
       padding: 0,
+      viewportSize: { x: 3840, y: 2160 },
     })
     expect(val.viewState).toEqual({
       latitude: 3.000457402301878,
       longitude: 2.0000000000000027,
-      zoom: 7.185340053829005,
+      zoom: 9.566616522774169,
     })
   })
 })

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -153,6 +153,7 @@ import { projectScheme } from './utils/filesystem'
 import type { OpId } from './utils/id-utils'
 import { isDirectChild } from './utils/path-utils'
 import { pick } from './utils/pick'
+import { DEFAULT_RENDER_SETTINGS } from './utils/render-settings-constants'
 import { getTimelineContext } from './utils/timeline-context'
 import { subscribeOpToTimeline, unsubscribeOpFromTimeline } from './utils/timeline-dependencies'
 // Side-effect import: registers the field expression evaluator so { $expr } payloads
@@ -293,7 +294,7 @@ export abstract class Operator<OP extends IOperator> {
 
     if (data) {
       for (const [key, value] of Object.entries(data)) {
-        if (key in this.inputs) {
+        if (key in this.inputs && !this.inputs[key].runtimeOnly) {
           // Routes { $expr } payloads to setExpression, plain values to setValue
           applySerializedFieldValue(this.inputs[key], value)
         }
@@ -355,6 +356,7 @@ export abstract class Operator<OP extends IOperator> {
 
   // Check if a field is visible (for UI rendering)
   isFieldVisible(name: string): boolean {
+    if (this.inputs[name]?.runtimeOnly) return false
     const visible = this.visibleFields.value
     if (visible === null) {
       // Use defaults: showByDefault defaults to true
@@ -368,6 +370,8 @@ export abstract class Operator<OP extends IOperator> {
   showField(name: string): void {
     // Skip if inputs not initialized yet or field doesn't exist
     if (!this.inputs || !(name in this.inputs)) return
+    // Runtime inputs are supplied by the host environment, not edited by users.
+    if (this.inputs[name].runtimeOnly) return
     // Skip if already visible
     if (this.isFieldVisible(name)) return
 
@@ -376,7 +380,7 @@ export abstract class Operator<OP extends IOperator> {
       this.visibleFields.value ??
       new Set(
         Object.entries(this.inputs)
-          .filter(([_, field]) => field.showByDefault)
+          .filter(([_, field]) => field.showByDefault && !field.runtimeOnly)
           .map(([fieldName]) => fieldName)
       )
 
@@ -397,7 +401,7 @@ export abstract class Operator<OP extends IOperator> {
       this.visibleFields.value ??
       new Set(
         Object.entries(this.inputs)
-          .filter(([_, field]) => field.showByDefault)
+          .filter(([_, field]) => field.showByDefault && !field.runtimeOnly)
           .map(([fieldName]) => fieldName)
       )
 
@@ -2553,16 +2557,27 @@ export class BoundsOp extends Operator<BoundsOp> {
   }
 }
 
+const DEFAULT_BOUNDING_BOX_VIEWPORT_SIZE = {
+  x: Math.round(DEFAULT_RENDER_SETTINGS.resolution.width * DEFAULT_RENDER_SETTINGS.lod),
+  y: Math.round(DEFAULT_RENDER_SETTINGS.resolution.height * DEFAULT_RENDER_SETTINGS.lod),
+}
+
 export class BoundingBoxOp extends Operator<BoundingBoxOp> {
   static displayName = 'BoundingBox'
   static description =
     'Calculate the geographic bounds of your points (with lat/lng keys) and get a camera position (center, zoom) that fits them all in view.'
   asDownload = () => this.outputData
+
   createInputs() {
     return {
       data: new ArrayField(new Point2DField()),
       // TODO: could be a union, either a number or object with top, right, bottom, left
       padding: new NumberField(0, { softMin: -1_000, softMax: 1_000 }),
+      viewportSize: new Vec2Field(DEFAULT_BOUNDING_BOX_VIEWPORT_SIZE, {
+        returnType: 'object',
+        runtimeOnly: true,
+        showByDefault: false,
+      }),
     }
   }
   createOutputs() {
@@ -2578,7 +2593,11 @@ export class BoundingBoxOp extends Operator<BoundingBoxOp> {
       }),
     }
   }
-  execute({ data, padding }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
+  execute({
+    data,
+    padding,
+    viewportSize = DEFAULT_BOUNDING_BOX_VIEWPORT_SIZE,
+  }: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
     let east = -180
     let west = 180
     let north = -90
@@ -2604,13 +2623,13 @@ export class BoundingBoxOp extends Operator<BoundingBoxOp> {
       [east, north],
     ] as [[number, number], [number, number]]
 
-    // const { resolution: { width, height } } = useSlice(store => store.renderer)
-    // TODO: get the state values. Currently broken due to tests
-    // Different containers for interleaved and pure deck.gl mode
-    const container =
-      document.querySelector('.deckgl-container') || document.querySelector('.maplibregl-map')
-    const width = container?.clientWidth || window.innerWidth
-    const height = container?.clientHeight || window.innerHeight
+    if (
+      !viewportSize ||
+      ![viewportSize.x, viewportSize.y].every(value => Number.isFinite(value) && value > 0)
+    ) {
+      throw new Error('BoundingBox viewportSize must contain positive, finite x and y values')
+    }
+    const { x: width, y: height } = viewportSize
 
     const { longitude, latitude, zoom } = fitBounds({
       bounds,

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -317,7 +317,8 @@ export function transformGraph<
 
         if (visibleInputs && Array.isArray(visibleInputs)) {
           // Explicit visibility saved - use it directly as the full set
-          op.visibleFields.next(new Set(visibleInputs))
+          const inputs = op.inputs
+          op.visibleFields.next(new Set(visibleInputs.filter(name => !inputs[name]?.runtimeOnly)))
         } else {
           // No saved visibility - derive from heuristic
           const customValues = data?.inputs ?? {}
@@ -396,6 +397,11 @@ export function transformGraph<
         targetOp[targetNamespace === 'par' ? 'inputs' : 'outputs'][targetFieldName]
       if (!sourceField || !targetField) {
         debugExecutor('Invalid connection')
+        continue
+      }
+
+      if (targetField.runtimeOnly) {
+        targetOp.addConnectionError(edge.id, 'Runtime-only inputs cannot be connected')
         continue
       }
 

--- a/noodles-editor/src/noodles/utils/can-connect.ts
+++ b/noodles-editor/src/noodles/utils/can-connect.ts
@@ -361,6 +361,14 @@ export function validateConnection(from: Field, to: Field): ConnectionValidation
     debugConnect(`To: ${to.constructor.name} (type=${toFieldType})`)
   }
 
+  if (to.runtimeOnly) {
+    return {
+      valid: false,
+      severity: 'error',
+      error: 'Runtime-only inputs cannot be connected',
+    }
+  }
+
   // UnknownField can connect to anything
   if (from instanceof UnknownField) {
     if (debugConnect.enabled) {
@@ -447,6 +455,7 @@ export function canConnect(from: Field, to: Field): boolean {
 const canConnectCache = new Map<string, boolean>()
 
 export function canConnectCached(from: Field, to: Field): boolean {
+  if (to.runtimeOnly) return false
   const key = `${from.constructor.name}:${to.constructor.name}`
   const cached = canConnectCache.get(key)
   if (cached !== undefined) return cached

--- a/noodles-editor/src/noodles/utils/property-history.ts
+++ b/noodles-editor/src/noodles/utils/property-history.ts
@@ -22,6 +22,7 @@ export function captureOperatorInputs(): string | null {
   for (const op of ops) {
     const inputs: Record<string, unknown> = {}
     for (const [name, field] of Object.entries(op.inputs as Record<string, IField>)) {
+      if (field.runtimeOnly) continue
       // Expression-driven fields serialize their (small) expression source, so include
       // them even when reference connections have populated `subscriptions`
       const isDriven =
@@ -63,7 +64,7 @@ export function applyOperatorInputs(snapshot: string): void {
     const opInputs = op.inputs as Record<string, IField>
     for (const [name, value] of Object.entries(inputs)) {
       const field = opInputs[name]
-      if (field) {
+      if (field && !field.runtimeOnly) {
         // Routes { $expr } payloads to setExpression, plain values to setValue
         applySerializedFieldValue(field as Field, value)
       }

--- a/noodles-editor/src/noodles/utils/serialization.ts
+++ b/noodles-editor/src/noodles/utils/serialization.ts
@@ -144,6 +144,7 @@ export function serializeNodes(
     // Serialize fields
     const inputs: ExtractProps<ReturnType<typeof op.createInputs>> = {}
     for (const [name, field] of Object.entries(op.inputs)) {
+      if (field.runtimeOnly) continue
       const serialized = field.serialize()
       // Compare transformed values to properly detect non-default values
       // This handles fields where serialize() returns a different format than stored value
@@ -225,7 +226,7 @@ export function serializeNodes(
 }
 
 export function serializeEdges(
-  _store: ReturnType<typeof useOperatorStore.getState>,
+  store: ReturnType<typeof useOperatorStore.getState>,
   nodes: ReactFlowNode<Record<string, unknown>>[],
   edges: ReactFlowEdge[]
 ) {
@@ -242,6 +243,9 @@ export function serializeEdges(
       }
       // Skip ReferenceEdge types - they should not be persisted in save files
       if (edge.type === 'ReferenceEdge') {
+        return false
+      }
+      if (isRuntimeOnlyInputEdge(store, edge)) {
         return false
       }
       return true
@@ -269,6 +273,15 @@ export function serializeEdges(
 
       return serialized
     })
+}
+
+export function isRuntimeOnlyInputEdge(
+  store: ReturnType<typeof useOperatorStore.getState>,
+  edge: ReactFlowEdge
+): boolean {
+  const targetHandle = parseHandleId(String(edge.targetHandle))
+  if (targetHandle?.namespace !== 'par') return false
+  return store.getOp(edge.target)?.inputs[targetHandle.fieldName]?.runtimeOnly === true
 }
 
 // Pre-load all example asset URLs for download functionality

--- a/noodles-editor/src/noodles/utils/suggested-nodes.test.ts
+++ b/noodles-editor/src/noodles/utils/suggested-nodes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  CombineXYOp,
   FileOp,
   FilterOp,
   GeoJsonLayerOp,
@@ -76,6 +77,13 @@ describe('getSuggestedNodes', () => {
 
     const opTypes = suggestions.map(s => s.opType)
     expect(opTypes).not.toContain('NumberOp')
+  })
+
+  it('does not suggest operators based on runtime-only inputs', () => {
+    const op = new CombineXYOp('/vector-1')
+    const suggestions = getSuggestedNodes(op, 100)
+
+    expect(suggestions.map(suggestion => suggestion.opType)).not.toContain('BoundingBoxOp')
   })
 
   it('includes same-category operators when curated and compatible are exhausted', () => {

--- a/noodles-editor/src/noodles/utils/suggested-nodes.ts
+++ b/noodles-editor/src/noodles/utils/suggested-nodes.ts
@@ -1,6 +1,6 @@
-import type { Field } from '../fields'
-import { type IOperator, type OpType, type Operator, opTypes } from '../operators'
 import { categories, nodeTypeToDisplayName } from '../components/categories'
+import type { Field } from '../fields'
+import { type IOperator, type Operator, type OpType, opTypes } from '../operators'
 
 export interface SuggestedNode {
   opType: OpType
@@ -86,6 +86,7 @@ function buildTypeIndex(): Map<string, Set<OpType>> {
       // Create temporary instance to inspect inputs
       const tempOp = new OpClass('/temp')
       for (const input of Object.values(tempOp.inputs)) {
+        if (input.runtimeOnly) continue
         const fieldType = (input.constructor as typeof Field).type
         if (fieldType) {
           if (!index.has(fieldType)) {

--- a/noodles-editor/src/noodles/utils/visibility-heuristic.ts
+++ b/noodles-editor/src/noodles/utils/visibility-heuristic.ts
@@ -21,6 +21,7 @@ export function computeVisibilityHeuristic(
   let differsFromDefaults = false
 
   for (const [name, field] of Object.entries(op.inputs)) {
+    if (field.runtimeOnly) continue
     const hasCustomValue = name in customValues
     const hasConnection = connectedFields.has(name)
     const shouldShow = field.showByDefault || hasCustomValue || hasConnection

--- a/noodles-editor/src/render/render-output-integration.test.tsx
+++ b/noodles-editor/src/render/render-output-integration.test.tsx
@@ -1,0 +1,220 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import TimelineEditor from '../timeline-editor'
+import { captureScreenshot } from './renderer'
+
+const harness = vi.hoisted(() => ({
+  hostSize: { width: 500, height: 280 },
+  settings: {
+    display: 'fixed' as 'fixed' | 'responsive',
+    resolution: { width: 320, height: 180 },
+    lod: 1,
+    scaleMode: 'fit' as const,
+    waitForData: false,
+    codec: 'avc' as const,
+    bitrateMbps: 10,
+    bitrateMode: 'constant' as const,
+    scaleControl: 0.3,
+    framerate: 30,
+    captureDelay: 0,
+    rendersDirectory: 'renders',
+  },
+  visualization: {
+    deckProps: {
+      layers: [],
+      viewState: { longitude: 0, latitude: 0, zoom: 0 },
+    },
+    mapProps: undefined as Record<string, unknown> | undefined,
+  },
+}))
+
+vi.mock('../layout', async () => {
+  const { createElement } = await import('react')
+  return {
+    Layout: ({ children }: { children?: ReactNode }) =>
+      createElement(
+        'div',
+        {
+          'data-testid': 'render-host',
+          style: {
+            position: 'relative',
+            width: `${harness.hostSize.width}px`,
+            height: `${harness.hostSize.height}px`,
+          },
+        },
+        children
+      ),
+  }
+})
+
+vi.mock('../noodles/hooks/use-render-settings', () => ({
+  useRenderSettings: () => harness.settings,
+}))
+
+// TimelineEditor only needs these symbols while rendering this empty scene. Keeping
+// the full operator registry out of the test also avoids eagerly starting DuckDB.
+vi.mock('../noodles/operators', () => ({
+  BoundingBoxOp: class BoundingBoxOp {},
+  fnWithSource: () => () => ({}),
+}))
+
+vi.mock('../noodles/hooks/use-active-outop', () => ({ useActiveOutOp: () => null }))
+
+vi.mock('../noodles/noodles', () => ({
+  getNoodles: () => ({
+    projectName: 'render-output-integration',
+    deckProps: harness.visualization.deckProps,
+    mapProps: harness.visualization.mapProps,
+    selectedNodeIds: [],
+    onSaveProject: async () => {},
+    onNewProject: async () => {},
+    onImport: async () => {},
+    undoRedoRef: { current: null },
+    copyControlsRef: { current: null },
+    reactFlowRef: { current: null },
+  }),
+}))
+
+vi.mock('../noodles/components/top-menu-bar', () => ({ TopMenuBar: () => null }))
+vi.mock('../noodles/components/spreadsheet-pane/spreadsheet-pane', () => ({
+  SpreadsheetPane: () => null,
+}))
+vi.mock('../noodles/components/tools/map-tool-layer', () => ({ MapToolLayer: () => null }))
+vi.mock('../timeline/components/TimelinePanel', () => ({ TimelinePanel: () => null }))
+
+const EMPTY_MAP_STYLE = {
+  version: 8 as const,
+  sources: {},
+  layers: [
+    {
+      id: 'background',
+      type: 'background' as const,
+      paint: { 'background-color': '#000000' },
+    },
+  ],
+}
+
+type Size = { width: number; height: number }
+
+async function expectCanvasAndCapturedPng(
+  container: HTMLElement,
+  selector: string,
+  expected: Size
+) {
+  let canvas: HTMLCanvasElement | null = null
+  await waitFor(
+    () => {
+      canvas = container.querySelector<HTMLCanvasElement>(selector)
+      expect(canvas).not.toBeNull()
+      expect({ width: canvas!.width, height: canvas!.height }).toEqual(expected)
+    },
+    { timeout: 10_000 }
+  )
+  expect(canvas!.getContext('webgl2') ?? canvas!.getContext('webgl')).not.toBeNull()
+
+  let writtenBlob: Blob | undefined
+  const pickerSpy = vi.spyOn(window, 'showSaveFilePicker').mockResolvedValue({
+    getFile: async () => new File([], 'render.png', { type: 'image/png' }),
+    createWritable: async () => ({
+      write: async (blob: Blob) => {
+        writtenBlob = blob
+      },
+      close: async () => {},
+    }),
+  } as unknown as FileSystemFileHandle)
+
+  await captureScreenshot('render', () => canvas!)
+
+  const image = await createImageBitmap(writtenBlob!)
+  expect({ width: image.width, height: image.height }).toEqual(expected)
+  image.close()
+  pickerSpy.mockRestore()
+}
+
+describe('production render output dimensions', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    harness.hostSize = { width: 500, height: 280 }
+    harness.settings.display = 'fixed'
+    harness.settings.resolution = { width: 320, height: 180 }
+    harness.settings.lod = 1
+    harness.visualization.mapProps = undefined
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.useFakeTimers({ now: new Date('2025-02-01T00:00:00Z') })
+  })
+
+  it.each([
+    {
+      name: 'pure Deck at fixed LOD 1',
+      selector: '#deckgl-overlay',
+      basemap: false,
+      display: 'fixed' as const,
+      lod: 1,
+      expected: { width: 320, height: 180 },
+    },
+    {
+      name: 'pure Deck at fixed LOD 2',
+      selector: '#deckgl-overlay',
+      basemap: false,
+      display: 'fixed' as const,
+      lod: 2,
+      expected: { width: 640, height: 360 },
+    },
+    {
+      name: 'pure Deck in responsive mode',
+      selector: '#deckgl-overlay',
+      basemap: false,
+      display: 'responsive' as const,
+      lod: 2,
+      expected: { width: 500, height: 280 },
+    },
+    {
+      name: 'MapLibre at fixed LOD 1',
+      selector: '.maplibregl-canvas',
+      basemap: true,
+      display: 'fixed' as const,
+      lod: 1,
+      expected: { width: 320, height: 180 },
+    },
+    {
+      name: 'MapLibre at fixed LOD 2',
+      selector: '.maplibregl-canvas',
+      basemap: true,
+      display: 'fixed' as const,
+      lod: 2,
+      expected: { width: 640, height: 360 },
+    },
+    {
+      name: 'MapLibre in responsive mode',
+      selector: '.maplibregl-canvas',
+      basemap: true,
+      display: 'responsive' as const,
+      lod: 2,
+      expected: { width: 500, height: 280 },
+    },
+  ])('keeps $name canvas and captured PNG dimensions correct', async testCase => {
+    // MapLibre intentionally uses DPR (and its WebGL size cap), so the browser
+    // characterization runs in the DPR-1 context configured in vitest.config.ts.
+    expect(window.devicePixelRatio).toBe(1)
+    harness.settings.display = testCase.display
+    harness.settings.lod = testCase.lod
+
+    if (testCase.basemap) {
+      harness.visualization.mapProps = {
+        mapStyle: EMPTY_MAP_STYLE,
+        longitude: 0,
+        latitude: 0,
+        zoom: 0,
+      }
+    }
+
+    const view = render(<TimelineEditor />)
+    await expectCanvasAndCapturedPng(view.container, testCase.selector, testCase.expected)
+  })
+})

--- a/noodles-editor/src/render/render-output-resolution.test.ts
+++ b/noodles-editor/src/render/render-output-resolution.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { calculateRenderSurfaceSize } from './render-surface-size'
+import { captureScreenshot } from './renderer'
+
+describe('render output resolution', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('writes a PNG with the source canvas pixel dimensions unchanged', async () => {
+    const outputSize = calculateRenderSurfaceSize({ width: 320, height: 180 }, 2)
+    const canvas = document.createElement('canvas')
+    canvas.width = outputSize.width
+    canvas.height = outputSize.height
+    const context = canvas.getContext('2d')
+    context?.fillRect(0, 0, canvas.width, canvas.height)
+    let writtenBlob: Blob | undefined
+
+    vi.spyOn(window, 'showSaveFilePicker').mockResolvedValue({
+      getFile: async () => new File([], 'render.png', { type: 'image/png' }),
+      createWritable: async () => ({
+        write: async (blob: Blob) => {
+          writtenBlob = blob
+        },
+        close: async () => {},
+      }),
+    } as unknown as FileSystemFileHandle)
+
+    await captureScreenshot('render', () => canvas)
+
+    expect(writtenBlob?.type).toBe('image/png')
+    const image = await createImageBitmap(writtenBlob!)
+    expect({ width: image.width, height: image.height }).toEqual(outputSize)
+    image.close()
+  })
+})

--- a/noodles-editor/src/render/render-surface-size.test.ts
+++ b/noodles-editor/src/render/render-surface-size.test.ts
@@ -1,0 +1,340 @@
+import { fitBounds } from '@math.gl/web-mercator'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Vec2Field } from '../noodles/fields'
+import { BoundingBoxOp, CombineXYOp, NumberOp } from '../noodles/operators'
+import { clearOps, getOpStore, setOp } from '../noodles/store'
+import { transformGraph } from '../noodles/transform-graph'
+import { canConnect, canConnectCached } from '../noodles/utils/can-connect'
+import { applyOperatorInputs, captureOperatorInputs } from '../noodles/utils/property-history'
+import { DEFAULT_RENDER_SETTINGS } from '../noodles/utils/render-settings-constants'
+import {
+  isRuntimeOnlyInputEdge,
+  serializeEdges,
+  serializeNodes,
+} from '../noodles/utils/serialization'
+import {
+  calculateRenderSurfaceSize,
+  observeRenderSurface,
+  syncBoundingBoxViewportSize,
+} from './render-surface-size'
+
+afterEach(() => {
+  clearOps()
+})
+
+describe('render surface size', () => {
+  it.each([
+    { resolution: { width: 1920, height: 1080 }, lod: 1, expected: { width: 1920, height: 1080 } },
+    { resolution: { width: 1920, height: 1080 }, lod: 2, expected: { width: 3840, height: 2160 } },
+    { resolution: { width: 1280, height: 720 }, lod: 1.5, expected: { width: 1920, height: 1080 } },
+  ])('calculates the render target for resolution $resolution at LOD $lod', ({
+    resolution,
+    lod,
+    expected,
+  }) => {
+    expect(calculateRenderSurfaceSize(resolution, lod)).toEqual(expected)
+  })
+
+  it('publishes the initial responsive size and later element resizes', () => {
+    let resize: ResizeObserverCallback | undefined
+    const disconnect = vi.fn()
+    const createObserver = (callback: ResizeObserverCallback) => {
+      resize = callback
+      return { observe: vi.fn(), disconnect }
+    }
+
+    let width = 800
+    let height = 600
+    const element = document.createElement('div')
+    Object.defineProperties(element, {
+      clientWidth: { configurable: true, get: () => width },
+      clientHeight: { configurable: true, get: () => height },
+    })
+    const listener = vi.fn()
+    const stop = observeRenderSurface(element, listener, createObserver)
+    expect(listener).toHaveBeenLastCalledWith({ width: 800, height: 600 })
+
+    resize?.([], {} as ResizeObserver)
+    expect(listener).toHaveBeenCalledOnce()
+
+    width = 1200
+    height = 700
+    resize?.([], {} as ResizeObserver)
+    expect(listener).toHaveBeenLastCalledWith({ width: 1200, height: 700 })
+
+    width = 0
+    resize?.([], {} as ResizeObserver)
+    expect(listener).toHaveBeenCalledTimes(2)
+
+    width = Number.NaN
+    height = Number.POSITIVE_INFINITY
+    resize?.([], {} as ResizeObserver)
+    expect(listener).toHaveBeenCalledTimes(2)
+
+    stop()
+    expect(disconnect).toHaveBeenCalledOnce()
+  })
+})
+
+describe('BoundingBoxOp viewport integration', () => {
+  const data = [
+    { lng: -97.3159, lat: 32.9917 },
+    { lng: -96.8629, lat: 32.8517 },
+  ]
+
+  it('is deterministic from its declared inputs', () => {
+    const operator = new BoundingBoxOp('/bbox')
+    const props = {
+      data,
+      padding: 180,
+      viewportSize: { x: 1000, y: 500 },
+    }
+    const first = operator.execute(props)
+
+    const second = operator.execute(props)
+    const expected = fitBounds({
+      bounds: [
+        [-97.3159, 32.8517],
+        [-96.8629, 32.9917],
+      ],
+      width: 1000,
+      height: 500,
+      padding: 180,
+    })
+
+    expect(second).toEqual(first)
+    expect(second.viewState).toEqual({
+      longitude: expected.longitude,
+      latitude: expected.latitude,
+      zoom: expected.zoom,
+    })
+  })
+
+  it('uses the render-settings default when direct callers omit viewportSize', () => {
+    const operator = new BoundingBoxOp('/bbox')
+    const expectedSize = calculateRenderSurfaceSize(
+      DEFAULT_RENDER_SETTINGS.resolution,
+      DEFAULT_RENDER_SETTINGS.lod
+    )
+    const result = operator.execute({ data, padding: 0 } as never)
+    const expected = fitBounds({
+      bounds: [
+        [-97.3159, 32.8517],
+        [-96.8629, 32.9917],
+      ],
+      width: expectedSize.width,
+      height: expectedSize.height,
+      padding: 0,
+    })
+
+    expect(operator.inputs.viewportSize.value).toEqual({
+      x: expectedSize.width,
+      y: expectedSize.height,
+    })
+    expect(result.viewState.zoom).toBe(expected.zoom)
+  })
+
+  it('rejects invalid viewport dimensions with a clear error', () => {
+    const operator = new BoundingBoxOp('/bbox')
+
+    expect(() =>
+      operator.execute({ data, padding: 0, viewportSize: { x: Number.NaN, y: 500 } })
+    ).toThrow('BoundingBox viewportSize must contain positive, finite x and y values')
+    expect(() => operator.execute({ data, padding: 0, viewportSize: { x: 1000, y: 0 } })).toThrow(
+      'BoundingBox viewportSize must contain positive, finite x and y values'
+    )
+    expect(() => operator.execute({ data, padding: 0, viewportSize: null } as never)).toThrow(
+      'BoundingBox viewportSize must contain positive, finite x and y values'
+    )
+  })
+
+  it('syncs fixed resolution and LOD through the runtime input', async () => {
+    const operator = new BoundingBoxOp('/bbox')
+    const unrelated = new NumberOp('/number')
+    operator.inputs.data.setValue(data)
+    operator.inputs.padding.setValue(100)
+    await operator.pull()
+    expect(operator.dirty).toBe(false)
+
+    const renderSize = calculateRenderSurfaceSize({ width: 1000, height: 500 }, 2)
+    syncBoundingBoxViewportSize([unrelated, operator], renderSize)
+
+    expect(operator.inputs.viewportSize.value).toEqual({ x: 2000, y: 1000 })
+    expect(operator.dirty).toBe(true)
+    const resized = await operator.pull()
+    const expected = fitBounds({
+      bounds: [
+        [-97.3159, 32.8517],
+        [-96.8629, 32.9917],
+      ],
+      width: 2000,
+      height: 1000,
+      padding: 100,
+    })
+    expect(resized.viewState.zoom).toBe(expected.zoom)
+  })
+
+  it('syncs responsive ResizeObserver measurements through the runtime input', () => {
+    let resize: ResizeObserverCallback | undefined
+    const createObserver = (callback: ResizeObserverCallback) => {
+      resize = callback
+      return { observe: vi.fn(), disconnect: vi.fn() }
+    }
+
+    let width = 800
+    let height = 600
+    const element = document.createElement('div')
+    Object.defineProperties(element, {
+      clientWidth: { configurable: true, get: () => width },
+      clientHeight: { configurable: true, get: () => height },
+    })
+    const operator = new BoundingBoxOp('/bbox')
+    const stop = observeRenderSurface(
+      element,
+      size => syncBoundingBoxViewportSize([operator], size),
+      createObserver
+    )
+    expect(operator.inputs.viewportSize.value).toEqual({ x: 800, y: 600 })
+
+    width = 1280
+    height = 720
+    resize?.([], {} as ResizeObserver)
+    expect(operator.inputs.viewportSize.value).toEqual({ x: 1280, y: 720 })
+    stop()
+  })
+
+  it('does not dirty a settled operator when the size is unchanged', async () => {
+    const operator = new BoundingBoxOp('/bbox')
+    await operator.pull()
+    expect(operator.dirty).toBe(false)
+
+    syncBoundingBoxViewportSize([operator], { width: 3840, height: 2160 })
+    expect(operator.dirty).toBe(false)
+  })
+
+  it('ignores invalid runtime measurements', () => {
+    const operator = new BoundingBoxOp('/bbox')
+
+    syncBoundingBoxViewportSize([operator], { width: Number.NaN, height: 500 })
+    syncBoundingBoxViewportSize([operator], { width: 1000, height: Number.POSITIVE_INFINITY })
+
+    expect(operator.inputs.viewportSize.value).toEqual({ x: 3840, y: 2160 })
+  })
+
+  it('does not persist the runtime viewport size in projects or undo snapshots', () => {
+    const operator = new BoundingBoxOp('/bbox')
+    operator.inputs.viewportSize.setValue({ x: 1234, y: 567 })
+    setOp(operator.id, operator as never)
+
+    const nodes = [{ id: operator.id, type: 'BoundingBoxOp', data: {}, position: { x: 0, y: 0 } }]
+    const runtimeEdge = {
+      id: '/vec.out.xy->/bbox.par.viewportSize',
+      source: '/vec',
+      sourceHandle: 'out.xy',
+      target: operator.id,
+      targetHandle: 'par.viewportSize',
+    }
+    const serialized = serializeNodes(getOpStore(), nodes, [])
+    const clipboard = serializeNodes(getOpStore(), nodes, [], { forClipboard: true })
+    const history = JSON.parse(captureOperatorInputs() ?? '{}')
+    applyOperatorInputs(JSON.stringify({ [operator.id]: { viewportSize: { x: 10, y: 10 } } }))
+
+    expect(serialized[0].data.inputs).not.toHaveProperty('viewportSize')
+    expect(clipboard[0].data.inputs).not.toHaveProperty('viewportSize')
+    expect(clipboard[0].data.visibleInputs).not.toContain('viewportSize')
+    expect(history[operator.id]).not.toHaveProperty('viewportSize')
+    expect(operator.inputs.viewportSize.value).toEqual({ x: 1234, y: 567 })
+    expect(
+      serializeEdges(getOpStore(), [...nodes, { ...nodes[0], id: '/vec' }], [runtimeEdge])
+    ).toEqual([])
+    expect(isRuntimeOnlyInputEdge(getOpStore(), runtimeEdge)).toBe(true)
+  })
+
+  it('keeps the runtime input out of editable visibility and graph connections', () => {
+    const operator = new BoundingBoxOp('/bbox')
+    const source = new CombineXYOp('/vec')
+    const editableTarget = new Vec2Field()
+
+    operator.showField('viewportSize')
+
+    expect(operator.isFieldVisible('viewportSize')).toBe(false)
+    expect(operator.visibleFields.value?.has('viewportSize')).not.toBe(true)
+    expect(canConnect(source.outputs.xy as never, operator.inputs.viewportSize as never)).toBe(
+      false
+    )
+    expect(
+      canConnectCached(source.outputs.xy as never, operator.inputs.viewportSize as never)
+    ).toBe(false)
+    operator.inputs.viewportSize.addConnection('crafted-edge', source.outputs.xy)
+    expect(operator.inputs.viewportSize.subscriptions.size).toBe(0)
+    expect(canConnectCached(source.outputs.xy as never, editableTarget as never)).toBe(true)
+  })
+
+  it('rejects crafted project edges targeting the runtime input', () => {
+    const edgeId = '/vec.out.xy->/bbox.par.viewportSize'
+    const { operators } = transformGraph({
+      nodes: [
+        {
+          id: '/vec',
+          type: 'CombineXYOp',
+          position: { x: 0, y: 0 },
+          data: { inputs: { x: 1, y: 1 } },
+        },
+        {
+          id: '/bbox',
+          type: 'BoundingBoxOp',
+          position: { x: 200, y: 0 },
+          data: { inputs: {} },
+        },
+      ] as never,
+      edges: [
+        {
+          id: edgeId,
+          source: '/vec',
+          sourceHandle: 'out.xy',
+          target: '/bbox',
+          targetHandle: 'par.viewportSize',
+        },
+      ] as never,
+    })
+    const boundingBox = operators.find(
+      operator => operator.id === '/bbox'
+    ) as unknown as BoundingBoxOp
+
+    expect(boundingBox.inputs.viewportSize.value).toEqual({ x: 3840, y: 2160 })
+    expect(boundingBox.inputs.viewportSize.subscriptions.size).toBe(0)
+    expect(boundingBox.connectionErrors.value.get(edgeId)).toBe(
+      'Runtime-only inputs cannot be connected'
+    )
+  })
+
+  it('ignores serialized runtime values and visibility when loading a project', () => {
+    const { operators } = transformGraph({
+      nodes: [
+        {
+          id: '/bbox',
+          type: 'BoundingBoxOp',
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: { viewportSize: { x: 1, y: 1 } },
+            visibleInputs: ['padding', 'viewportSize'],
+          },
+        },
+      ] as never,
+      edges: [],
+    })
+    const [operator] = operators
+    const expected = calculateRenderSurfaceSize(
+      DEFAULT_RENDER_SETTINGS.resolution,
+      DEFAULT_RENDER_SETTINGS.lod
+    )
+
+    const boundingBox = operator as unknown as BoundingBoxOp
+    expect(boundingBox.inputs.viewportSize.value).toEqual({
+      x: expected.width,
+      y: expected.height,
+    })
+    expect(boundingBox.visibleFields.value).toEqual(new Set(['padding']))
+  })
+})

--- a/noodles-editor/src/render/render-surface-size.ts
+++ b/noodles-editor/src/render/render-surface-size.ts
@@ -1,0 +1,62 @@
+import { BoundingBoxOp } from '../noodles/operators'
+
+export interface RenderSurfaceSize {
+  width: number
+  height: number
+}
+
+type ResizeObserverFactory = (
+  callback: ResizeObserverCallback
+) => Pick<ResizeObserver, 'observe' | 'disconnect'>
+
+function isValidRenderSurfaceSize(size: RenderSurfaceSize): boolean {
+  return [size.width, size.height].every(value => Number.isFinite(value) && value > 0)
+}
+
+export function calculateRenderSurfaceSize(
+  resolution: RenderSurfaceSize,
+  lod: number
+): RenderSurfaceSize {
+  return {
+    width: Math.round(resolution.width * lod),
+    height: Math.round(resolution.height * lod),
+  }
+}
+
+export function syncBoundingBoxViewportSize(
+  operators: Iterable<unknown>,
+  size: RenderSurfaceSize
+): void {
+  if (!isValidRenderSurfaceSize(size)) return
+
+  for (const operator of operators) {
+    if (!(operator instanceof BoundingBoxOp)) continue
+
+    const current = operator.inputs.viewportSize.value
+    if (current.x === size.width && current.y === size.height) continue
+    operator.inputs.viewportSize.setValue({ x: size.width, y: size.height })
+  }
+}
+
+export function observeRenderSurface(
+  element: HTMLElement,
+  listener: (size: RenderSurfaceSize) => void,
+  createObserver: ResizeObserverFactory = callback => new ResizeObserver(callback)
+): () => void {
+  let previous: RenderSurfaceSize | undefined
+  const publish = () => {
+    const size = {
+      width: element.clientWidth,
+      height: element.clientHeight,
+    }
+    if (!isValidRenderSurfaceSize(size)) return
+    if (previous?.width === size.width && previous.height === size.height) return
+    previous = size
+    listener(size)
+  }
+
+  publish()
+  const observer = createObserver(publish)
+  observer.observe(element)
+  return () => observer.disconnect()
+}

--- a/noodles-editor/src/timeline-editor.tsx
+++ b/noodles-editor/src/timeline-editor.tsx
@@ -3,7 +3,7 @@ import { MapLibreOverlay, type MapLibreOverlayProps } from '@deck.gl/maplibre'
 import { DeckGL } from '@deck.gl/react'
 import { ReactFlowProvider } from '@xyflow/react'
 import type { CustomLayerInterface, Map as MapLibre } from 'maplibre-gl'
-import { forwardRef, useCallback, useEffect, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import ReactMapGL, { type MapProps, useControl } from 'react-map-gl/maplibre'
 import { Layout } from './layout'
 import { ErrorBoundary } from './noodles/components/error-boundary'
@@ -16,12 +16,17 @@ import { useActiveOutOp } from './noodles/hooks/use-active-outop'
 import { useRenderSettings } from './noodles/hooks/use-render-settings'
 import { getNoodles } from './noodles/noodles'
 import { fnWithSource } from './noodles/operators'
+import { useOperatorStore, useUIStore } from './noodles/store'
 import type { RenderSettings } from './noodles/utils/serialization'
 import { useDeckDrawLoop } from './render/draw-loop'
+import {
+  calculateRenderSurfaceSize,
+  observeRenderSurface,
+  syncBoundingBoxViewportSize,
+} from './render/render-surface-size'
 import { captureScreenshot, useRenderer } from './render/renderer'
 import { deckRenderingDefaults, mapRenderingDefaults } from './render/rendering-defaults'
 import { TransformScale } from './render/transform-scale'
-import { useUIStore } from './noodles/store'
 import { TimelinePanel } from './timeline/components/TimelinePanel'
 import { getTimelineStore, useTimelineStore } from './timeline/timeline-store'
 import s from './timeline-editor.module.css'
@@ -75,6 +80,8 @@ const isMapReady = (map: MapLibre | null) => !map || (map.isStyleLoaded() && map
 export default function TimelineEditor() {
   const mapRef = useRef<MapLibre | null>(null)
   const deckRef = useRef<Deck>(null)
+  const renderSurfaceRef = useRef<HTMLDivElement>(null)
+  const operators = useOperatorStore(state => state.operators)
   const isRenderingRef = useRef(false)
   // Session-only handle set by selectRendersDirectory; takes priority over project subdir
   const rendersDirectoryHandleRef = useRef<FileSystemDirectoryHandle | null>(null)
@@ -530,36 +537,51 @@ export default function TimelineEditor() {
 
   // Increase the render target resolution to increase map tile detail.
   // To convert viewport bounds back to their original size, add about 1 to the zoom value.
-  const lodResolution = {
-    width: Math.round(resolution.width * lod),
-    height: Math.round(resolution.height * lod),
-  }
+  const lodResolution = calculateRenderSurfaceSize(resolution, lod)
 
   // Use fixed resolution for 'fixed' display mode, undefined for 'responsive' mode to use natural dimensions
   const isFixedMode = renderSettings.display === 'fixed'
   const displayResolution = isFixedMode ? lodResolution : undefined
+  const renderWidth = lodResolution.width
+  const renderHeight = lodResolution.height
+
+  useLayoutEffect(() => {
+    const syncViewportSize = (size: { width: number; height: number }) =>
+      syncBoundingBoxViewportSize(operators.values(), size)
+
+    if (isFixedMode) {
+      syncViewportSize({ width: renderWidth, height: renderHeight })
+      return
+    }
+
+    const surface = renderSurfaceRef.current
+    if (!surface) return
+    return observeRenderSurface(surface, syncViewportSize)
+  }, [isFixedMode, operators, renderWidth, renderHeight])
 
   const renderContent = () => {
-    if (basemapEnabled) {
-      return (
-        <ReactMapGL style={displayResolution} {...mapProps}>
-          <DeckGLOverlay
-            ref={deckRef}
-            renderer={renderSettings}
-            isRendering={isRendering}
-            {...deckProps}
-          />
-          {/* Interactive Draw and Measure tools, armed from the top shelf */}
-          <MapToolLayer mapRef={mapRef} basemapEnabled isRendering={isRendering} />
-        </ReactMapGL>
-      )
-    }
-    return (
+    const content = basemapEnabled ? (
+      <ReactMapGL style={displayResolution} {...mapProps}>
+        <DeckGLOverlay
+          ref={deckRef}
+          renderer={renderSettings}
+          isRendering={isRendering}
+          {...deckProps}
+        />
+        {/* Interactive Draw and Measure tools, armed from the top shelf */}
+        <MapToolLayer mapRef={mapRef} basemapEnabled isRendering={isRendering} />
+      </ReactMapGL>
+    ) : (
       <DeckGL
         ref={ref => setRef(deckRef, ref?.deck)}
         {...deckProps}
         {...(displayResolution || {})}
       />
+    )
+    return (
+      <div ref={renderSurfaceRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
+        {content}
+      </div>
     )
   }
 

--- a/noodles-editor/src/timeline/__tests__/field-bindings.test.ts
+++ b/noodles-editor/src/timeline/__tests__/field-bindings.test.ts
@@ -671,6 +671,22 @@ describe('bindOperatorToTimeline - Vec2Field per-channel handling', () => {
     cleanup()
   })
 
+  it('does not expose runtime-only Vec2 fields as timeline tracks', () => {
+    const viewportField = new Vec2Field(
+      { x: 3840, y: 2160 },
+      { runtimeOnly: true, returnType: 'object' }
+    )
+    const op = makeOpWithField('/bbox', 'viewportSize', viewportField)
+    const store = getTimelineStore()
+
+    const cleanup = bindOperatorToTimeline(op)
+
+    expect(store.getTrack('bbox / viewportSize / x')).toBeUndefined()
+    expect(store.getTrack('bbox / viewportSize / y')).toBeUndefined()
+
+    cleanup()
+  })
+
   it('scrubbing updates only the x channel when only x has keyframes', () => {
     const posField = new Vec2Field({ x: 0, y: 5 })
     const op = makeOpWithField('/scatter', 'position', posField)

--- a/noodles-editor/src/timeline/field-bindings.ts
+++ b/noodles-editor/src/timeline/field-bindings.ts
@@ -722,6 +722,7 @@ export function bindOperatorToTimeline(op: Operator<IOperator>, store?: Timeline
   const cleanupFns: Array<() => void> = []
 
   for (const [fieldName, field] of Object.entries(op.inputs)) {
+    if (field.runtimeOnly) continue
     // Skip non-animatable fields
     if (typeof field.value === 'function') continue
     if (!isAnimatableField(field as AnyField)) continue

--- a/noodles-editor/vitest.config.ts
+++ b/noodles-editor/vitest.config.ts
@@ -9,7 +9,16 @@ export default defineConfig({
   test: {
     setupFiles: ['src/setupTests.ts'],
     browser: {
-      provider: playwright(),
+      provider: playwright({
+        launchOptions: {
+          // Permit Chromium's software WebGL fallback for real-renderer tests; this does not force it.
+          args: ['--enable-unsafe-swiftshader'],
+        },
+        contextOptions: {
+          // MapLibre sizes its canvas from DPR, so pin browser raster dimensions in CI.
+          deviceScaleFactor: 1,
+        },
+      }),
       enabled: true,
       headless: true,
       screenshotFailures: false,


### PR DESCRIPTION
## Summary
Fixes `BoundingBoxOp` initially fitting against the browser window and remaining incorrectly zoomed until its padding input changes.

`BoundingBoxOp` is now pure: `execute()` derives its result only from declared inputs and the operator owns no render-size subscription or external mutable state.

## Changes
- Adds a hidden, runtime-only `viewportSize` input whose default is derived from `DEFAULT_RENDER_SETTINGS`.
- Has `TimelineEditor` inject `resolution × LOD` in fixed mode and measured render-surface dimensions in responsive mode. Updating the field uses normal dirty propagation, with no reverse graph edge or cycle.
- Keeps runtime-only values out of project load/save, clipboard data, undo history, timeline tracks, editable property UI, generated operator metadata, suggestions, and programmatic edits; crafted graph connections to the input are rejected.
- Removes the global render-size subject and the operator constructor subscription/global read.
- Retains one `calculateRenderSurfaceSize` helper for renderer and camera-fit arithmetic.

## Output-resolution characterization
There was no pre-existing end-to-end test of the actual renderer-created canvas and exported PNG dimensions.

This PR adds a browser characterization test that mounts the production `TimelineEditor`, exercises real DeckGL and MapLibre WebGL renderers, inspects the canvas each renderer creates, runs that canvas through the production `captureScreenshot` path, decodes the resulting PNG, and verifies both dimensions. MapLibre uses an inline, no-network style.

The identical two-file characterization patch was applied to `origin/main` and this branch:

| Renderer / mode | Expected canvas and PNG | `origin/main` | This branch |
| --- | ---: | ---: | ---: |
| pure Deck, fixed LOD 1 | 320×180 | pass | pass |
| pure Deck, fixed LOD 2 | 640×360 | pass | pass |
| pure Deck, responsive | 500×280 | pass | pass |
| MapLibre, fixed LOD 1 | 320×180 | pass | pass |
| MapLibre, fixed LOD 2 | 640×360 | pass | pass |
| MapLibre, responsive | 500×280 | pass | pass |

Both refs passed 6/6 cases. The browser context is pinned to DPR 1 so MapLibre raster dimensions are deterministic in headless CI. Chromium is allowed to use its software WebGL fallback, but it is not forced.

A separate manual DPR characterization with the same fixed 1920×1080, LOD 2 MapLibre project remains identical before and after: DPR 1 produces 3840×2160; DPR 2 produces 4096×2304 after MapLibre/WebGL canvas-size clamping.

## Testing
- New real-renderer output integration test: 6 passed on both `origin/main` and this branch with the identical patch.
- Relevant browser suites: 33 assertions passed.
- Full local browser-suite comparison: `origin/main` 3234 passed / 18 failed / 10 skipped; this branch 3253 passed / 18 failed / 10 skipped. The same 18 failures occur on both refs in this local linked-dependency environment.
- `render-surface-size.test.ts`: 15 passed (fixed/LOD and responsive sizing, deterministic execution, validation/default compatibility, invalidation/deduplication, runtime-only persistence/UI/connection guards).
- Serialization, history, connection, timeline binding, programmatic modification, suggestions, graph transform, fields, property visibility, and targeted `BoundingBoxOp` suites: 496 passed, 3 skipped.
- Generated operator metadata check: `BoundingBoxOp` exposes only `data,padding`; runtime `viewportSize` does not leak.
- Biome checks for the new test/config pass.
- `npm run build` passes.

## Manual verification
1. Reload a fixed project with `BoundingBoxOp` feeding the active camera and confirm its initial framing matches the framing after editing and restoring padding.
2. Change width, height, or LOD and confirm the camera refits without touching `BoundingBoxOp`.
3. Switch to responsive display, resize the map panel in both MapLibre and pure-Deck views, and confirm the fit updates.

## Documentation
No user documentation changes; the editable operator interface is unchanged.