### PR TITLE
fix: BitmapLayer project asset rendering

### DIFF
--- a/noodles-editor/src/noodles/bitmap-layer.test.ts
+++ b/noodles-editor/src/noodles/bitmap-layer.test.ts
@@ -1,0 +1,363 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FileUrlField } from './fields'
+import { BitmapLayerOp } from './operators'
+import { DeckProjectAssetResolver } from './utils/deck-project-asset-resolver'
+import { memoryProjectStore } from './utils/memory-project-store'
+
+const PROJECT_NAME = 'bitmap-layer-test'
+const PROJECT_CONTEXT = {
+  currentProjectName: PROJECT_NAME,
+  activeStorageType: 'memory' as const,
+}
+
+type TestLayer = {
+  type: string
+  id: string
+  image?: string
+  bounds?: number[]
+  updateTriggers?: object
+}
+
+const resolvers: DeckProjectAssetResolver[] = []
+
+function createResolver() {
+  const resolver = new DeckProjectAssetResolver()
+  resolvers.push(resolver)
+  return resolver
+}
+
+async function resolveAndCommit(resolver: DeckProjectAssetResolver, layers: TestLayer[]) {
+  const resolution = await resolver.resolveLayers(layers, PROJECT_CONTEXT)
+  if (!resolution) throw new Error('Asset resolution was unexpectedly cancelled')
+  if (!resolver.commit(resolution)) throw new Error('Asset resolution was unexpectedly stale')
+  return resolution
+}
+
+async function createTinyPng(color: [number, number, number, number]) {
+  const canvas = document.createElement('canvas')
+  canvas.width = 1
+  canvas.height = 1
+  const context = canvas.getContext('2d')
+  if (!context) throw new Error('Canvas 2D context is unavailable')
+  const imageData = context.createImageData(1, 1)
+  imageData.data.set(color)
+  context.putImageData(imageData, 0, 0)
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(blob => {
+      if (blob) resolve(blob)
+      else reject(new Error('Unable to encode test PNG'))
+    }, 'image/png')
+  })
+}
+
+function bitmapProps(overrides: Record<string, unknown> = {}) {
+  return {
+    visible: true,
+    opacity: 1,
+    image: '',
+    bounds: [
+      [-97.1, 32.8],
+      [-96.9, 33],
+    ],
+    desaturate: 0,
+    transparentColor: null,
+    tintColor: null,
+    parameters: { depthTest: true },
+    extensions: [],
+    ...overrides,
+  } as unknown as Parameters<BitmapLayerOp['execute']>[0]
+}
+
+afterEach(() => {
+  for (const resolver of resolvers.splice(0)) resolver.dispose()
+  memoryProjectStore.deleteProject(PROJECT_NAME)
+  vi.restoreAllMocks()
+})
+
+describe('BitmapLayerOp', () => {
+  it('offers image uploads through a FileUrlField', () => {
+    const op = new BitmapLayerOp('/bitmap')
+
+    expect(op.inputs.image).toBeInstanceOf(FileUrlField)
+    expect((op.inputs.image as FileUrlField).accept).toBe('.png,.jpg,.jpeg,.gif,.webp,.svg')
+  })
+
+  it('purely passes image references through for runtime materialization', () => {
+    const op = new BitmapLayerOp('/bitmap')
+
+    const project = op.execute(bitmapProps({ image: '@/airport.png' }))
+    const external = op.execute(bitmapProps({ image: 'https://example.com/diagram.png' }))
+
+    expect((project.layer as unknown as { image: string }).image).toBe('@/airport.png')
+    expect((external.layer as unknown as { image: string }).image).toBe(
+      'https://example.com/diagram.png'
+    )
+  })
+
+  it('flattens BboxField southwest and northeast points for Deck.gl', () => {
+    const op = new BitmapLayerOp('/bitmap')
+
+    const result = op.execute(
+      bitmapProps({
+        image: '@/airport.png',
+        bounds: [
+          [-97.05, 32.85],
+          [-96.95, 32.95],
+        ],
+      })
+    )
+    const layer = result.layer as unknown as { bounds: number[] }
+
+    expect(layer.bounds).toEqual([-97.05, 32.85, -96.95, 32.95])
+  })
+
+  it('preserves a legacy flat Deck.gl bounding box', () => {
+    const op = new BitmapLayerOp('/bitmap')
+
+    const result = op.execute(
+      bitmapProps({
+        image: '@/airport.png',
+        bounds: [-97.05, 32.85, -96.95, 32.95],
+      })
+    )
+    const layer = result.layer as unknown as { bounds: number[] }
+
+    expect(layer.bounds).toEqual([-97.05, 32.85, -96.95, 32.95])
+  })
+})
+
+describe('DeckProjectAssetResolver', () => {
+  it('materializes a valid project PNG with the correct MIME type and unchanged bounds', async () => {
+    const resolver = createResolver()
+    memoryProjectStore.writeAsset(
+      PROJECT_NAME,
+      'airport.PNG',
+      await createTinyPng([255, 0, 0, 255])
+    )
+    let imageBlob: Blob | undefined
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(source => {
+      if (!(source instanceof Blob)) throw new Error('Expected an image Blob')
+      imageBlob = source
+      return 'blob:airport-diagram'
+    })
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const resolution = await resolveAndCommit(resolver, [
+      {
+        type: 'BitmapLayer',
+        id: '/bitmap',
+        image: '@/airport.PNG',
+        bounds: [-97.1, 32.8, -96.9, 33],
+      },
+    ])
+    const [layer] = resolution.layers
+
+    expect(layer.image).toBe('blob:airport-diagram')
+    expect(layer.bounds).toEqual([-97.1, 32.8, -96.9, 33])
+    expect(imageBlob?.type).toBe('image/png')
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    if (!imageBlob) throw new Error('The runtime resolver did not create an image Blob')
+    const bitmap = await createImageBitmap(imageBlob)
+    expect([bitmap.width, bitmap.height]).toEqual([1, 1])
+    const canvas = document.createElement('canvas')
+    canvas.width = 1
+    canvas.height = 1
+    const context = canvas.getContext('2d')
+    if (!context) throw new Error('Canvas 2D context is unavailable')
+    context.drawImage(bitmap, 0, 0)
+    expect(Array.from(context.getImageData(0, 0, 1, 1).data)).toEqual([255, 0, 0, 255])
+    bitmap.close()
+  })
+
+  it('leaves external URLs and non-bitmap layers unchanged', async () => {
+    const resolver = createResolver()
+    const layers = [
+      { type: 'BitmapLayer', id: '/bitmap', image: 'https://example.com/diagram.png' },
+      { type: 'GeoJsonLayer', id: '/geojson' },
+    ]
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL')
+
+    const resolution = await resolveAndCommit(resolver, layers)
+
+    expect(resolution.layers).toEqual(layers)
+    expect(createObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('does not reread an unchanged bitmap execution from unrelated vis updates', async () => {
+    const resolver = createResolver()
+    memoryProjectStore.writeAsset(PROJECT_NAME, 'airport.png', new Blob(['airport']))
+    const descriptor = {
+      type: 'BitmapLayer',
+      id: '/bitmap',
+      image: '@/airport.png',
+      updateTriggers: {},
+    }
+    const readAssetBinary = vi.spyOn(memoryProjectStore, 'readAssetBinary')
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:airport')
+
+    const first = await resolveAndCommit(resolver, [descriptor])
+    const unrelatedRendererUpdate = await resolveAndCommit(resolver, [descriptor])
+    const unrelatedLayerUpdate = await resolveAndCommit(resolver, [{ ...descriptor }])
+
+    expect(first.layers[0].image).toBe('blob:airport')
+    expect(unrelatedRendererUpdate.layers[0].image).toBe('blob:airport')
+    expect(unrelatedLayerUpdate.layers[0].image).toBe('blob:airport')
+    expect(readAssetBinary).toHaveBeenCalledOnce()
+    expect(createObjectURL).toHaveBeenCalledOnce()
+
+    const reexecutedDescriptor = { ...descriptor, updateTriggers: {} }
+    const operatorUpdate = await resolveAndCommit(resolver, [reexecutedDescriptor])
+    expect(operatorUpdate.layers[0].image).toBe('blob:airport')
+    expect(readAssetBinary).toHaveBeenCalledTimes(2)
+    expect(createObjectURL).toHaveBeenCalledOnce()
+  })
+
+  it('reuses unchanged content and revokes changed images after renderer commit', async () => {
+    const resolver = createResolver()
+    memoryProjectStore.writeAsset(PROJECT_NAME, 'first.png', new Blob(['first']))
+    memoryProjectStore.writeAsset(PROJECT_NAME, 'second.webp', new Blob(['second']))
+    const createdBlobs: Blob[] = []
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockImplementation(source => {
+      if (!(source instanceof Blob)) throw new Error('Expected an image Blob')
+      createdBlobs.push(source)
+      return `blob:image-${createdBlobs.length}`
+    })
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const first = await resolveAndCommit(resolver, [
+      { type: 'BitmapLayer', id: '/bitmap', image: '@/first.png' },
+    ])
+    resolver.releaseRetiredUrlsThrough(first.generation)
+    const cached = await resolveAndCommit(resolver, [
+      { type: 'BitmapLayer', id: '/bitmap', image: '@/first.png' },
+    ])
+    resolver.releaseRetiredUrlsThrough(cached.generation)
+    const second = await resolveAndCommit(resolver, [
+      { type: 'BitmapLayer', id: '/bitmap', image: '@/second.webp' },
+    ])
+
+    expect(first.layers[0].image).toBe('blob:image-1')
+    expect(cached.layers[0].image).toBe('blob:image-1')
+    expect(second.layers[0].image).toBe('blob:image-2')
+    expect(createObjectURL).toHaveBeenCalledTimes(2)
+    expect(createdBlobs.map(blob => blob.type)).toEqual(['image/png', 'image/webp'])
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    resolver.releaseRetiredUrlsThrough(second.generation)
+    expect(revokeObjectURL).toHaveBeenCalledOnce()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:image-1')
+
+    const external = await resolveAndCommit(resolver, [
+      { type: 'BitmapLayer', id: '/bitmap', image: 'https://example.com/diagram.png' },
+    ])
+    resolver.releaseRetiredUrlsThrough(external.generation)
+    expect(external.layers[0].image).toBe('https://example.com/diagram.png')
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2)
+    expect(revokeObjectURL).toHaveBeenLastCalledWith('blob:image-2')
+  })
+
+  it('reloads changed bytes when a project image is replaced at the same path', async () => {
+    const resolver = createResolver()
+    const redPng = await createTinyPng([255, 0, 0, 255])
+    const bluePng = await createTinyPng([0, 0, 255, 255])
+    memoryProjectStore.writeAsset(PROJECT_NAME, 'airport.png', redPng)
+    const createdBlobs: Blob[] = []
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(source => {
+      if (!(source instanceof Blob)) throw new Error('Expected an image Blob')
+      createdBlobs.push(source)
+      return `blob:replacement-${createdBlobs.length}`
+    })
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const first = await resolveAndCommit(resolver, [
+      { type: 'BitmapLayer', id: '/bitmap', image: '@/airport.png' },
+    ])
+    memoryProjectStore.writeAsset(PROJECT_NAME, 'airport.png', bluePng)
+    const replaced = await resolveAndCommit(resolver, [
+      { type: 'BitmapLayer', id: '/bitmap', image: '@/airport.png' },
+    ])
+    const unchanged = await resolveAndCommit(resolver, [
+      { type: 'BitmapLayer', id: '/bitmap', image: '@/airport.png' },
+    ])
+
+    expect(first.layers[0].image).toBe('blob:replacement-1')
+    expect(replaced.layers[0].image).toBe('blob:replacement-2')
+    expect(unchanged.layers[0].image).toBe('blob:replacement-2')
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(2)
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    resolver.releaseRetiredUrlsThrough(unchanged.generation)
+    expect(revokeObjectURL).toHaveBeenCalledOnce()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:replacement-1')
+
+    const replacementBitmap = await createImageBitmap(createdBlobs[1])
+    const canvas = document.createElement('canvas')
+    canvas.width = 1
+    canvas.height = 1
+    const context = canvas.getContext('2d')
+    if (!context) throw new Error('Canvas 2D context is unavailable')
+    context.drawImage(replacementBitmap, 0, 0)
+    expect(Array.from(context.getImageData(0, 0, 1, 1).data)).toEqual([0, 0, 255, 255])
+    replacementBitmap.close()
+  })
+
+  it('does not create an object URL when disposal overtakes an asset read', async () => {
+    const resolver = createResolver()
+    const pngBytes = await (await createTinyPng([255, 255, 255, 255])).arrayBuffer()
+    let signalReadStarted: () => void = () => {}
+    let finishRead: (contents: ArrayBuffer | null) => void = () => {}
+    const readStarted = new Promise<void>(resolve => {
+      signalReadStarted = resolve
+    })
+    const pendingRead = new Promise<ArrayBuffer | null>(resolve => {
+      finishRead = resolve
+    })
+    vi.spyOn(memoryProjectStore, 'readAssetBinary').mockImplementation(async () => {
+      signalReadStarted()
+      return await pendingRead
+    })
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL')
+
+    const resolution = resolver.resolveLayers(
+      [{ type: 'BitmapLayer', id: '/bitmap', image: '@/airport.png' }],
+      PROJECT_CONTEXT
+    )
+    await readStarted
+    resolver.dispose()
+    finishRead(pngBytes)
+
+    await expect(resolution).resolves.toBeNull()
+    expect(createObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('revokes a resolved URL if disposal happens before renderer commit', async () => {
+    const resolver = createResolver()
+    memoryProjectStore.writeAsset(PROJECT_NAME, 'airport.png', new Blob(['airport']))
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:pending')
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const resolution = await resolver.resolveLayers(
+      [{ type: 'BitmapLayer', id: '/bitmap', image: '@/airport.png' }],
+      PROJECT_CONTEXT
+    )
+    if (!resolution) throw new Error('Asset resolution was unexpectedly cancelled')
+    resolver.dispose()
+
+    expect(resolver.commit(resolution)).toBe(false)
+    expect(revokeObjectURL).toHaveBeenCalledOnce()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:pending')
+  })
+
+  it('reports that project assets require a loaded project', async () => {
+    const resolver = createResolver()
+
+    await expect(
+      resolver.resolveLayers([{ type: 'BitmapLayer', id: '/bitmap', image: '@/airport.png' }], {
+        ...PROJECT_CONTEXT,
+        currentProjectName: null,
+      })
+    ).rejects.toThrow('No project loaded')
+  })
+})

--- a/noodles-editor/src/noodles/noodles.tsx
+++ b/noodles-editor/src/noodles/noodles.tsx
@@ -109,6 +109,7 @@ import {
 } from './store'
 import { transformGraph } from './transform-graph'
 import { canConnectCached } from './utils/can-connect'
+import { DeckProjectAssetResolver } from './utils/deck-project-asset-resolver'
 import { instantiateDeckView } from './utils/deck-view'
 import { directoryHandleCache } from './utils/directory-handle-cache'
 import {
@@ -215,8 +216,13 @@ export function getNoodles(): Visualization {
   const [showExampleNotFoundDialog, setShowExampleNotFoundDialog] = useState(false)
   const [graphErrors, setGraphErrors] = useState<GraphError[]>([])
   const storageType = useActiveStorageType()
-  const { currentDirectory, setCurrentDirectory, setActiveStorageType, setError } =
-    useFileSystemStore()
+  const {
+    currentDirectory,
+    currentProjectName: storedProjectName,
+    setCurrentDirectory,
+    setActiveStorageType,
+    setError,
+  } = useFileSystemStore()
   const timelineStore = getTimelineStore()
   const getTimelineJson = useCallback((): Record<string, unknown> => {
     return timelineStore.toTimelineJSON() as unknown as Record<string, unknown>
@@ -1742,6 +1748,20 @@ export function getNoodles(): Visualization {
   const [visProps, setVisProps] = useState(
     deckRendererOp?.outputs.vis.value || outOp?.inputs.vis.value || {}
   )
+  const deckProjectAssetResolver = useMemo(() => new DeckProjectAssetResolver(), [])
+  const [committedAssetGeneration, setCommittedAssetGeneration] = useState(0)
+
+  useEffect(
+    () => () => {
+      deckProjectAssetResolver.dispose()
+    },
+    [deckProjectAssetResolver]
+  )
+
+  useEffect(() => {
+    // Deck.gl has received the replacement props by the time this effect runs.
+    deckProjectAssetResolver.releaseRetiredUrlsThrough(committedAssetGeneration)
+  }, [committedAssetGeneration, deckProjectAssetResolver])
 
   // Create overlay layer for selected GeoJSON-producing operators
   const selectedGeoJsonFeatures = useMemo(() => {
@@ -1773,101 +1793,144 @@ export function getNoodles(): Visualization {
         'Creating vis subscription from %s',
         deckRendererOp ? 'DeckRendererOp.outputs.vis' : 'OutOp.inputs.vis'
       )
+      let cancelled = false
+      const reportMaterializationError = (error: unknown) => {
+        if (cancelled) return
+        console.error('[Noodles] Failed to materialize Deck.gl layer assets:', error)
+        debugVis('Failed to materialize Deck.gl layer assets: %o', error)
+      }
       const visSub = field.subscribe(
         ({ deckProps: { layers, widgets, views, ...deckProps }, mapProps }) => {
-          // Map layers from POJOs to deck.gl instances
-          const instantiatedLayers =
-            layers?.map(({ type, extensions, ...layer }) => {
-              // Instantiate extensions from POJOs if present
-              let instantiatedExtensions: LayerExtension[] | undefined
-              if (extensions && Array.isArray(extensions)) {
-                instantiatedExtensions = extensions
-                  .map((ext: { type: string; [key: string]: unknown }) => {
-                    const { type: extType, ...constructorArgs } = ext
-                    const extensionDef = extensionMap[extType]
-                    if (!extensionDef) {
-                      debugApp(`Unknown extension type: ${extType}`)
-                      return null
-                    }
-
-                    // Check if it's a wrapped extension (with ExtensionClass and args)
-                    if (typeof extensionDef === 'object' && 'ExtensionClass' in extensionDef) {
-                      return new extensionDef.ExtensionClass(extensionDef.args)
-                    }
-
-                    // It's a direct class constructor
-                    const ExtensionClass = extensionDef as new (
-                      ...args: unknown[]
-                    ) => LayerExtension
-                    return Object.keys(constructorArgs).length > 0
-                      ? new ExtensionClass(constructorArgs)
-                      : new ExtensionClass()
-                  })
-                  .filter((e): e is LayerExtension => e !== null)
+          void deckProjectAssetResolver
+            .resolveLayers(layers ?? [], {
+              activeStorageType: storageType,
+              currentProjectName: storedProjectName,
+            })
+            .then(assetResolution => {
+              if (!assetResolution || cancelled) {
+                if (assetResolution) deckProjectAssetResolver.discard(assetResolution)
+                return
               }
 
-              // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl layer types dynamically
-              return new deck[type]({
-                ...layer,
-                ...(instantiatedExtensions ? { extensions: instantiatedExtensions } : {}),
-                // Prevent deck.gl layer errors from crashing the GPU process
-                onError: (e: Error) => {
-                  console.error(`[Noodles] Layer error in ${layer.id} (${type}):`, e)
-                  debugVis('Layer error in %s (id=%s): %o', type, layer.id, e)
-                },
-              })
-            }) || []
+              try {
+                // Map layers from POJOs to deck.gl instances
+                const instantiatedLayers = assetResolution.layers.map(
+                  ({ type, extensions, ...layer }) => {
+                    // Instantiate extensions from POJOs if present
+                    let instantiatedExtensions: LayerExtension[] | undefined
+                    if (extensions && Array.isArray(extensions)) {
+                      instantiatedExtensions = extensions
+                        .map((ext: { type: string; [key: string]: unknown }) => {
+                          const { type: extType, ...constructorArgs } = ext
+                          const extensionDef = extensionMap[extType]
+                          if (!extensionDef) {
+                            debugApp(`Unknown extension type: ${extType}`)
+                            return null
+                          }
 
-          // Add overlay layer for selected GeoJSON features
-          if (selectedGeoJsonFeatures.length > 0) {
-            const overlayLayer = new deck.GeoJsonLayer({
-              id: 'selected-geojson-overlay',
-              data: selectedGeoJsonFeatures,
-              filled: true,
-              stroked: true,
-              getFillColor: [255, 0, 0, 100], // Red with transparency
-              getLineColor: [255, 0, 0, 255], // Red outline
-              getLineWidth: 2,
-              lineWidthMinPixels: 2,
-              getPointRadius: 10,
-              pointRadiusMinPixels: 10,
+                          // Check if it's a wrapped extension (with ExtensionClass and args)
+                          if (
+                            typeof extensionDef === 'object' &&
+                            'ExtensionClass' in extensionDef
+                          ) {
+                            return new extensionDef.ExtensionClass(extensionDef.args)
+                          }
+
+                          // It's a direct class constructor
+                          const ExtensionClass = extensionDef as new (
+                            ...args: unknown[]
+                          ) => LayerExtension
+                          return Object.keys(constructorArgs).length > 0
+                            ? new ExtensionClass(constructorArgs)
+                            : new ExtensionClass()
+                        })
+                        .filter((e): e is LayerExtension => e !== null)
+                    }
+
+                    // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl layer types dynamically
+                    return new deck[type]({
+                      ...layer,
+                      ...(instantiatedExtensions ? { extensions: instantiatedExtensions } : {}),
+                      // Prevent deck.gl layer errors from crashing the GPU process
+                      onError: (e: Error) => {
+                        console.error(`[Noodles] Layer error in ${layer.id} (${type}):`, e)
+                        debugVis('Layer error in %s (id=%s): %o', type, layer.id, e)
+                      },
+                    })
+                  }
+                )
+
+                // Add overlay layer for selected GeoJSON features
+                if (selectedGeoJsonFeatures.length > 0) {
+                  const overlayLayer = new deck.GeoJsonLayer({
+                    id: 'selected-geojson-overlay',
+                    data: selectedGeoJsonFeatures,
+                    filled: true,
+                    stroked: true,
+                    getFillColor: [255, 0, 0, 100], // Red with transparency
+                    getLineColor: [255, 0, 0, 255], // Red outline
+                    getLineWidth: 2,
+                    lineWidthMinPixels: 2,
+                    getPointRadius: 10,
+                    pointRadiusMinPixels: 10,
+                  })
+                  instantiatedLayers.push(overlayLayer)
+                }
+
+                const instantiatedViews = views?.map(instantiateDeckView)
+
+                debugVis(
+                  'vis subscription fired: %d layers types=%O hasMapProps=%s',
+                  instantiatedLayers.length,
+                  assetResolution.layers.map(l => l.type),
+                  !!mapProps
+                )
+
+                const nextVisProps = {
+                  deckProps: {
+                    ...deckProps,
+                    layers: instantiatedLayers,
+                    widgets: widgets?.map(({ type, ...widget }) => {
+                      if (type === 'LegendWidget')
+                        return new LegendWidget(widget as unknown as LegendWidgetProps)
+                      if (type === 'BitmapOverlay')
+                        return new BitmapOverlayWidget(
+                          widget as unknown as BitmapOverlayWidgetProps
+                        )
+                      // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl widget types dynamically
+                      return new deckWidgets[type](widget)
+                    }),
+                    ...(instantiatedViews?.length ? { views: instantiatedViews } : {}),
+                  },
+                  mapProps,
+                }
+
+                if (!deckProjectAssetResolver.commit(assetResolution)) return
+                setCommittedAssetGeneration(assetResolution.generation)
+                setVisProps(nextVisProps)
+              } catch (error) {
+                deckProjectAssetResolver.discard(assetResolution)
+                reportMaterializationError(error)
+              }
             })
-            instantiatedLayers.push(overlayLayer)
-          }
-
-          const instantiatedViews = views?.map(instantiateDeckView)
-
-          debugVis(
-            'vis subscription fired: %d layers types=%O hasMapProps=%s',
-            instantiatedLayers.length,
-            layers?.map(l => l.type) || [],
-            !!mapProps
-          )
-
-          setVisProps({
-            deckProps: {
-              ...deckProps,
-              layers: instantiatedLayers,
-              widgets: widgets?.map(({ type, ...widget }) => {
-                if (type === 'LegendWidget')
-                  return new LegendWidget(widget as unknown as LegendWidgetProps)
-                if (type === 'BitmapOverlay')
-                  return new BitmapOverlayWidget(widget as unknown as BitmapOverlayWidgetProps)
-                // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We intentionally support all deck.gl widget types dynamically
-                return new deckWidgets[type](widget)
-              }),
-              ...(instantiatedViews?.length ? { views: instantiatedViews } : {}),
-            },
-            mapProps,
-          })
+            .catch(reportMaterializationError)
         }
       )
       return () => {
         debugVis('Cleaning up vis subscription')
+        cancelled = true
         visSub.unsubscribe()
+        deckProjectAssetResolver.cancelPending()
       }
     }
-  }, [deckRendererOp, outOp, selectedGeoJsonFeatures])
+  }, [
+    deckProjectAssetResolver,
+    deckRendererOp,
+    outOp,
+    selectedGeoJsonFeatures,
+    storageType,
+    storedProjectName,
+  ])
 
   const propertiesPanel = (
     <ErrorBoundary title="Property Panel Error">

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -33,6 +33,7 @@ import type {
 } from '@deck.gl/geo-layers'
 import type {
   ArcLayerProps,
+  BitmapBoundingBox,
   BitmapLayerProps,
   ColumnLayerProps,
   GeoJsonLayerProps,
@@ -8779,11 +8780,14 @@ export class SmoothOp extends Operator<SmoothOp> {
 export class BitmapLayerOp extends Operator<BitmapLayerOp> {
   static displayName = 'BitmapLayer'
   static description = 'Render a raster image at specified boundaries'
+
   createInputs() {
     return {
       visible: new BooleanField(true),
       opacity: new NumberField(1, { min: 0, max: 1, step: 0.01 }),
-      image: new StringField(''),
+      image: new FileUrlField('', {
+        accept: '.png,.jpg,.jpeg,.gif,.webp,.svg',
+      }),
       bounds: new BboxField(
         { southwest: { lng: -122.5, lat: 37.7 }, northeast: { lng: -122.3, lat: 37.9 } },
         { returnType: 'tuple' }
@@ -8813,32 +8817,38 @@ export class BitmapLayerOp extends Operator<BitmapLayerOp> {
       layer: new LayerField<BitmapLayerProps>(),
     }
   }
+
   execute(props: ExtractProps<typeof this.inputs>): ExtractProps<typeof this.outputs> {
-    const { bounds, ...restProps } = props
-    let boundsArray: number[][]
-    if (Array.isArray(bounds) && bounds.length === 4) {
-      // Vec4Field format: [minLng, minLat, maxLng, maxLat]
-      boundsArray = [
-        [bounds[0], bounds[1]],
-        [bounds[2], bounds[3]],
-      ]
+    const { bounds, image, ...restProps } = props
+    let deckBounds: BitmapBoundingBox
+    if (
+      Array.isArray(bounds) &&
+      bounds.length === 4 &&
+      bounds.every((coordinate: unknown) => typeof coordinate === 'number')
+    ) {
+      // Preserve the flat format accepted by Deck.gl and older direct callers.
+      deckBounds = [...bounds] as BitmapBoundingBox
     } else if (
       Array.isArray(bounds) &&
       bounds.length === 2 &&
       Array.isArray(bounds[0]) &&
-      Array.isArray(bounds[1])
+      Array.isArray(bounds[1]) &&
+      typeof bounds[0][0] === 'number' &&
+      typeof bounds[0][1] === 'number' &&
+      typeof bounds[1][0] === 'number' &&
+      typeof bounds[1][1] === 'number'
     ) {
-      // Legacy nested array format from old projects
-      boundsArray = bounds as number[][]
+      // BboxField returns [southwest, northeast], while Deck.gl requires a flat bbox.
+      deckBounds = [bounds[0][0], bounds[0][1], bounds[1][0], bounds[1][1]]
     } else {
-      // Unexpected format - throw error
       throw new Error(
         `[BitmapLayerOp] Invalid bounds format. Expected [minLng, minLat, maxLng, maxLat] or [[minLng, minLat], [maxLng, maxLat]], got: ${JSON.stringify(bounds)}`
       )
     }
+
     const layer = {
-      ...parseLayerProps<BitmapLayerProps>(restProps as Omit<typeof props, 'bounds'>),
-      bounds: boundsArray,
+      ...parseLayerProps<BitmapLayerProps>({ ...restProps, image }),
+      bounds: deckBounds,
       type: 'BitmapLayer' as const,
       id: this.id,
       updateTriggers: gatherTriggers(this.inputs, props),

--- a/noodles-editor/src/noodles/utils/deck-project-asset-resolver.ts
+++ b/noodles-editor/src/noodles/utils/deck-project-asset-resolver.ts
@@ -1,0 +1,277 @@
+import { readAssetBinary } from '../storage'
+import { projectScheme, type StorageType } from './filesystem'
+
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+}
+
+type DeckLayerDescriptor = {
+  type: string
+  [key: string]: unknown
+}
+
+type ProjectAssetContext = {
+  activeStorageType: StorageType
+  currentProjectName: string | null
+}
+
+type CacheEntry = {
+  contentIdentity: string
+  sourceKey: string
+  url: string
+}
+
+type PendingResolution = {
+  createdUrls: Set<string>
+  descriptorEntries: Array<{ descriptorIdentity: object; entry: CacheEntry }>
+  nextCache: Map<string, CacheEntry>
+}
+
+export type DeckProjectAssetResolution<T extends DeckLayerDescriptor> = {
+  generation: number
+  layers: T[]
+}
+
+function extensionOf(fileName: string) {
+  const match = /(?:^|\/)(?:[^/]*)(\.[^./]+)$/.exec(fileName)
+  return match?.[1]?.toLowerCase() ?? ''
+}
+
+function descriptorIdentity(layer: DeckLayerDescriptor) {
+  // ListField's Zod parse shallow-clones layer descriptors whenever any sibling layer changes,
+  // but it preserves nested values. Layer operators create a new updateTriggers object on each
+  // execution, making it a stable execution identity across unrelated list/renderer updates.
+  return layer.updateTriggers !== null && typeof layer.updateTriggers === 'object'
+    ? layer.updateTriggers
+    : layer
+}
+
+async function contentIdentity(data: ArrayBuffer) {
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+/**
+ * Owns browser resources needed while materializing serializable layer descriptors.
+ * Operators deliberately keep emitting project-relative references; this runtime service
+ * resolves them only at the boundary where Deck.gl layer instances are constructed.
+ */
+export class DeckProjectAssetResolver {
+  private activeCache = new Map<string, CacheEntry>()
+  private descriptorCache = new WeakMap<object, CacheEntry>()
+  private disposed = false
+  private generation = 0
+  private pendingResolutions = new Map<number, PendingResolution>()
+  private retiredUrls = new Map<string, number>()
+
+  private isCurrent(generation: number) {
+    return !this.disposed && generation === this.generation
+  }
+
+  private revokePendingResolutions() {
+    for (const pending of this.pendingResolutions.values()) {
+      for (const url of pending.createdUrls) URL.revokeObjectURL(url)
+    }
+    this.pendingResolutions.clear()
+  }
+
+  private beginResolution() {
+    this.generation++
+    this.revokePendingResolutions()
+    return this.generation
+  }
+
+  async resolveLayers<T extends DeckLayerDescriptor>(
+    layers: readonly T[],
+    context: ProjectAssetContext
+  ): Promise<DeckProjectAssetResolution<T> | null> {
+    if (this.disposed) return null
+
+    const generation = this.beginResolution()
+    const projectImages = new Map<
+      string,
+      {
+        fileName: string
+        layers: Array<{ descriptor: T; descriptorIdentity: object; index: number }>
+        sourceKey: string
+      }
+    >()
+
+    for (const [index, layer] of layers.entries()) {
+      if (
+        layer.type !== 'BitmapLayer' ||
+        typeof layer.image !== 'string' ||
+        !layer.image.startsWith(projectScheme)
+      ) {
+        continue
+      }
+
+      if (!context.currentProjectName) {
+        throw new Error('No project loaded. Please save or load a project first.')
+      }
+
+      const fileName = layer.image.substring(projectScheme.length)
+      const sourceKey = JSON.stringify([
+        context.activeStorageType,
+        context.currentProjectName,
+        fileName,
+      ])
+      const request = projectImages.get(sourceKey)
+      const identity = descriptorIdentity(layer)
+      if (request) request.layers.push({ descriptor: layer, descriptorIdentity: identity, index })
+      else {
+        projectImages.set(sourceKey, {
+          fileName,
+          layers: [{ descriptor: layer, descriptorIdentity: identity, index }],
+          sourceKey,
+        })
+      }
+    }
+
+    const loadedImages = await Promise.all(
+      Array.from(projectImages.values(), async request => {
+        const activeEntry = this.activeCache.get(request.sourceKey)
+        const descriptorsAreCached =
+          activeEntry !== undefined &&
+          request.layers.every(
+            ({ descriptorIdentity }) =>
+              this.descriptorCache.get(descriptorIdentity)?.url === activeEntry.url
+          )
+        if (descriptorsAreCached) return { ...request, cachedEntry: activeEntry }
+
+        // FileUrlField can overwrite an asset without changing its @/ path, so the current
+        // bytes—not the path alone—must participate in cache identity whenever an operator
+        // emits a new descriptor. Stable descriptors from unrelated vis updates reuse the URL.
+        const result = await readAssetBinary(
+          context.activeStorageType,
+          context.currentProjectName as string,
+          request.fileName
+        )
+        if (!this.isCurrent(generation)) return null
+        if (!result.success) throw new Error(result.error.message)
+
+        const identity = await contentIdentity(result.data)
+        if (!this.isCurrent(generation)) return null
+        return { ...request, data: result.data, identity }
+      })
+    )
+
+    if (!this.isCurrent(generation) || loadedImages.some(image => image === null)) return null
+
+    const resolvedLayers = [...layers]
+    const nextCache = new Map<string, CacheEntry>()
+    const createdUrls = new Set<string>()
+    const descriptorEntries: PendingResolution['descriptorEntries'] = []
+
+    try {
+      for (const loadedImage of loadedImages) {
+        if (!loadedImage) continue
+
+        const cached =
+          'cachedEntry' in loadedImage
+            ? loadedImage.cachedEntry
+            : this.activeCache.get(loadedImage.sourceKey)
+        let entry = cached
+        if (
+          !entry ||
+          ('identity' in loadedImage && entry.contentIdentity !== loadedImage.identity)
+        ) {
+          if (!('data' in loadedImage) || !('identity' in loadedImage)) continue
+          const mimeType =
+            IMAGE_MIME_TYPES[extensionOf(loadedImage.fileName)] ?? 'application/octet-stream'
+          const url = URL.createObjectURL(new Blob([loadedImage.data], { type: mimeType }))
+          createdUrls.add(url)
+          entry = {
+            sourceKey: loadedImage.sourceKey,
+            contentIdentity: loadedImage.identity,
+            url,
+          }
+        }
+        nextCache.set(entry.sourceKey, entry)
+
+        for (const { descriptorIdentity, index } of loadedImage.layers) {
+          descriptorEntries.push({ descriptorIdentity, entry })
+          resolvedLayers[index] = {
+            ...resolvedLayers[index],
+            image: entry.url,
+          }
+        }
+      }
+    } catch (error) {
+      for (const url of createdUrls) URL.revokeObjectURL(url)
+      throw error
+    }
+
+    if (!this.isCurrent(generation)) {
+      for (const url of createdUrls) URL.revokeObjectURL(url)
+      return null
+    }
+
+    this.pendingResolutions.set(generation, { createdUrls, descriptorEntries, nextCache })
+    return { generation, layers: resolvedLayers }
+  }
+
+  /** Commits a resolution immediately before its layer instances are published to React. */
+  commit<T extends DeckLayerDescriptor>(resolution: DeckProjectAssetResolution<T>) {
+    const pending = this.pendingResolutions.get(resolution.generation)
+    if (!pending || !this.isCurrent(resolution.generation)) {
+      this.discard(resolution)
+      return false
+    }
+
+    const nextUrls = new Set(Array.from(pending.nextCache.values(), entry => entry.url))
+    for (const entry of this.activeCache.values()) {
+      if (!nextUrls.has(entry.url)) this.retiredUrls.set(entry.url, resolution.generation)
+    }
+
+    this.activeCache = pending.nextCache
+    for (const { descriptorIdentity, entry } of pending.descriptorEntries) {
+      this.descriptorCache.set(descriptorIdentity, entry)
+    }
+    this.pendingResolutions.delete(resolution.generation)
+    return true
+  }
+
+  discard<T extends DeckLayerDescriptor>(resolution: DeckProjectAssetResolution<T>) {
+    const pending = this.pendingResolutions.get(resolution.generation)
+    if (!pending) return
+    for (const url of pending.createdUrls) URL.revokeObjectURL(url)
+    this.pendingResolutions.delete(resolution.generation)
+  }
+
+  /** Revoke superseded URLs only after React has committed the replacement layer props. */
+  releaseRetiredUrlsThrough(generation: number) {
+    for (const [url, retiredAt] of this.retiredUrls) {
+      if (retiredAt > generation) continue
+      URL.revokeObjectURL(url)
+      this.retiredUrls.delete(url)
+    }
+  }
+
+  cancelPending() {
+    if (this.disposed) return
+    this.generation++
+    this.revokePendingResolutions()
+  }
+
+  dispose() {
+    if (this.disposed) return
+    this.disposed = true
+    this.generation++
+    this.revokePendingResolutions()
+
+    const urls = new Set([
+      ...Array.from(this.activeCache.values(), entry => entry.url),
+      ...this.retiredUrls.keys(),
+    ])
+    for (const url of urls) URL.revokeObjectURL(url)
+    this.activeCache.clear()
+    this.descriptorCache = new WeakMap<object, CacheEntry>()
+    this.retiredUrls.clear()
+  }
+}


### PR DESCRIPTION
## Summary
Fixes `BitmapLayerOp` project-local image loading by resolving `@/` assets to correctly MIME-typed, cached object URLs at the Deck.gl runtime boundary, and normalizes `BboxField` output to Deck.gl's flat `[west, south, east, north]` bounds.

## Changes
- Image upload UI via `FileUrlField`
- Pure, synchronous `BitmapLayerOp` output with project asset resolution moved to renderer materialization
- PNG, JPEG, GIF, WebP, and SVG MIME inference
- Content-identified URL reuse with same-path replacement detection
- Execution-identity fast path that skips asset reads and hashing for unrelated visualization updates
- Transactional generation cancellation plus post-render replacement and disposal revocation
- External URL pass-through and legacy flat-bounds compatibility

## Testing
- Focused browser tests — 12 passed, including valid PNG decode/pixels, pure operator output, unchanged-execution read reuse, same-path overwrite, post-commit cleanup, and deferred-read disposal
- `npm run lint` — passed
- `npm run build` — passed
- Broader `operators.test.ts` — 295 passed, 8 unrelated shared-symlink DuckDB WASM/API-key environment failures
- Repository-wide `tsc --noEmit` — baseline failures across existing files; no diagnostics from the new test file

## Manual Testing
1. In a saved project, add `BitmapLayerOp`, `DeckRendererOp`, and `OutOp`, then connect bitmap layer → renderer layers → output.
2. Use the bitmap image upload control to choose a PNG stored with the project and set its southwest/northeast bounds around the current camera.
3. Change opacity or bounds, replace the project image with a different PNG using the same filename, then switch to an external URL and back to the uploaded `@/` asset.

Expected: the project PNG renders at the selected extent without a bounds-conversion CodeOp, same-name replacements appear immediately, and external URLs continue to render unchanged.
