### PR TITLE
fix: persist number input precision

### DIFF
--- a/noodles-editor/src/noodles/components/draggable-number-input.test.tsx
+++ b/noodles-editor/src/noodles/components/draggable-number-input.test.tsx
@@ -12,12 +12,14 @@ describe('DraggableNumberInput', () => {
     vi.useFakeTimers()
     const onChange = vi.fn()
     const onDragEnd = vi.fn()
+    const onStepChange = vi.fn()
     const { container } = render(
       <DraggableNumberInput
         value={10}
         step={0.1}
         onChange={onChange}
         onDragEnd={onDragEnd}
+        onStepChange={onStepChange}
         aria-label="Value"
       />
     )
@@ -35,6 +37,8 @@ describe('DraggableNumberInput', () => {
     expect(screen.getByText('0.01').parentElement?.className).toContain('stepLadderItemActive')
 
     fireEvent.mouseMove(document, { clientX: 120, clientY: 120 })
+    expect(onStepChange).toHaveBeenCalledOnce()
+    expect(onStepChange).toHaveBeenCalledWith(0.01)
     expect(onChange).toHaveBeenLastCalledWith(10.2)
     expect(input).toHaveValue(10.2)
 
@@ -84,6 +88,115 @@ describe('DraggableNumberInput', () => {
 
     fireEvent.change(input, { target: { value: '-1' } })
     expect(onChange).toHaveBeenLastCalledWith(-1)
+  })
+
+  it('displays the complete number when no display formatter is provided', () => {
+    render(
+      <DraggableNumberInput
+        value={1.234567891234}
+        step={1e-12}
+        onChange={vi.fn()}
+        aria-label="Value"
+      />
+    )
+
+    expect(screen.getByRole('spinbutton', { name: 'Value' })).toHaveValue(1.234567891234)
+  })
+
+  it('freezes the step for the duration of a focused interaction', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <DraggableNumberInput value={0.25} step={0.01} onChange={onChange} aria-label="Value" />
+    )
+    const input = screen.getByRole('spinbutton', { name: 'Value' })
+
+    fireEvent.focus(input)
+    rerender(<DraggableNumberInput value={1} step={1} onChange={onChange} aria-label="Value" />)
+    expect(input).toHaveAttribute('step', '0.01')
+
+    fireEvent.blur(input)
+    expect(input).toHaveAttribute('step', '1')
+  })
+
+  it('uses a selected ladder step immediately after mouseup while focused', () => {
+    const { container } = render(
+      <DraggableNumberInput value={0.25} step={0.1} onChange={vi.fn()} aria-label="Value" />
+    )
+    const input = screen.getByRole('spinbutton', { name: 'Value' })
+    const wrapper = container.querySelector('[role="group"]') as HTMLElement
+
+    fireEvent.focus(input)
+    fireEvent.mouseDown(wrapper, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(document, { clientX: 100, clientY: 120 })
+    fireEvent.mouseMove(document, { clientX: 120, clientY: 120 })
+    fireEvent.mouseUp(document)
+
+    expect(input).toHaveAttribute('step', '0.01')
+  })
+
+  it('releases a frozen step when a drag is interrupted by window blur', () => {
+    const onChange = vi.fn()
+    const { container, rerender } = render(
+      <DraggableNumberInput value={0.25} step={0.01} onChange={onChange} aria-label="Value" />
+    )
+    const input = screen.getByRole('spinbutton', { name: 'Value' })
+    const wrapper = container.querySelector('[role="group"]') as HTMLElement
+
+    fireEvent.focus(input)
+    fireEvent.mouseDown(wrapper, { clientX: 100, clientY: 100 })
+    rerender(<DraggableNumberInput value={1} step={1} onChange={onChange} aria-label="Value" />)
+    fireEvent(window, new Event('blur'))
+
+    expect(input).toHaveAttribute('step', '1')
+  })
+
+  it('does not truncate dragged values to seven decimal places', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <DraggableNumberInput
+        value={1.234567891}
+        step={1e-9}
+        onChange={onChange}
+        aria-label="Value"
+      />
+    )
+    const wrapper = container.querySelector('[role="group"]') as HTMLElement
+
+    fireEvent.mouseDown(wrapper, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(document, { clientX: 116, clientY: 100 })
+
+    expect(onChange).toHaveBeenLastCalledWith(1.234567907)
+    fireEvent.mouseUp(document)
+  })
+
+  it('removes binary residue from decimal scrub deltas', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <DraggableNumberInput value={0.1} step={0.1} onChange={onChange} aria-label="Value" />
+    )
+    const wrapper = container.querySelector('[role="group"]') as HTMLElement
+
+    fireEvent.mouseDown(wrapper, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(document, { clientX: 116, clientY: 100 })
+    fireEvent.mouseMove(document, { clientX: 102, clientY: 100 })
+
+    expect(onChange).toHaveBeenLastCalledWith(0.3)
+    fireEvent.mouseUp(document)
+  })
+
+  it('preserves starting decimals finer than the selected scrub step', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <DraggableNumberInput value={1.234567891} step={0.1} onChange={onChange} aria-label="Value" />
+    )
+    const wrapper = container.querySelector('[role="group"]') as HTMLElement
+
+    fireEvent.mouseDown(wrapper, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(document, { clientX: 116, clientY: 100 })
+    fireEvent.mouseMove(document, { clientX: 102, clientY: 100 })
+
+    expect(onChange).toHaveBeenLastCalledWith(1.434567891)
+    fireEvent.mouseUp(document)
   })
 
   it('removes document drag listeners when unmounted mid-gesture', () => {

--- a/noodles-editor/src/noodles/components/draggable-number-input.tsx
+++ b/noodles-editor/src/noodles/components/draggable-number-input.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from 'react'
 import s from '../noodles.module.css'
+import { addDecimalSteps } from '../utils/number-precision'
 
 type DragState = {
   startX: number
@@ -156,6 +157,14 @@ export function useDrag(options: UseDragOptions) {
   }
 }
 
+// The ladder only scales by powers of ten. Adjusting the exponent directly avoids
+// persisting artifacts such as 0.1 * 0.1 === 0.010000000000000002.
+function scaleStep(baseStep: number, multiplier: number): number {
+  const multiplierExponent = Math.round(Math.log10(multiplier))
+  const [coefficient, exponent = '0'] = baseStep.toExponential().split('e')
+  return Number(`${coefficient}e${Number(exponent) + multiplierExponent}`)
+}
+
 export function StepLadder({
   baseStep,
   currentStepMultiplier,
@@ -170,7 +179,7 @@ export function StepLadder({
   const steps = []
   for (let i = 2; i >= -2; i--) {
     const multiplier = 10 ** i
-    const stepSize = baseStep * multiplier
+    const stepSize = scaleStep(baseStep, multiplier)
     const isActive = Math.abs(currentStepMultiplier - multiplier) < 0.01
 
     steps.push({
@@ -222,6 +231,7 @@ export interface DraggableNumberInputProps {
   onCommit?: () => void
   onDragEnd?: () => void
   onInteractionStart?: () => void
+  onStepChange?: (step: number) => void
   onBlur?: FocusEventHandler<HTMLInputElement>
   onKeyDown?: KeyboardEventHandler<HTMLInputElement>
   min?: number
@@ -246,6 +256,7 @@ export function DraggableNumberInput({
   onCommit,
   onDragEnd,
   onInteractionStart,
+  onStepChange,
   onBlur,
   onKeyDown,
   min,
@@ -261,18 +272,23 @@ export function DraggableNumberInput({
   placeholder,
   'aria-label': ariaLabel,
 }: DraggableNumberInputProps) {
+  const validStep = Number.isFinite(step) && step > 0 ? step : 1
   const [displayValue, setDisplayValue] = useState(value?.toString() ?? '0')
   const [isActive, setIsActive] = useState(false)
   const [currentStepMultiplier, setCurrentStepMultiplier] = useState(1)
   const [isDragStarted, setIsDragStarted] = useState(false)
   const [showLadder, setShowLadder] = useState(false)
   const [initialMousePos, setInitialMousePos] = useState({ x: 0, y: 0 })
+  const [interactionStep, setInteractionStep] = useState<number | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const startValueRef = useRef(0)
+  const interactionStepRef = useRef(validStep)
+  const interactionActiveRef = useRef(false)
+  const inputFocusedRef = useRef(false)
   const isHorizontalLockedRef = useRef(false)
   const lockedStepMultiplierRef = useRef(1)
+  const selectedStepRef = useRef<number | null>(null)
   const ladderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const effectiveStep = Number.isFinite(step) && step > 0 ? step : 1
 
   useEffect(() => {
     setDisplayValue(value?.toString() ?? '0')
@@ -295,6 +311,18 @@ export function DraggableNumberInput({
       clearTimeout(ladderTimerRef.current)
       ladderTimerRef.current = null
     }
+  }, [])
+
+  const beginStepInteraction = useCallback(() => {
+    if (interactionActiveRef.current) return
+    interactionActiveRef.current = true
+    interactionStepRef.current = validStep
+    setInteractionStep(validStep)
+  }, [validStep])
+
+  const endStepInteraction = useCallback(() => {
+    interactionActiveRef.current = false
+    setInteractionStep(null)
   }, [])
 
   const handleInputChange = useCallback(
@@ -322,6 +350,7 @@ export function DraggableNumberInput({
       }
 
       onInteractionStart?.()
+      beginStepInteraction()
       startValueRef.current = value
       setInitialMousePos({
         x: 'clientX' in event ? event.clientX : touchEvent.touches[0].clientX,
@@ -331,6 +360,7 @@ export function DraggableNumberInput({
       isHorizontalLockedRef.current = false
       setIsDragStarted(true)
       lockedStepMultiplierRef.current = 1
+      selectedStepRef.current = null
 
       ladderTimerRef.current = setTimeout(() => {
         window.getSelection()?.removeAllRanges()
@@ -357,6 +387,9 @@ export function DraggableNumberInput({
         } else {
           lockedStepMultiplierRef.current = snappedStepMultiplier
           isHorizontalLockedRef.current = true
+          const selectedStep = scaleStep(interactionStepRef.current, snappedStepMultiplier)
+          selectedStepRef.current = selectedStep
+          onStepChange?.(selectedStep)
         }
       }
 
@@ -364,23 +397,28 @@ export function DraggableNumberInput({
         const activeStepMultiplier = isHorizontalLockedRef.current
           ? lockedStepMultiplierRef.current
           : snappedStepMultiplier
-        const stepSize = activeStepMultiplier * effectiveStep
-        const valueChange = Math.round(deltaX) * stepSize
-        const newValue = startValueRef.current + valueChange
+        const stepSize = scaleStep(interactionStepRef.current, activeStepMultiplier)
+        const newValue = addDecimalSteps(startValueRef.current, stepSize, deltaX)
         const minClampedValue = min === undefined ? newValue : Math.max(newValue, min)
         const clampedValue = max === undefined ? minClampedValue : Math.min(minClampedValue, max)
-        const stepExponent = Math.floor(Math.log10(stepSize))
-        const precision = Math.max(0, Math.min(100, -stepExponent + 2))
-        const fixedValue =
-          Number.isFinite(stepExponent) && stepExponent >= -100
-            ? Number.parseFloat(clampedValue.toFixed(precision))
-            : clampedValue
-
-        setDisplayValue(fixedValue.toString())
-        onChange(fixedValue)
+        setDisplayValue(clampedValue.toString())
+        onChange(clampedValue)
       }
     },
-    onInteractionEnd: resetDragUi,
+    onInteractionEnd: event => {
+      const selectedStep = selectedStepRef.current
+      selectedStepRef.current = null
+      resetDragUi()
+      if (event.type === 'blur' || event.type === 'touchcancel') {
+        inputFocusedRef.current = false
+        endStepInteraction()
+      } else if (inputFocusedRef.current && selectedStep !== null) {
+        interactionStepRef.current = selectedStep
+        setInteractionStep(selectedStep)
+      } else if (!inputFocusedRef.current) {
+        endStepInteraction()
+      }
+    },
     onDragEnd: () => {
       onCommit?.()
       onDragEnd?.()
@@ -389,11 +427,8 @@ export function DraggableNumberInput({
 
   const shouldShowLadder = showLadder && isDragStarted && !isHorizontalLockedRef.current
   const containerRect = containerRef.current?.getBoundingClientRect()
-  const formatted =
-    displayValue === ''
-      ? ''
-      : (formatDisplayValue?.(+displayValue) ??
-        Math.round((+displayValue + Number.EPSILON) * 100) / 100)
+  const formatted = displayValue === '' ? '' : (formatDisplayValue?.(+displayValue) ?? displayValue)
+  const effectiveStep = interactionStep ?? validStep
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: Number input wrapper with drag interaction requires div with role
@@ -410,10 +445,14 @@ export function DraggableNumberInput({
         id={id}
         type="number"
         onFocus={() => {
+          inputFocusedRef.current = true
+          beginStepInteraction()
           setIsActive(true)
           onInteractionStart?.()
         }}
         onBlur={event => {
+          inputFocusedRef.current = false
+          endStepInteraction()
           setIsActive(false)
           onCommit?.()
           onBlur?.(event)

--- a/noodles-editor/src/noodles/components/field-components.test.tsx
+++ b/noodles-editor/src/noodles/components/field-components.test.tsx
@@ -17,7 +17,7 @@ import {
   Vec2Field,
   Vec3Field,
 } from '../fields'
-import { StringOp } from '../operators'
+import { NumberOp, StringOp } from '../operators'
 import { clearOps, setOp } from '../store'
 import { registerPropertyMutationCallback } from '../utils/property-history'
 import {
@@ -137,6 +137,51 @@ describe('NumberFieldComponent', () => {
 
     const input = screen.getByRole('spinbutton')
     expect(input).toHaveAttribute('step', '0.5')
+  })
+
+  it('derives the Number operator step from its current decimal precision', () => {
+    const op = new NumberOp('/number', { val: 0.25 })
+    render(<NumberFieldComponent id="val" field={op.inputs.val} disabled={false} />)
+
+    expect(screen.getByRole('spinbutton')).toHaveAttribute('step', '0.01')
+  })
+
+  it('increments a decimal Number operator by its derived precision', () => {
+    const op = new NumberOp('/number', { val: 0.25 })
+    render(<NumberFieldComponent id="val" field={op.inputs.val} disabled={false} />)
+    const input = screen.getByRole('spinbutton') as HTMLInputElement
+
+    fireEvent.focus(input)
+    input.stepUp()
+    fireEvent.input(input)
+
+    expect(op.inputs.val.value).toBe(0.26)
+    expect(input).toHaveAttribute('step', '0.01')
+  })
+
+  it('reacts to a restored explicit step override', () => {
+    const op = new NumberOp('/number', { val: 0.25 })
+    render(<NumberFieldComponent id="val" field={op.inputs.val} disabled={false} />)
+
+    act(() => op.inputs.val.setStepOverride(0.001))
+
+    expect(screen.getByRole('spinbutton')).toHaveAttribute('step', '0.001')
+  })
+
+  it('persists the precision selected while scrubbing', () => {
+    const op = new NumberOp('/number', { val: 0.25 })
+    setOp(op.id, op)
+    const { container } = render(
+      <NumberFieldComponent id="val" field={op.inputs.val} disabled={false} />
+    )
+    const wrapper = container.querySelector('[role="group"]') as HTMLElement
+
+    fireEvent.mouseDown(wrapper, { clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(document, { clientX: 100, clientY: 120 })
+    fireEvent.mouseMove(document, { clientX: 120, clientY: 120 })
+
+    expect(op.inputs.val.stepOverride).toBe(0.001)
+    fireEvent.mouseUp(document)
   })
 })
 
@@ -988,9 +1033,8 @@ describe('NumberFieldComponent edge cases', () => {
     render(<NumberFieldComponent id="test-field" field={field} disabled={false} />)
 
     const input = screen.getByRole('spinbutton')
-    // The display rounds to 2 decimal places when not focused
-    expect(input).toHaveValue(1.23)
-    // But the field stores the full precision
+    // The display and field both preserve the full precision.
+    expect(input).toHaveValue(1.23456)
     expect(field.value).toBe(1.23456)
   })
 

--- a/noodles-editor/src/noodles/components/field-components.tsx
+++ b/noodles-editor/src/noodles/components/field-components.tsx
@@ -1566,14 +1566,19 @@ export function NumberFieldComponent({
   disabled: boolean
 }) {
   const [value, setValue] = useState<number>(guardAccessorFallback(field.value))
+  const [stepOverride, setStepOverride] = useState(field.stepOverride)
   const { captureStart, commitChange } = usePropertyHistory()
 
   useEffect(() => {
-    const sub = field.subscribe(newVal => {
+    const valueSub = field.subscribe(newVal => {
       if (typeof newVal === 'function') return
       setValue(newVal)
     })
-    return () => sub.unsubscribe()
+    const stepSub = field.stepOverride$.subscribe(setStepOverride)
+    return () => {
+      valueSub.unsubscribe()
+      stepSub.unsubscribe()
+    }
   }, [field])
 
   const handleChange = useCallback(
@@ -1596,11 +1601,12 @@ export function NumberFieldComponent({
         onChange={handleChange}
         onCommit={() => commitChange('Change value')}
         onInteractionStart={captureStart}
+        onStepChange={step => field.setStepOverride(step)}
         min={field.min}
         max={field.max}
         softMin={field.softMin}
         softMax={field.softMax}
-        step={field.step}
+        step={stepOverride ?? field.getEffectiveStep(value)}
         className={cx(s.fieldInput, s.fieldInputNumber)}
         title={value.toString()}
       />

--- a/noodles-editor/src/noodles/fields.test.ts
+++ b/noodles-editor/src/noodles/fields.test.ts
@@ -5,11 +5,14 @@ import z from 'zod/v4'
 import { hexToColor } from '../utils/color'
 import {
   ArrayField,
+  applyNodeUIMetadata,
   BboxField,
   ColorField,
   CompoundPropsField,
+  captureNodeUIMetadata,
   DataField,
   DateField,
+  deriveDecimalStep,
   Field,
   FileUrlField,
   FunctionField,
@@ -561,6 +564,73 @@ describe('NumberField', () => {
     // Cannot go below hard min
     field.setValue(-10)
     expect(field.value).toEqual(200) // unchanged
+  })
+
+  it.each([
+    { value: 0.25, step: 0.01 },
+    { value: -12.345, step: 0.001 },
+    { value: 1.25e-4, step: 1e-6 },
+    { value: 1.25e-13, step: 1e-15 },
+    { value: -1.25e-13, step: 1e-15 },
+  ])('derives a $step decimal step from $value', ({ value, step }) => {
+    expect(deriveDecimalStep(value)).toBe(step)
+  })
+
+  it.each([42, 0, 1.25e13])('uses the declared fallback step for integer value %s', value => {
+    expect(deriveDecimalStep(value, 0.25)).toBe(0.25)
+  })
+
+  it('ignores ordinary floating-point arithmetic noise when deriving a step', () => {
+    expect(deriveDecimalStep(0.1 + 0.2)).toBe(0.1)
+  })
+
+  it('uses the declared step unless value-derived precision is explicitly enabled', () => {
+    const semanticField = new NumberField(0.25, { step: 0.5 })
+    const numberOp = new NumberOp('/number', { val: 0.25 })
+
+    expect(semanticField.getEffectiveStep()).toBe(0.5)
+    expect(numberOp.inputs.val.getEffectiveStep()).toBe(0.01)
+
+    semanticField.setStepOverride(0.01)
+    expect(semanticField.getEffectiveStep()).toBe(0.01)
+  })
+
+  it('prefers an observable user-selected step over declared or derived steps', () => {
+    const field = new NumberField(0.25, { step: 1, deriveStepFromValue: true })
+    const observed: Array<number | undefined> = []
+    const subscription = field.stepOverride$.subscribe(step => observed.push(step))
+
+    field.setStepOverride(0.001)
+    expect(field.getEffectiveStep()).toBe(0.001)
+    field.setStepOverride(undefined)
+    expect(field.getEffectiveStep()).toBe(0.01)
+    expect(observed).toEqual([undefined, 0.001, undefined])
+
+    subscription.unsubscribe()
+  })
+
+  it('captures and restores top-level and nested number-step overrides', () => {
+    const plain = new NumberField(1)
+    const nested = new NumberField(2)
+    const fields = {
+      plain,
+      settings: new CompoundPropsField({ nested, untouched: new NumberField(3) }),
+    }
+    plain.setStepOverride(0.1)
+    nested.setStepOverride(0.001)
+
+    expect(captureNodeUIMetadata(fields)).toEqual({
+      numberSteps: { plain: 0.1, 'settings.nested': 0.001 },
+    })
+
+    applyNodeUIMetadata(fields, { numberSteps: { plain: 10, 'settings.nested': 0.01 } })
+    expect(plain.stepOverride).toBe(10)
+    expect(nested.stepOverride).toBe(0.01)
+
+    applyNodeUIMetadata(fields)
+    expect(plain.stepOverride).toBeUndefined()
+    expect(nested.stepOverride).toBeUndefined()
+    expect(captureNodeUIMetadata(fields)).toBeUndefined()
   })
 })
 

--- a/noodles-editor/src/noodles/fields.ts
+++ b/noodles-editor/src/noodles/fields.ts
@@ -12,7 +12,10 @@ import type { IOperator, Operator } from './operators'
 import type { DeckViewDescriptor, DeckViewValue } from './types'
 import { deepEqual } from './utils/deep-equal'
 import type { ExtractProps } from './utils/extract-props'
+import { deriveDecimalStep } from './utils/number-precision'
 import { resolvePath } from './utils/path-utils'
+
+export { deriveDecimalStep } from './utils/number-precision'
 
 export interface IField<
   S extends z.ZodType = z.ZodType,
@@ -57,6 +60,9 @@ type NumberFieldOptions = BaseFieldOptions & {
   softMin: number
   softMax: number
   step: number
+  // Generic Number operators can infer their editing step from the current value.
+  // Semantic fields (opacity, latitude, width, etc.) keep their declared step.
+  deriveStepFromValue: boolean
 }
 
 type CompoundPropsFieldOptions = BaseFieldOptions &
@@ -647,6 +653,11 @@ export class NumberField extends Field<z.ZodNumber, NumberFieldOptions> {
   softMin: number
   softMax: number
   step: number
+  deriveStepFromValue: boolean
+
+  // A user-selected step is UI state rather than graph data. Keeping it observable
+  // lets an undo/redo restore update an already-mounted number control.
+  readonly stepOverride$ = new BehaviorSubject<number | undefined>(undefined)
 
   createSchema(options: NumberFieldOptions) {
     const schema = z.number().min(options.min).max(options.max)
@@ -662,6 +673,7 @@ export class NumberField extends Field<z.ZodNumber, NumberFieldOptions> {
       softMin: -Infinity,
       softMax: Infinity,
       step: 0.1,
+      deriveStepFromValue: false,
       ...options,
     }
     super(override, opts)
@@ -670,6 +682,23 @@ export class NumberField extends Field<z.ZodNumber, NumberFieldOptions> {
     this.softMin = opts.softMin
     this.softMax = opts.softMax
     this.step = opts.step
+    this.deriveStepFromValue = opts.deriveStepFromValue
+  }
+
+  get stepOverride(): number | undefined {
+    return this.stepOverride$.value
+  }
+
+  setStepOverride(step: number | undefined): void {
+    if (step !== undefined && (!Number.isFinite(step) || step <= 0)) return
+    if (Object.is(this.stepOverride$.value, step)) return
+    this.stepOverride$.next(step)
+  }
+
+  getEffectiveStep(value: number = this.value): number {
+    if (this.stepOverride !== undefined) return this.stepOverride
+    if (this.deriveStepFromValue) return deriveDecimalStep(value, this.step)
+    return this.step
   }
 }
 
@@ -1422,6 +1451,61 @@ export class CompoundPropsField extends Field<
     this.subscriptions.set(id, subscription)
     return subscription
   }
+}
+
+export type NumberStepOverrides = Record<string, number>
+
+export type NodeUIMetadata = {
+  numberSteps?: NumberStepOverrides
+}
+
+function visitNumberFields(
+  fields: Record<string, unknown>,
+  visitor: (path: string, field: NumberField) => void,
+  parentPath = ''
+): void {
+  for (const [name, field] of Object.entries(fields)) {
+    const path = parentPath ? `${parentPath}.${name}` : name
+    if (field instanceof NumberField) {
+      visitor(path, field)
+    } else if (field instanceof CompoundPropsField) {
+      visitNumberFields(field.fields, visitor, path)
+    }
+  }
+}
+
+export function captureNumberStepOverrides(fields: Record<string, unknown>): NumberStepOverrides {
+  const overrides: NumberStepOverrides = {}
+  visitNumberFields(fields, (path, field) => {
+    if (field.stepOverride !== undefined) overrides[path] = field.stepOverride
+  })
+  return overrides
+}
+
+// Applying an absent map deliberately clears overrides. Property-history snapshots
+// need to undo a precision-only change even when the numeric input value is unchanged.
+export function applyNumberStepOverrides(
+  fields: Record<string, unknown>,
+  overrides?: NumberStepOverrides
+): void {
+  visitNumberFields(fields, (path, field) => {
+    const step = overrides?.[path]
+    field.setStepOverride(
+      typeof step === 'number' && Number.isFinite(step) && step > 0 ? step : undefined
+    )
+  })
+}
+
+export function captureNodeUIMetadata(fields: Record<string, unknown>): NodeUIMetadata | undefined {
+  const numberSteps = captureNumberStepOverrides(fields)
+  return Object.keys(numberSteps).length > 0 ? { numberSteps } : undefined
+}
+
+export function applyNodeUIMetadata(
+  fields: Record<string, unknown>,
+  metadata?: NodeUIMetadata
+): void {
+  applyNumberStepOverrides(fields, metadata?.numberSteps)
 }
 
 // TODO: Should this be flag like `multiple`? Or should it be a separate class?

--- a/noodles-editor/src/noodles/operators.test.ts
+++ b/noodles-editor/src/noodles/operators.test.ts
@@ -3221,6 +3221,30 @@ describe('Custom Fields', () => {
     expect(operator.inputs.myNumber.value).toBe(999)
   })
 
+  it('preserves a custom number field step override when rebuilding inputs', () => {
+    const operator = new CodeOp('/code-custom')
+
+    operator.addCustomInput({
+      id: 'id-1',
+      name: 'myNumber',
+      type: 'number',
+      order: 0,
+      defaultValue: 0,
+    })
+    const numberField = operator.inputs.myNumber as NumberField
+    numberField.setStepOverride(0.001)
+
+    operator.addCustomInput({
+      id: 'id-2',
+      name: 'myString',
+      type: 'string',
+      order: 1,
+      defaultValue: '',
+    })
+
+    expect((operator.inputs.myNumber as NumberField).stepOverride).toBe(0.001)
+  })
+
   it('getAllInputs returns built-in and custom inputs', () => {
     const operator = new CodeOp('/code-custom')
 

--- a/noodles-editor/src/noodles/operators.ts
+++ b/noodles-editor/src/noodles/operators.ts
@@ -99,6 +99,7 @@ import { FilterColorExtension } from './extensions/filter-color-extension'
 import { Mask3DExtension } from './extensions/mask-3d-extension'
 import {
   ArrayField,
+  applyNodeUIMetadata,
   applySerializedFieldValue,
   BboxField,
   BezierCurveField,
@@ -108,6 +109,7 @@ import {
   ColorField,
   ColorRampField,
   CompoundPropsField,
+  captureNodeUIMetadata,
   DataField,
   DateField,
   EffectField,
@@ -994,6 +996,7 @@ export abstract class Operator<OP extends IOperator> {
     )
     // Preserve existing field values and connections
     const oldValues = new Map<string, unknown>()
+    const oldUIMetadata = captureNodeUIMetadata(this.inputs)
     const oldConnections = new Map<
       string,
       Array<{ id: string; field: Field; connectionType: 'reference' | 'value' }>
@@ -1053,6 +1056,8 @@ export abstract class Operator<OP extends IOperator> {
       assignPathToProps(field, key, [this.id, IN_NS])
     }
 
+    applyNodeUIMetadata(this.inputs, oldUIMetadata)
+
     // Note: Connections will be restored by transform-graph.ts when edges are re-applied
 
     // Notify listeners that custom fields have changed
@@ -1080,7 +1085,7 @@ export class NumberOp extends Operator<NumberOp> {
   static description = 'A number'
   public createInputs() {
     return {
-      val: new NumberField(0, { step: 1 }),
+      val: new NumberField(0, { step: 1, deriveStepFromValue: true }),
     }
   }
   public createOutputs() {

--- a/noodles-editor/src/noodles/transform-graph.test.ts
+++ b/noodles-editor/src/noodles/transform-graph.test.ts
@@ -1,5 +1,6 @@
 import type { Node as ReactFlowNode } from '@xyflow/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NumberField } from './fields'
 import { getExecutor } from './graph-executor'
 import type { Edge } from './noodles'
 import {
@@ -19,6 +20,60 @@ import { edgeId } from './utils/id-utils'
 
 afterEach(() => {
   referenceDependencyModel.reset()
+})
+
+describe('Number field UI metadata restoration', () => {
+  afterEach(() => {
+    clearOps()
+  })
+
+  it('restores a custom number step after custom inputs have been rebuilt', () => {
+    const nodes = [
+      {
+        id: '/code',
+        type: 'CodeOp',
+        data: {
+          inputs: {},
+          customInputs: [
+            {
+              id: 'custom-number',
+              name: 'amount',
+              type: 'number',
+              order: 0,
+              defaultValue: 0.25,
+            },
+          ],
+          ui: { numberSteps: { amount: 0.001 } },
+        },
+        position: { x: 0, y: 0 },
+      },
+    ]
+
+    transformGraph({ nodes, edges: [] })
+
+    const op = getOpStore().getOp('/code') as CodeOp
+    expect((op.inputs.amount as NumberField).stepOverride).toBe(0.001)
+  })
+
+  it('ignores invalid and unknown saved number steps', () => {
+    const nodes = [
+      {
+        id: '/number',
+        type: 'NumberOp',
+        data: {
+          inputs: { val: 0.25 },
+          ui: { numberSteps: { val: -1, missing: 0.01 } },
+        },
+        position: { x: 0, y: 0 },
+      },
+    ]
+
+    transformGraph({ nodes, edges: [] })
+
+    const op = getOpStore().getOp('/number') as NumberOp
+    expect(op.inputs.val.stepOverride).toBeUndefined()
+    expect(op.inputs.val.getEffectiveStep()).toBe(0.01)
+  })
 })
 
 describe('transform-graph topological sort with missing upstream nodes', () => {

--- a/noodles-editor/src/noodles/transform-graph.ts
+++ b/noodles-editor/src/noodles/transform-graph.ts
@@ -1,7 +1,7 @@
 import { getIncomers, type Node as ReactFlowNode } from '@xyflow/react'
 import { analytics } from '../utils/analytics'
 import { debugExecutor } from '../utils/debug'
-import { type Field, ListField } from './fields'
+import { applyNodeUIMetadata, type Field, ListField, type NodeUIMetadata } from './fields'
 import type { Edge as ExecutorEdge } from './graph-executor'
 import type { Edge } from './noodles'
 import type { IOperator, Operator, OpType } from './operators'
@@ -39,6 +39,8 @@ export {
 export type NodeDataJSON<_T extends Operator<IOperator> = Operator<IOperator>> = {
   inputs?: Record<string, unknown>
   locked?: boolean
+  ui?: NodeUIMetadata
+  visibleInputs?: string[]
   customInputs?: Array<{
     id: string
     name: string
@@ -308,12 +310,14 @@ export function transformGraph<
           op.rebuildInputs()
         }
 
+        applyNodeUIMetadata(op.inputs, data?.ui)
+
         created.push(op)
         // Store operator in store using fully qualified path
         store.setOp(id, op)
 
         // Restore field visibility from saved data or derive from heuristic
-        const visibleInputs = (data as { visibleInputs?: string[] })?.visibleInputs
+        const visibleInputs = data?.visibleInputs
 
         if (visibleInputs && Array.isArray(visibleInputs)) {
           // Explicit visibility saved - use it directly as the full set

--- a/noodles-editor/src/noodles/utils/number-precision.ts
+++ b/noodles-editor/src/noodles/utils/number-precision.ts
@@ -1,0 +1,89 @@
+const MAX_SIGNIFICANT_DIGITS = 17
+const FLOAT_NOISE_ULPS = 4
+
+type DecimalParts = {
+  coefficient: bigint
+  exponent: number
+}
+
+// Find the shortest decimal representation that is within a few ULPs of the
+// stored double. This removes arithmetic residue such as 0.1 + 0.2 while the
+// significant-digit search remains relative to the value's scientific exponent.
+function normalizeFloatingPointNoise(value: number): number {
+  if (!Number.isFinite(value) || value === 0) return value
+
+  const tolerance = Math.max(Number.MIN_VALUE, Number.EPSILON * Math.abs(value) * FLOAT_NOISE_ULPS)
+  for (
+    let significantDigits = 1;
+    significantDigits <= MAX_SIGNIFICANT_DIGITS;
+    significantDigits++
+  ) {
+    const candidate = Number(value.toPrecision(significantDigits))
+    if (Math.abs(value - candidate) <= tolerance) return candidate
+  }
+
+  return value
+}
+
+function toDecimalParts(value: number): DecimalParts | undefined {
+  if (!Number.isFinite(value)) return undefined
+
+  const normalized = normalizeFloatingPointNoise(value)
+  const match = normalized.toExponential().match(/^(-?)(\d)(?:\.(\d+))?e([+-]?\d+)$/)
+  if (!match) return undefined
+
+  const [, sign, leadingDigit, fractionalDigits = '', scientificExponent] = match
+  const digits = `${leadingDigit}${fractionalDigits}`
+  return {
+    coefficient: BigInt(`${sign}${digits}`),
+    exponent: Number(scientificExponent) - fractionalDigits.length,
+  }
+}
+
+function pow10(exponent: number): bigint {
+  return 10n ** BigInt(exponent)
+}
+
+// Returns the place-value of the least-significant meaningful decimal digit.
+// Integer and zero values have no decimal precision, so they use the field's
+// declared fallback step.
+export function deriveDecimalStep(value: number, fallback = 1): number {
+  const fallbackStep = Number.isFinite(fallback) && fallback > 0 ? fallback : 1
+  if (!Number.isFinite(value) || value === 0) return fallbackStep
+
+  const normalized = normalizeFloatingPointNoise(value)
+  if (Number.isInteger(normalized)) return fallbackStep
+
+  const parts = toDecimalParts(normalized)
+  if (!parts) return fallbackStep
+
+  const step = 10 ** parts.exponent
+  if (Number.isFinite(step) && step > 0) return step
+  return parts.exponent < 0 ? Number.MIN_VALUE : fallbackStep
+}
+
+// Adds an integer number of steps using aligned decimal coefficients. Converting
+// to Number only after the exact BigInt addition prevents binary residue while
+// retaining any meaningful decimals finer than the selected step in `start`.
+export function addDecimalSteps(start: number, step: number, delta: number): number {
+  const roundedDelta = Math.round(delta)
+  if (
+    !Number.isFinite(start) ||
+    !Number.isFinite(step) ||
+    step <= 0 ||
+    !Number.isSafeInteger(roundedDelta)
+  ) {
+    return start + roundedDelta * step
+  }
+
+  const startParts = toDecimalParts(start)
+  const stepParts = toDecimalParts(step)
+  if (!startParts || !stepParts) return start + roundedDelta * step
+
+  const commonExponent = Math.min(startParts.exponent, stepParts.exponent)
+  const startCoefficient = startParts.coefficient * pow10(startParts.exponent - commonExponent)
+  const deltaCoefficient =
+    BigInt(roundedDelta) * stepParts.coefficient * pow10(stepParts.exponent - commonExponent)
+
+  return Number(`${startCoefficient + deltaCoefficient}e${commonExponent}`)
+}

--- a/noodles-editor/src/noodles/utils/property-history.test.ts
+++ b/noodles-editor/src/noodles/utils/property-history.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NumberField } from '../fields'
 import {
   applyOperatorInputs,
   captureOperatorInputs,
@@ -73,6 +74,20 @@ describe('captureOperatorInputs', () => {
     const result = captureOperatorInputs()
     const parsed = JSON.parse(result)
     expect(parsed['/op'].compound).toEqual({ nested: [1, 2, 3] })
+  })
+
+  it('captures explicit number steps separately from graph inputs', () => {
+    const field = new NumberField(0.25, { step: 1, deriveStepFromValue: true })
+    field.setStepOverride(0.001)
+    const op = { id: '/number', inputs: { val: field } }
+    mockedGetAllOps.mockReturnValue([op as never])
+
+    const parsed = JSON.parse(captureOperatorInputs() as string)
+
+    expect(parsed['/number']).toEqual({ val: 0.25 })
+    expect(parsed.$ui).toEqual({
+      '/number': { numberSteps: { val: 0.001 } },
+    })
   })
 })
 
@@ -151,6 +166,37 @@ describe('applyOperatorInputs', () => {
     expect(field1.setValue).toHaveBeenCalledWith(42)
     expect(field2.setValue).toHaveBeenCalledWith('hello')
   })
+
+  it('restores an explicit number step and notifies mounted subscribers', () => {
+    const field = new NumberField(0.25, { step: 1, deriveStepFromValue: true })
+    const op = { id: '/number', inputs: { val: field } }
+    const observed: Array<number | undefined> = []
+    const subscription = field.stepOverride$.subscribe(step => observed.push(step))
+    mockedGetOpStore.mockReturnValue({ getOp: vi.fn(() => op) } as never)
+
+    applyOperatorInputs(
+      JSON.stringify({
+        '/number': { val: 0.25 },
+        $ui: { '/number': { numberSteps: { val: 0.001 } } },
+      })
+    )
+
+    expect(field.stepOverride).toBe(0.001)
+    expect(observed).toEqual([undefined, 0.001])
+    subscription.unsubscribe()
+  })
+
+  it('clears an explicit number step when restoring a snapshot without UI metadata', () => {
+    const field = new NumberField(0.25, { step: 1, deriveStepFromValue: true })
+    field.setStepOverride(0.001)
+    const op = { id: '/number', inputs: { val: field } }
+    mockedGetOpStore.mockReturnValue({ getOp: vi.fn(() => op) } as never)
+
+    applyOperatorInputs(JSON.stringify({ '/number': { val: 0.25 } }))
+
+    expect(field.stepOverride).toBeUndefined()
+    expect(field.getEffectiveStep()).toBe(0.01)
+  })
 })
 
 describe('registerPropertyMutationCallback and firePropertyMutation', () => {
@@ -207,6 +253,25 @@ describe('registerPropertyMutationCallback and firePropertyMutation', () => {
     firePropertyMutation('No change', before)
 
     expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('records a precision-only change when the numeric value is unchanged', () => {
+    const callback = vi.fn()
+    registerPropertyMutationCallback(callback)
+    const field = new NumberField(0.25, { step: 1, deriveStepFromValue: true })
+    const op = { id: '/number', inputs: { val: field } }
+    mockedGetAllOps.mockReturnValue([op as never])
+    const before = captureOperatorInputs()
+
+    field.setStepOverride(0.001)
+    firePropertyMutation('Change precision', before)
+
+    expect(callback).toHaveBeenCalledOnce()
+    const [, beforeState, afterState] = callback.mock.calls[0]
+    expect(JSON.parse(beforeState)).not.toHaveProperty('$ui')
+    expect(JSON.parse(afterState).$ui).toEqual({
+      '/number': { numberSteps: { val: 0.001 } },
+    })
   })
 
   it('can clear the callback by registering undefined', () => {
@@ -445,5 +510,24 @@ describe('captureOperatorInputs + applyOperatorInputs round-trip', () => {
 
     // setValue should be called with the original value (42)
     expect(field.setValue).toHaveBeenCalledWith(42)
+  })
+
+  it('round-trips a precision-only change when the number value is unchanged', () => {
+    const field = new NumberField(0.25, { step: 1, deriveStepFromValue: true })
+    const op = { id: '/number', inputs: { val: field } }
+    mockedGetAllOps.mockReturnValue([op as never])
+    mockedGetOpStore.mockReturnValue({ getOp: vi.fn(() => op) } as never)
+
+    const automatic = captureOperatorInputs() as string
+    field.setStepOverride(0.001)
+    const explicit = captureOperatorInputs() as string
+    expect(explicit).not.toBe(automatic)
+
+    applyOperatorInputs(automatic)
+    expect(field.stepOverride).toBeUndefined()
+
+    applyOperatorInputs(explicit)
+    expect(field.stepOverride).toBe(0.001)
+    expect(field.value).toBe(0.25)
   })
 })

--- a/noodles-editor/src/noodles/utils/property-history.ts
+++ b/noodles-editor/src/noodles/utils/property-history.ts
@@ -1,6 +1,13 @@
 import { useCallback, useRef } from 'react'
 import { debugHistory, debugHistorySnapshot } from '../../utils/debug'
-import { applySerializedFieldValue, type Field, type IField } from '../fields'
+import {
+  applyNodeUIMetadata,
+  applySerializedFieldValue,
+  captureNodeUIMetadata,
+  type Field,
+  type IField,
+  type NodeUIMetadata,
+} from '../fields'
 import { getAllOps, getOpStore } from '../store'
 import type { OpId } from './id-utils'
 
@@ -8,6 +15,7 @@ type PropertyMutationCallback = (description: string, before: string, after: str
 
 let _propertyMutationCallback: PropertyMutationCallback | undefined
 let _lastCommittedBeforeState: string | null = null
+const UI_STATE_KEY = '$ui'
 
 export function registerPropertyMutationCallback(cb: PropertyMutationCallback | undefined) {
   _propertyMutationCallback = cb
@@ -19,6 +27,7 @@ export function registerPropertyMutationCallback(cb: PropertyMutationCallback | 
 export function captureOperatorInputs(): string | null {
   const ops = getAllOps()
   const state: Record<string, Record<string, unknown>> = {}
+  const uiState: Record<string, NodeUIMetadata> = {}
   for (const op of ops) {
     const inputs: Record<string, unknown> = {}
     for (const [name, field] of Object.entries(op.inputs as Record<string, IField>)) {
@@ -35,7 +44,10 @@ export function captureOperatorInputs(): string | null {
       inputs[name] = field.serialize()
     }
     state[op.id] = inputs
+    const ui = captureNodeUIMetadata(op.inputs)
+    if (ui) uiState[op.id] = ui
   }
+  if (Object.keys(uiState).length > 0) state[UI_STATE_KEY] = uiState
   debugHistorySnapshot('Captured operator inputs for %d ops', ops.length)
   try {
     return JSON.stringify(state)
@@ -57,7 +69,9 @@ export function applyOperatorInputs(snapshot: string): void {
     return
   }
   const store = getOpStore()
+  const uiState = data[UI_STATE_KEY] as Record<string, NodeUIMetadata> | undefined
   for (const [id, inputs] of Object.entries(data)) {
+    if (id === UI_STATE_KEY) continue
     const op = store.getOp(id as OpId)
     if (!op) continue
     const opInputs = op.inputs as Record<string, IField>
@@ -68,6 +82,7 @@ export function applyOperatorInputs(snapshot: string): void {
         applySerializedFieldValue(field as Field, value)
       }
     }
+    applyNodeUIMetadata(op.inputs, uiState?.[id])
   }
 }
 

--- a/noodles-editor/src/noodles/utils/serialization.test.ts
+++ b/noodles-editor/src/noodles/utils/serialization.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hexToColor } from '../../utils/color'
 import { CodeField, ColorField, NumberField } from '../fields'
-import { GeoJsonLayerOp, NumberOp, ScenegraphLayerOp, TableEditorOp } from '../operators'
+import { CodeOp, GeoJsonLayerOp, NumberOp, ScenegraphLayerOp, TableEditorOp } from '../operators'
 import { clearOps, getOpStore, setOp } from '../store'
 import { edgeId } from './id-utils'
 import {
@@ -234,6 +234,44 @@ describe('serializeNodes', () => {
     const result = serializeNodes(getOpStore(), nodes, [])
     expect(result[0].data.inputs).toEqual({ val: 123 })
     expect(result[1].data.inputs).toEqual({})
+  })
+
+  it('omits optional UI metadata when a number field has no explicit step override', () => {
+    setOp('num', new NumberOp('num', { val: 0.25 }, false))
+    const nodes = [{ id: 'num', type: 'NumberOp', data: {}, position: { x: 0, y: 0 } }]
+
+    const [result] = serializeNodes(getOpStore(), nodes, [])
+
+    expect(result.data).not.toHaveProperty('ui')
+  })
+
+  it('serializes an explicit number step as optional per-field UI metadata', () => {
+    const op = new NumberOp('num', { val: 0.25 }, false)
+    op.inputs.val.setStepOverride(0.001)
+    setOp('num', op)
+    const nodes = [{ id: 'num', type: 'NumberOp', data: {}, position: { x: 0, y: 0 } }]
+
+    const [result] = serializeNodes(getOpStore(), nodes, [])
+
+    expect(result.data.ui).toEqual({ numberSteps: { val: 0.001 } })
+  })
+
+  it('serializes an explicit step for a custom number field', () => {
+    const op = new CodeOp('code')
+    op.addCustomInput({
+      id: 'amount-id',
+      name: 'amount',
+      type: 'number',
+      order: 0,
+      defaultValue: 0.25,
+    })
+    ;(op.inputs.amount as NumberField).setStepOverride(0.001)
+    setOp('code', op)
+    const nodes = [{ id: 'code', type: 'CodeOp', data: {}, position: { x: 0, y: 0 } }]
+
+    const [result] = serializeNodes(getOpStore(), nodes, [])
+
+    expect(result.data.ui).toEqual({ numberSteps: { amount: 0.001 } })
   })
 
   it('does not serialize object default values', () => {

--- a/noodles-editor/src/noodles/utils/serialization.ts
+++ b/noodles-editor/src/noodles/utils/serialization.ts
@@ -6,6 +6,7 @@ import type {
 } from '@xyflow/react'
 import { debugSerialize } from '../../utils/debug'
 import { resizeableNodes } from '../components/op-components'
+import { captureNodeUIMetadata } from '../fields'
 import type { useOperatorStore } from '../store'
 import { deepEqual } from './deep-equal'
 import type { ExtractProps } from './extract-props'
@@ -206,6 +207,8 @@ export function serializeNodes(
       }
     }
 
+    const ui = captureNodeUIMetadata(op.inputs)
+
     preparedNodes.push({
       ...cleanedNode,
       ...(node.type && (resizeableNodes as readonly string[]).includes(node.type)
@@ -217,6 +220,7 @@ export function serializeNodes(
         ...(op.customInputDefinitions?.length > 0
           ? { customInputs: op.customInputDefinitions }
           : {}),
+        ...(ui ? { ui } : {}),
         ...visibilityData,
       },
     })


### PR DESCRIPTION
## Summary
Makes `NumberOp` infer its editing step from meaningful exponent-relative precision while preserving explicit scrub-ladder choices in node UI metadata.

## Changes
Adds ULP-tolerant significant-digit derivation, exact decimal-aligned scrub arithmetic, interaction-frozen steps, immediate selected-step adoption, complete numeric display, nested/custom-field serialization, rebuild survival, and undo/redo observability; semantic number fields retain declared steps unless explicitly overridden.

## Testing
433 focused tests pass, the custom-input rebuild regression passes, the shared table-scrubbing suites pass, and `npm run build` succeeds.

## Manual Testing
Set a Number node to `0.25`, verify increment produces `0.26`, scrub `0.1` forward two pixels and verify exactly `0.3`, then confirm a selected precision survives undo/redo and project reload.

Stacked on #620.